### PR TITLE
chore: pre-launch repo hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/SponsioLabs/Sponsio/security/advisories/new
+    about: Please report security issues privately via GitHub Security Advisories, NOT as public issues. See SECURITY.md for details.
+  - name: Questions and discussion
+    url: https://github.com/SponsioLabs/Sponsio/discussions
+    about: Ask questions, share use cases, and discuss ideas with the community. Use Discussions for anything that isn't a concrete bug or feature request.

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ build/
 .pytest_cache/
 .ruff_cache/
 .hypothesis/
-.DS_Store
 *.env
 .venv/
 venv/
@@ -24,8 +23,14 @@ data/scores.db
 data/scores.db-wal
 data/scores.db-shm
 
-# Internal docs — do not push to GitHub
-agent_docs/
+# Internal docs — do NOT commit to public repo
+# Canonical home for launch prep, internal planning, handoffs, reviews, etc.
+# Anything that is not meant for public OSS users goes under internal/.
+# New rule: any future internal doc goes here. Do not add more exceptions below.
+internal/
+
+# Internal files that intentionally live outside internal/ (kept colocated
+# with the subsystems they describe). All others should go under internal/.
 PLAN.md
 STATUS.md
 docs/demo-video-script.md
@@ -35,9 +40,3 @@ examples/scan_test_agent_run_debug.py
 # Claude Code
 .claude/
 ts-sdk/node_modules/
-LAUNCH_PLAN.md
-
-# Internal-only docs — do NOT commit to public repo
-LAUNCH_HANDOFF.md
-sponsio-code-review.md
-PYPI_RELEASE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [0.1.0a2] - 2026-04-19
-
-### Changed
-- Public release: cleaned commit history; rebased onto initial commit.
-
 ## [Unreleased]
+
+### Planned
+- Pre-deployment compositional verification
+- Metrics & before/after comparison dashboard
+
+## [0.1.0a2] - 2026-04-19
 
 ### Added
 - **`CODE_OF_CONDUCT.md`** at repo root: short stub adopting the
@@ -20,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   plus a reporting email and pointer to the upstream enforcement
   ladder. `CONTRIBUTING.md` already links here, so the reference
   now resolves.
+- **`SECURITY.md`** at repo root: responsible disclosure policy with
+  reporting email, 72-hour ack / 90-day patch timeline, explicit scope
+  (det bypasses are vulns; sto bypasses are quality bugs by default),
+  and safe-harbor language for good-faith reporters.
 - **`sponsio report` — shadow-mode session log reader.** New CLI subcommand that
   reads the JSONL files written by `mode="observe"` from
   `~/.sponsio/sessions/<agent_id>/*.jsonl` and produces a shareable summary of
@@ -73,69 +78,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Incremental LTL evaluation** (G-node memoization in `TraceVerifier._cached_g_eval`): caches `(scanned_upto, result)` per `G` formula; on re-eval, only the newly-grounded positions are checked. Guarded by `_is_temporally_flat` so nested temporal operators (e.g. `no_reversal = G(A → G(!B))`) correctly fall through to full evaluation instead of caching stale prefix decisions. Brings per-check latency on a 500-event trace × 10 `rate_limit` contracts from 5.2 ms → 0.09 ms (**60× faster**) and eliminates the O(N²) session-total scaling for common G-rooted safety patterns.
 - **`scripts/bench_verifier.py`**: micro-benchmark comparing batch vs incremental grounding vs G-cache fast path across rate_limit (G-rooted, cacheable) and must_precede (U-rooted, short-circuit) workloads.
 - **27 `TraceVerifier` unit tests** (`tests/test_verifier.py`): Verdict/ContractVerdict shape, `check`/`check_contract`/`check_assumption` semantics, incremental grounding correctness (batch vs stepped sync parity, auto-reset on shrink/content-atoms change), G-cache hit/miss/transition-to-false behavior, nested-temporal fall-through, and `Verifier` alias preservation.
-
-### Changed
-- **README rewrite for launch**: restructured around the before/after hero (`<!-- HERO_GIF -->` placeholder for the 8-second demo GIF), value prop on top, 60-second start example pulled above the fold, shadow mode promoted to its own section as the zero-risk onboarding path, Architecture/LTL explanation moved below the fold. Pattern Library, Integrations, and Benchmarks tables preserved unchanged. Quick Start badge row extended with a test-count badge.
-- **YAML config now accepts both short keys (`A` / `E`) and long keys (`assumption` / `enforcement`)** for each contract entry. The previous YAML-only / Python-only split was a footgun — users copying `{"assumption": ..., "enforcement": ...}` examples from the Python docs into YAML would hit `ConfigError`. Short keys stay recommended for terse hand-edited YAML; long keys are accepted when users prefer them. Using both forms of the *same* field in a single entry (e.g. both `A` and `assumption`) is ambiguous and still raises `ConfigError` with a "pick one" hint. Python API is unchanged (full keys only). 5 new tests in `tests/test_config.py` cover long-key loading, cross-entry mixing, cross-field mixing, and conflict detection.
-- **Unified `wrap()` method across all integration guards.** `tools()` (LangGraph, CrewAI, Agents SDK, BaseGuard), `tool_node()` (LangGraph, CrewAI), `wrap_tools()` (Agents SDK), and `middleware()` (Vercel AI) are all renamed to `wrap()`. Old names kept as backward-compatible aliases. All docs, examples, and tests updated to use `guard.wrap(tools)` as the canonical form.
-- **`RuntimeMonitor._check_det` and `_check_sto` refactored to delegate all formal evaluation to `self._verifier: TraceVerifier`.** The monitor no longer imports `ground` / `evaluate` directly — it only orchestrates spans, violations, and enforcement strategies. `_check_det` shrank from ~200 lines to ~80 lines by extracting `_emit_pass_event` / `_handle_assumption_failure` / `_handle_enforcement_failure` helpers.
-- **`BaseGuard.guard_before` now calls `monitor.verifier.reset()` after popping a blocked event from the trace** so the verifier's incremental cache is invalidated. Required for correctness: without this, a following event that reuses the popped index would be evaluated against stale grounded state.
-- **Grounding refactored to expose a per-event kernel.** `sponsio/tracer/grounding.py` now has `GroundingState` (dataclass of cumulative accumulators) and `ground_event(event, idx, state, …)` (single-event grounding); the existing batch `ground(trace, …)` becomes a thin loop over `ground_event`. Batch semantics are unchanged — all 630 existing tests pass against the refactored kernel.
-
-### Changed (BREAKING)
-- **Contract semantics redesigned to per-(A, E) pair.** A `Contract` now holds a single `assumption` + single `enforcement` instead of parallel lists. An agent with multiple rules has multiple `Contract` objects in `System.contracts`. The runtime monitor (`_check_det`, `_check_sto`) evaluates each contract independently — an assumption on one contract no longer gates the enforcement of another contract, which was the root cause of the high false-positive rate observed in ODCV-Bench runs where all assumptions were ANDed across all guarantees.
-- **`Contract(agent, assumptions=[...], guarantees=[...])` removed.** The new constructor is `Contract(agent, enforcement=..., assumption=..., desc=...)`. Both fields accept a scalar or a list; a list is interpreted as the logical AND of its elements. `assumption=None` (the default) means the contract is unconditional.
-- **`BaseGuard` / `sponsio.init()` kwargs collapsed to a single `contracts=` kwarg.** `assumptions=[...]` and `guarantees=[...]` are gone. Entries inside `contracts=[...]` are either bare NL strings (= unconditional shortcut, one `Contract` each) or dicts with `assumption` / `enforcement` (= one `(A, E)` pair). List-valued fields are AND-combined. Python dicts **must** use the full keys `assumption` / `enforcement` — short keys `A` / `E` are YAML-only and raise `ValueError` if used in Python.
-- **YAML schema redesigned.** Agents declare a `contracts:` list of `{A, E}` pairs instead of parallel `assumptions:` / `guarantees:` blocks. YAML uses the **short keys** `A` / `E` — full names `assumption` / `enforcement` are Python-only and raise `ConfigError` if used in YAML. This split keeps YAML terse and Python self-describing. Old `assumptions:` / `guarantees:` schema also raises `ConfigError` on load with a migration hint.
-- **Soft (sto) pipeline now honors clause-level gating.** A sto enforcement inside a contract with an unsatisfied assumption is skipped for that turn. Sto constraints registered directly on a `StoEvaluator` (without an owning `Contract`) remain unconditional.
-- **`Contract` field shape.** Canonical state is the singular `Contract.assumption` / `Contract.enforcement` (scalar, list, or `None`). The old plural list fields are now read-only normalized views: `Contract.assumptions` / `Contract.enforcements` (properties) always return a flat `list`, which is the shape most callers want for iteration.
-- **`build_contract` → `build_contracts` (plural).** Parses NL text into a list of unconditional `Contract` objects instead of bundling them into a single Contract with ANDed guarantees. Old name kept as a thin backward-compat wrapper.
-- **API router `DELETE /contracts/{agent_id}/{index}`** now deletes a whole `Contract` (one A/E pair) by index, instead of popping a guarantee out of a larger contract bundle.
-- **`System.agent(...).guarantees(...)` builder** still works (as an alias for the new `.enforces(...)`) but now emits one `Contract` per enforcement instead of a single bundled `Contract`.
-
-### Added
 - **Walkthrough demo agent** (`examples/demo/demo_walkthrough.py`): A single "ops_agent" that handles a P1 support ticket across 5 stages (triage → data lookup → SQL remediation → customer reply → incident report), exercising 10 det patterns (must_precede ×4, rate_limit ×3, arg_blacklist ×1, check_db_env, confirm_action) and 4 sto evaluators (tone_empathy, pii_check, redaction_quality, content_prohibition). Runs in mock mode with no API key; pushes span trees to dashboard for live monitoring.
 - **Mock data fallback for all dashboard pages**: MonitorPage (Live + History tabs), Analytics, and Leaderboard now fall back to comprehensive mock data when the API is offline — enables demo/hackathon mode without running the backend. Mock data includes ops_agent trace events, 10 span trees, 6 trace summaries, analytics with score history + violation breakdowns, and a 7-entry leaderboard.
 - **Expanded mock data** (`web/src/data/mockMonitorData.ts`): Added ops_agent events (13 trace events, 17 monitor events, 4 new span trees with det+sto combined checks), updated analytics to include pii_check and content_prohibition patterns, added ops_agent to leaderboard and reliability scores.
 - **Monitor page redesign** (`web/src/pages/MonitorPage.tsx`): Complete rewrite of the Live tab as a professional observability dashboard with 6 panels: (1) Metric Cards — 5 real-time stats (events, det blocks, sto retries, pass rate, avg latency) with color-coded accents; (2) Agent Timeline — horizontal swimlane per agent with clickable dots colored by verdict (pass/block/retry); (3) Span Inspector — filterable span tree list with agent/status dropdowns and full SpanTree expansion; (4) Contract Health — per-contract pass rate progress bars sorted by violation count; (5) Enforcement Summary — stacked bar + legend showing outcome breakdown (blocked/retried/escalated/passed); (6) Enhanced Violation Feed — det/sto tabs, evidence display, and suggested fixes.
 - **External span bridge in API** (`api/routers/monitor.py`): Added `_external_log_entries()` and `_external_trace_events()` helpers that synthesize MonitorEvent and TraceEvent data from externally pushed span trees. The `/monitor/log`, `/monitor/status`, `/monitor/trace` endpoints and SSE stream now include data from agents that push via `/monitor/push-span`, fixing the issue where the demo walkthrough data was invisible to the frontend.
-
 - **Unified LLM extraction layer** (`sponsio/generation/llm_extraction.py`): Single Atom-aware LLM prompt shared by all three input paths (NL strings, policy documents, code scanning). The LLM is told about the full Atom vocabulary and Pattern catalog, enabling automatic hard/soft classification and accurate pattern selection. Includes `UnifiedExtractor` with `extract_from_nl()`, `extract_from_document()`, and `extract_from_code()` methods.
 - **Enhanced CodeAnalyzer** (`sponsio/discovery/extractors/code_analysis.py`): Two-stage pipeline — AST pass (deterministic, zero deps) + optional LLM pass for deeper inference across all 16 hard patterns and 6 soft categories. New: LangGraph `graph.add_node()` detection, docstring/param/source extraction for LLM context, `generate_yaml()` for `sponsio init --scan`, `get_tool_inventory()` export.
 - **Validation + suggestion engine**: Parse failures now include actionable suggestions ("Did you mean 'must_precede'?") with the list of available patterns.
 - **36 new tests** (`tests/test_llm_extraction.py`): Full coverage of compilation (all 16 hard patterns + 6 soft categories), suggestion engine, mock LLM integration, error resilience.
 - **LLM fallback in NL parser** — `parse_nl_unified()` now accepts an optional `llm_extractor` parameter. When rule-based keyword parsing fails, the `UnifiedExtractor` is tried before falling back to soft keyword classification. `config_to_system()` also accepts `llm_extractor` and `tool_inventory` so YAML-loaded contracts benefit from LLM-assisted parsing.
 - **Extensible Atom vocabulary** — `register_atom(signature, description)` and `register_atoms()` let users define custom observable predicates that are automatically included in the LLM extraction prompt. Custom atoms appear alongside built-in atoms so the LLM can reference them in constraint extraction. `get_custom_atoms()`, `clear_custom_atoms()` for inspection and testing.
-
-### Changed
-- **`AnnotatedFormula` renamed to `DetFormula`** with backward-compatible alias for compatibility. All internal references updated to use the new name. Reflects the renamed concept: "deterministic" (hard) constraints evaluated via LTL on the execution trace.
-- **`StoConstraint` renamed to `StoFormula`** with backward-compatible alias for compatibility. All internal references updated to use the new name.
-- **DocumentExtractor rewritten** to delegate to `UnifiedExtractor` — uses Atom-aware prompting instead of the old pattern-name-only prompt. Unknown hard patterns now fail with logged error instead of silently converting to soft constraints.
-- **Multi-Agent Eval Pipeline** (`AgentEval/`): Flagship example — 5 agents, 12 tools, 13 contracts covering every Sponsio pattern type. Demonstrates both NL and programmatic contract APIs, catches 5 violation types (must_precede, scope_limit, requires_permission, no_reversal, rate_limit), and exports trace datasets for downstream analysis.
-- **Pattern Architecture design doc** (`agent_docs/pattern_architecture.md`): Establishes the four-level concept stack (Atom -> Formula -> Pattern -> Contract), documents the full atom vocabulary, defines grounding as a thin event adapter, describes two complementary observation models (integration hooks for real-time blocking, OTEL consumer for post-hoc audit), and classifies patterns by observation boundary.
-- **`arg_paths_within(tool, *prefixes)` atom**: Checks all file paths in tool args are within allowed prefix set (replaces FOL `ForAllPaths` quantifier).
-- **`arg_field_has(tool, field, pattern)` atom**: Regex match on a specific arg field (`event.args[field]`), restoring field-level precision that was lost in FOL elimination. Used by `arg_blacklist`.
-
-### Fixed
-- **MCP example DX consistency** — `mcp_guard.py` rewritten to use `sponsio.init()` + `guard_before()`/`guard_after()` in mock mode, matching the pattern of all other integration examples. Now shows contract banner, per-constraint enforcement lines, and session summary.
-
-### Changed
-- **`arg_blacklist` uses `arg_field_has` for field-specific matching** — restores the per-field precision from the old FOL system. `arg_blacklist("bash", "command", [...])` now only checks `args["command"]`, not all args.
-- **`arg_blacklist`, `scope_limit`, `data_intact` now return `DetFormula`** instead of `PropertyConstraint`. Same function signatures, same behavioral semantics, unified into the Atom + LTL system.
-- **`PropertyConstraint` class removed** — all patterns use `DetFormula`.
-- **`sponsio/formulas/fol.py` deprecated** — FOL AST replaced by grounding-level atoms. Module emits `DeprecationWarning` on import.
-- **`property_constraints` parameter removed from `ground()`** (internal API).
-- **`prop.*` predicate key namespace removed** (internal — replaced by standard atom keys).
-- **`never_together` deprecated** — delegates to `mutual_exclusion` (original formula trivially satisfied in sequential traces)
-- **NL parser: `no_data_leak` with tool names** routes to `no_reversal` (tool ordering, not data flow)
-- **NL parser: `requires_permission` with tool-like names** routes to `must_precede` (dynamic, not static)
-- **`must_precede` and `must_confirm` formulas** rewritten to use `Until` operator instead of derived `precedes()` predicate
-- **Grounding simplified** — removed derived `precedes()` predicate; ordering now handled purely by LTL
-- **CrewAI hooks renamed**: `before_hook` → `on_tool_start`, `after_hook` → `on_tool_end` (old names kept as deprecated aliases)
-
-### Added
-- **NL keyword rules for 7 patterns**: `idempotent`, `must_confirm`, `cooldown`, `bounded_retry`, `segregation_of_duty`, `deadline`, `always_followed_by` — all now parseable from natural language
-- **End-to-end pattern verification** (`tests/test_pattern_e2e.py`): 13 tests covering all patterns through NL → BaseGuard pipeline
+- **NL keyword rules for 7 patterns**: `idempotent`, `must_confirm`, `cooldown`, `bounded_retry`, `segregation_of_duty`, `deadline`, `always_followed_by` — all now parseable from natural language.
+- **End-to-end pattern verification** (`tests/test_pattern_e2e.py`): 13 tests covering all patterns through NL → BaseGuard pipeline.
 - **6 integration examples** (`examples/integrations/`): Vanilla, LangGraph, OpenAI SDK, CrewAI, Agents SDK, MCP — each with a different real-world scenario and contract patterns. All support mock mode and real Gemini LLM (`USE_MOCK=0 GOOGLE_API_KEY=...`).
 - **`sponsio.init()` one-liner entry point** (`sponsio/core.py`): `guard = sponsio.init(framework="langgraph", agent_id="bot", guarantees=[...])` auto-selects the correct Guard class. Supports `dashboard=True` for auto-start, `config="sponsio.yaml"` for file-based config, and all framework guards. Framework registry with lazy imports — optional deps only loaded when needed.
 - **Clean `__init__.py`**: Removed internal class exports (`DetEvaluator`, `StoEvaluator`, `RuntimeMonitor`). Now exports only user-facing API: `init`, `load_config`, models, and lazy-loaded Guard classes via `__getattr__`.
@@ -154,18 +109,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Data flow metadata on demo scenarios**: All demo tool_call steps now include `event_type` (`data_read`/`data_write`/`tool_call`), `source` (e.g. "Order DB", "Google Drive"), and `target` (e.g. "Payment Gateway", "#marketing") for trace visualization.
 - **Dashboard push from demo examples**: `fmt.py` gains `dashboard_reset()`, `dashboard_seed()`, `dashboard_push_span()`, `dashboard_push_all_spans()`. All three demo scripts push ContractGuard span trees to the dashboard API after each guarded flow.
 - **`.env` file support**: API server loads `.env` from project root on startup for API keys (gitignored).
-
-### Fixed
-- **Leaderboard crash**: `sqlite3.Row` `row_factory` was being mutated per-query on a shared connection across threads, causing segfaults. Now set once at connection creation.
-- **Python 3.9 compatibility**: Added `from __future__ import annotations` to `api/db.py` for `Dict[str, Any] | None` syntax.
-
-### Changed
-- **`examples/hackathon/` renamed to `examples/demo/`**: All paths updated across codebase.
-- **`config_driven.py` removed**: YAML config usage documented in README instead.
-- **Demos.tsx refactored**: Replaced `NaiveTimeline` + `EnforcedTimeline` with unified `TraceTimeline` component.
-- **AgentConnect.tsx refactored**: Replaced inline `Timeline` component (~130 lines) with the same `TraceTimeline`.
-
-### Added
 - **Frontend redesign — 3-view developer tool**: Consolidated 7 pages into 3 focused views (Dashboard, Playground, Trace). Notebook-style Playground with contract cell, agent cell, execution cell, and inline result cell. Trace Viewer with horizontal flow summary, expandable block detail with SpanTree progressive disclosure, and sliding re-verify panel.
 - **Dark mode**: Full light/dark theme toggle via Tailwind `darkMode: 'class'`, persisted in localStorage with `prefers-color-scheme` fallback. All components styled for both modes.
 - **SpanTree component** (`web/src/components/SpanTree.tsx`): 3-level progressive disclosure — Level 1 (verdict card), Level 2 (per-contract summary), Level 3 (full evaluation chain). Auto-expands for violations.
@@ -176,29 +119,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Span tree API**: `GET /monitor/spans` returns structured span trees from the current session. Fixed `to_dict()` in all span subclasses to include subclass-specific fields.
 - **Pattern library API**: `GET /patterns/library` returns all 16 patterns with examples, descriptions, and parameters.
 - **Session reset**: `POST /monitor/reset` clears all state for fresh sessions.
-
-### Fixed
-- **Span serialization**: `to_dict()` in all 8 span subclasses (`AgentTurnSpan`, `ContractCheckSpan`, `PreconditionSpan`, `GuaranteeSpan`, `ViolationSpan`, `EnforcementSpan`, `StoCheckSpan`, `StoEvalSpan`) now includes subclass-specific fields
-
-### Removed
-- Frontend pages: `ContractEditor.tsx`, `Agents.tsx`, `PatternLibrary.tsx`, `Discovery.tsx` (functionality absorbed into Playground and Trace views)
-
-### Added
 - **First-Order Logic (FOL) predicate engine** (`sponsio/formulas/fol.py`): Per-event property checking with a typed AST — value references (`Field`, `Literal`), comparison predicates (`Equals`, `Matches`, `HasPrefix`, `InSet`, `GreaterThan`, `LessThanEq`), boolean connectives (`PNot`, `PAnd`, `POr`, `PImplies`), and universal quantification over file paths (`ForAllPaths`). Two-backend design: Python `eval_predicate()` for runtime, Z3 backend planned for pre-deployment satisfiability. Zero new dependencies.
 - **FOL-based PropertyConstraint patterns** (`sponsio/patterns/library.py`): Per-event constraints that bridge FOL predicates into the LTL pipeline — `arg_blacklist(tool, param, patterns)` forbids regex-matched content in tool arguments, `scope_limit(tool, allowed_paths)` restricts file operations to whitelisted path prefixes, `data_intact(bound_tool, original_paths)` ensures tools operate only on unmodified source data. Results are grounded as `prop.*` predicates consumed by the LTL evaluator.
 - **Structured observability** (`sponsio/models/spans.py`): Hierarchical span trees for contract enforcement. Each `check_action()` call produces an `AgentTurnSpan` tree with per-phase spans (`PreconditionSpan`, `GuaranteeSpan`, `ViolationSpan`, `EnforcementSpan`, `StoCheckSpan`, `StoEvalSpan`). Includes `SpanCollector` context manager, `render_tree()` CLI output, `to_dict()` / `to_flat_list()` for OTel-ready export. Zero new dependencies.
-- **BaseGuard span accessors**: `last_check_span`, `check_spans`, `render_checks()` on all integration guards
-- **RuntimeMonitor span properties**: `last_turn_span`, `turn_spans`, `render_last_turn()`
-- **Demo span tree output**: All three demos (`customer_service`, `coding_agent`, `mcp_leak`) now print structured span trees after each "with protection" scenario
-
-### Fixed
-- **Version mismatch**: `sponsio/__version__` now matches pyproject.toml (`"0.1.0-alpha"`)
-- **Repo-wide lint cleanup**: Fixed all 35 lint errors — unused imports across `discovery/`, `models/`, `tests/`, `examples/`; ambiguous variable `l` → `line` in `sto_catalog.py`; unused `agent_id` in `crewai.py`
-- **Stale docs**: Updated test counts (262 → 341) in CLAUDE.md and README.md; corrected STATUS.md known issues (CLI and `[project.scripts]` already exist); fixed soft evaluator count in cli.py (7 → 5)
-
-### Added
-- **Pattern library expanded to 16+ patterns**: 14 temporal LTL patterns (`idempotent`, `deadline`, `must_confirm`, `cooldown`, `segregation_of_duty`, `bounded_retry` — with bounded temporal operators) plus FOL-based `PropertyConstraint` patterns (`arg_blacklist`, `scope_limit`, `data_intact`)
-- **Grounding layer**: Added `count(action)` cumulative invocation tracking; FOL `property_constraints` parameter evaluates per-event predicates and stores results as `prop.*` keys in valuations
+- **BaseGuard span accessors**: `last_check_span`, `check_spans`, `render_checks()` on all integration guards.
+- **RuntimeMonitor span properties**: `last_turn_span`, `turn_spans`, `render_last_turn()`.
+- **Demo span tree output**: All three demos (`customer_service`, `coding_agent`, `mcp_leak`) now print structured span trees after each "with protection" scenario.
+- **Pattern library expanded to 16+ patterns**: 14 temporal LTL patterns (`idempotent`, `deadline`, `must_confirm`, `cooldown`, `segregation_of_duty`, `bounded_retry` — with bounded temporal operators) plus FOL-based `PropertyConstraint` patterns (`arg_blacklist`, `scope_limit`, `data_intact`).
+- **Grounding layer**: Added `count(action)` cumulative invocation tracking; FOL `property_constraints` parameter evaluates per-event predicates and stores results as `prop.*` keys in valuations.
 - **Automatic Contract Discovery** (`sponsio/discovery/`):
   - **Document extraction** (Phase 1): LLM-based extraction from policy docs (.txt, .md, .pdf)
   - **Trace mining** (Phase 2): Statistical pattern mining from historical traces (.json) — discovers ordering, exclusion, frequency, and sequence patterns
@@ -206,21 +134,72 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **Validation pipeline**: 5-step validation (syntactic, triviality, consistency, trace replay, human review)
   - **PatternStore**: Categorized, JSON-backed storage at `~/.sponsio/patterns.json` with auto-save, organized by source (builtin / user_defined / auto_extracted) and status (proposed / verified / rejected). Builtin patterns are protected from deletion.
   - **File loaders**: Support for `.txt`, `.md`, `.pdf` documents; single/array `.json` traces with glob patterns; `.py` files and directories with recursive resolution
-- **New integrations**: CrewAI (`CrewAIGuard` + before/after hooks), OpenAI Agents SDK (`AgentsGuard` + `wrap()`), OpenAI SDK (`patch_openai()` / `unpatch_openai()`)
-- All integrations support `store=` parameter for automatic pattern registration
-- **`on_violation` parameter**: Contracts support per-rule violation actions — `"block"` (default), `"warn"`, or `"log"`. New `WarnOnly` strategy records violations without blocking execution
-- **`sponsio` CLI**: `sponsio demo --scenario customer|coding|mcp [--real]` runs demos from terminal; `sponsio patterns` lists all 14 hard patterns + 7 soft evaluator categories
-- **Assume-guarantee contracts**: `assumptions=` parameter on all guards; assumption violations report upstream problems via `EscalateToHuman` instead of silently skipping
-- **Soft (semantic) constraints**: Auto-detected from NL input alongside det constraints
+- **New integrations**: CrewAI (`CrewAIGuard` + before/after hooks), OpenAI Agents SDK (`AgentsGuard` + `wrap()`), OpenAI SDK (`patch_openai()` / `unpatch_openai()`).
+- All integrations support `store=` parameter for automatic pattern registration.
+- **`on_violation` parameter**: Contracts support per-rule violation actions — `"block"` (default), `"warn"`, or `"log"`. New `WarnOnly` strategy records violations without blocking execution.
+- **`sponsio` CLI**: `sponsio demo --scenario customer|coding|mcp [--real]` runs demos from terminal; `sponsio patterns` lists all 14 hard patterns + 7 soft evaluator categories.
+- **Assume-guarantee contracts**: `assumptions=` parameter on all guards; assumption violations report upstream problems via `EscalateToHuman` instead of silently skipping.
+- **Soft (semantic) constraints**: Auto-detected from NL input alongside det constraints.
   - Built-in evaluators: PII detection (regex), length check, format validation, content prohibition — zero dependencies
   - LLM evaluators: tone, relevance, generic judge — optional, requires `openai`
   - `StoConstraint` dataclass in `sponsio/patterns/sto.py`; catalog in `sto_catalog.py`
   - `parse_nl_unified()` auto-routes NL to hard pattern or soft evaluator
   - Discovery extractors emit soft proposals for unmatched patterns
 
-### Planned
-- Pre-deployment compositional verification
-- Metrics & before/after comparison dashboard
+### Changed (BREAKING)
+- **Contract semantics redesigned to per-(A, E) pair.** A `Contract` now holds a single `assumption` + single `enforcement` instead of parallel lists. An agent with multiple rules has multiple `Contract` objects in `System.contracts`. The runtime monitor (`_check_det`, `_check_sto`) evaluates each contract independently — an assumption on one contract no longer gates the enforcement of another contract, which was the root cause of the high false-positive rate observed in ODCV-Bench runs where all assumptions were ANDed across all guarantees.
+- **`Contract(agent, assumptions=[...], guarantees=[...])` removed.** The new constructor is `Contract(agent, enforcement=..., assumption=..., desc=...)`. Both fields accept a scalar or a list; a list is interpreted as the logical AND of its elements. `assumption=None` (the default) means the contract is unconditional.
+- **`BaseGuard` / `sponsio.init()` kwargs collapsed to a single `contracts=` kwarg.** `assumptions=[...]` and `guarantees=[...]` are gone. Entries inside `contracts=[...]` are either bare NL strings (= unconditional shortcut, one `Contract` each) or dicts with `assumption` / `enforcement` (= one `(A, E)` pair). List-valued fields are AND-combined. Python dicts **must** use the full keys `assumption` / `enforcement` — short keys `A` / `E` are YAML-only and raise `ValueError` if used in Python.
+- **YAML schema redesigned.** Agents declare a `contracts:` list of `{A, E}` pairs instead of parallel `assumptions:` / `guarantees:` blocks. YAML uses the **short keys** `A` / `E` — full names `assumption` / `enforcement` are Python-only and raise `ConfigError` if used in YAML. This split keeps YAML terse and Python self-describing. Old `assumptions:` / `guarantees:` schema also raises `ConfigError` on load with a migration hint.
+- **Soft (sto) pipeline now honors clause-level gating.** A sto enforcement inside a contract with an unsatisfied assumption is skipped for that turn. Sto constraints registered directly on a `StoEvaluator` (without an owning `Contract`) remain unconditional.
+- **`Contract` field shape.** Canonical state is the singular `Contract.assumption` / `Contract.enforcement` (scalar, list, or `None`). The old plural list fields are now read-only normalized views: `Contract.assumptions` / `Contract.enforcements` (properties) always return a flat `list`, which is the shape most callers want for iteration.
+- **`build_contract` → `build_contracts` (plural).** Parses NL text into a list of unconditional `Contract` objects instead of bundling them into a single Contract with ANDed guarantees. Old name kept as a thin backward-compat wrapper.
+- **API router `DELETE /contracts/{agent_id}/{index}`** now deletes a whole `Contract` (one A/E pair) by index, instead of popping a guarantee out of a larger contract bundle.
+- **`System.agent(...).guarantees(...)` builder** still works (as an alias for the new `.enforces(...)`) but now emits one `Contract` per enforcement instead of a single bundled `Contract`.
+
+### Changed
+- Public release: cleaned commit history; rebased onto initial commit.
+- **README rewrite for launch**: restructured around the before/after hero (`<!-- HERO_GIF -->` placeholder for the 8-second demo GIF), value prop on top, 60-second start example pulled above the fold, shadow mode promoted to its own section as the zero-risk onboarding path, Architecture/LTL explanation moved below the fold. Pattern Library, Integrations, and Benchmarks tables preserved unchanged. Quick Start badge row extended with a test-count badge.
+- **YAML config now accepts both short keys (`A` / `E`) and long keys (`assumption` / `enforcement`)** for each contract entry. The previous YAML-only / Python-only split was a footgun — users copying `{"assumption": ..., "enforcement": ...}` examples from the Python docs into YAML would hit `ConfigError`. Short keys stay recommended for terse hand-edited YAML; long keys are accepted when users prefer them. Using both forms of the *same* field in a single entry (e.g. both `A` and `assumption`) is ambiguous and still raises `ConfigError` with a "pick one" hint. Python API is unchanged (full keys only). 5 new tests in `tests/test_config.py` cover long-key loading, cross-entry mixing, cross-field mixing, and conflict detection.
+- **Unified `wrap()` method across all integration guards.** `tools()` (LangGraph, CrewAI, Agents SDK, BaseGuard), `tool_node()` (LangGraph, CrewAI), `wrap_tools()` (Agents SDK), and `middleware()` (Vercel AI) are all renamed to `wrap()`. Old names kept as backward-compatible aliases. All docs, examples, and tests updated to use `guard.wrap(tools)` as the canonical form.
+- **`RuntimeMonitor._check_det` and `_check_sto` refactored to delegate all formal evaluation to `self._verifier: TraceVerifier`.** The monitor no longer imports `ground` / `evaluate` directly — it only orchestrates spans, violations, and enforcement strategies. `_check_det` shrank from ~200 lines to ~80 lines by extracting `_emit_pass_event` / `_handle_assumption_failure` / `_handle_enforcement_failure` helpers.
+- **`BaseGuard.guard_before` now calls `monitor.verifier.reset()` after popping a blocked event from the trace** so the verifier's incremental cache is invalidated. Required for correctness: without this, a following event that reuses the popped index would be evaluated against stale grounded state.
+- **Grounding refactored to expose a per-event kernel.** `sponsio/tracer/grounding.py` now has `GroundingState` (dataclass of cumulative accumulators) and `ground_event(event, idx, state, …)` (single-event grounding); the existing batch `ground(trace, …)` becomes a thin loop over `ground_event`. Batch semantics are unchanged — all 630 existing tests pass against the refactored kernel.
+- **`AnnotatedFormula` renamed to `DetFormula`** with backward-compatible alias for compatibility. All internal references updated to use the new name. Reflects the renamed concept: "deterministic" (hard) constraints evaluated via LTL on the execution trace.
+- **`StoConstraint` renamed to `StoFormula`** with backward-compatible alias for compatibility. All internal references updated to use the new name.
+- **DocumentExtractor rewritten** to delegate to `UnifiedExtractor` — uses Atom-aware prompting instead of the old pattern-name-only prompt. Unknown hard patterns now fail with logged error instead of silently converting to soft constraints.
+- **Multi-Agent Eval Pipeline** (`AgentEval/`): Flagship example — 5 agents, 12 tools, 13 contracts covering every Sponsio pattern type. Demonstrates both NL and programmatic contract APIs, catches 5 violation types (must_precede, scope_limit, requires_permission, no_reversal, rate_limit), and exports trace datasets for downstream analysis.
+- **Pattern Architecture design doc** (`agent_docs/pattern_architecture.md`): Establishes the four-level concept stack (Atom -> Formula -> Pattern -> Contract), documents the full atom vocabulary, defines grounding as a thin event adapter, describes two complementary observation models (integration hooks for real-time blocking, OTEL consumer for post-hoc audit), and classifies patterns by observation boundary.
+- **`arg_paths_within(tool, *prefixes)` atom**: Checks all file paths in tool args are within allowed prefix set (replaces FOL `ForAllPaths` quantifier).
+- **`arg_field_has(tool, field, pattern)` atom**: Regex match on a specific arg field (`event.args[field]`), restoring field-level precision that was lost in FOL elimination. Used by `arg_blacklist`.
+- **`arg_blacklist` uses `arg_field_has` for field-specific matching** — restores the per-field precision from the old FOL system. `arg_blacklist("bash", "command", [...])` now only checks `args["command"]`, not all args.
+- **`arg_blacklist`, `scope_limit`, `data_intact` now return `DetFormula`** instead of `PropertyConstraint`. Same function signatures, same behavioral semantics, unified into the Atom + LTL system.
+- **`PropertyConstraint` class removed** — all patterns use `DetFormula`.
+- **`sponsio/formulas/fol.py` deprecated** — FOL AST replaced by grounding-level atoms. Module emits `DeprecationWarning` on import.
+- **`property_constraints` parameter removed from `ground()`** (internal API).
+- **`prop.*` predicate key namespace removed** (internal — replaced by standard atom keys).
+- **`never_together` deprecated** — delegates to `mutual_exclusion` (original formula trivially satisfied in sequential traces).
+- **NL parser: `no_data_leak` with tool names** routes to `no_reversal` (tool ordering, not data flow).
+- **NL parser: `requires_permission` with tool-like names** routes to `must_precede` (dynamic, not static).
+- **`must_precede` and `must_confirm` formulas** rewritten to use `Until` operator instead of derived `precedes()` predicate.
+- **Grounding simplified** — removed derived `precedes()` predicate; ordering now handled purely by LTL.
+- **CrewAI hooks renamed**: `before_hook` → `on_tool_start`, `after_hook` → `on_tool_end` (old names kept as deprecated aliases).
+- **`examples/hackathon/` renamed to `examples/demo/`**: All paths updated across codebase.
+- **`config_driven.py` removed**: YAML config usage documented in README instead.
+- **Demos.tsx refactored**: Replaced `NaiveTimeline` + `EnforcedTimeline` with unified `TraceTimeline` component.
+- **AgentConnect.tsx refactored**: Replaced inline `Timeline` component (~130 lines) with the same `TraceTimeline`.
+
+### Fixed
+- **MCP example DX consistency** — `mcp_guard.py` rewritten to use `sponsio.init()` + `guard_before()`/`guard_after()` in mock mode, matching the pattern of all other integration examples. Now shows contract banner, per-constraint enforcement lines, and session summary.
+- **Leaderboard crash**: `sqlite3.Row` `row_factory` was being mutated per-query on a shared connection across threads, causing segfaults. Now set once at connection creation.
+- **Python 3.9 compatibility**: Added `from __future__ import annotations` to `api/db.py` for `Dict[str, Any] | None` syntax.
+- **Span serialization**: `to_dict()` in all 8 span subclasses (`AgentTurnSpan`, `ContractCheckSpan`, `PreconditionSpan`, `GuaranteeSpan`, `ViolationSpan`, `EnforcementSpan`, `StoCheckSpan`, `StoEvalSpan`) now includes subclass-specific fields.
+- **Version mismatch**: `sponsio/__version__` now matches pyproject.toml (`"0.1.0a2"`).
+- **Repo-wide lint cleanup**: Fixed all 35 lint errors — unused imports across `discovery/`, `models/`, `tests/`, `examples/`; ambiguous variable `l` → `line` in `sto_catalog.py`; unused `agent_id` in `crewai.py`.
+- **Stale docs**: Updated test counts (262 → 341) in CLAUDE.md and README.md; corrected STATUS.md known issues (CLI and `[project.scripts]` already exist); fixed soft evaluator count in cli.py (7 → 5).
+
+### Removed
+- Frontend pages: `ContractEditor.tsx`, `Agents.tsx`, `PatternLibrary.tsx`, `Discovery.tsx` (functionality absorbed into Playground and Trace views).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Runtime contract enforcement for LLM agent systems. Natural language → LTL formal contracts → dual-pipeline runtime enforcement.
 
+> This file lives at the root of the **public** `SponsioLabs/Sponsio` repo. Every line here ships to the world. Do NOT reference internal-only files (anything under `internal/`, or `STATUS.md`, `PLAN.md`, `LAUNCH_*.md`, `sponsio-code-review.md`) from this doc — they are gitignored and not visible to OSS contributors.
+
+## Repo State
+
+- **Latest PyPI release**: `0.1.0a2` (alpha — users install with `pip install --pre sponsio`).
+- **Branch protection on `main`**: direct pushes blocked; all changes go through PRs. Force-push and branch deletion disabled. Required approvals = 0 (maintainers can self-merge after the PR checklist; external PRs need a maintainer to merge).
+- **GitHub defaults enabled**: Secret scanning, push protection, Dependabot alerts.
+- **CI**: `.github/workflows/ci.yml` runs `pytest` + ruff on Python 3.10/3.11/3.12, plus the TypeScript SDK cross-language parity tests. Required before merge.
+
 ## Build & Test
 
 ```bash
@@ -14,6 +23,7 @@ ruff format sponsio/ api/ tests/ # format
 
 Frontend: `cd web && npm install && npm run dev`
 Dashboard: `sponsio serve` (API :8000, Swagger :8000/docs) or `sponsio serve --dev` (+ frontend :5173)
+TS SDK: `cd ts-sdk && npm install && npx tsc && node dist/__tests__/core.test.js`
 
 ## Architecture Overview
 
@@ -23,7 +33,7 @@ The package and import path is `sponsio`.
 sponsio/
 ├── core.py          # Main entry point: sponsio.init() — auto-selects Guard by framework
 ├── config.py        # YAML config loader: load_config(), config_to_guard_kwargs()
-├── cli.py           # CLI: sponsio validate, check, serve, demo, patterns
+├── cli.py           # CLI: sponsio validate, check, serve, demo, patterns, report
 ├── formulas/        # LTL AST + evaluators
 │   ├── formula.py       #   Immutable LTL/propositional/arithmetic AST (G, F, X, U, Atom, etc.)
 │   ├── evaluator.py     #   Finite-trace LTL evaluator (weak semantics)
@@ -33,7 +43,7 @@ sponsio/
 │   ├── _pred_key.py     #   Canonical predicate key format (shared by formula + grounding)
 │   └── fol.py           #   [DEPRECATED] FOL predicate AST — replaced by Atom system
 ├── models/          # Core dataclasses: Agent, Contract, System, Trace, Event
-├── patterns/        # 16 det patterns + sto catalog
+├── patterns/        # 29 det patterns + sto catalog
 │   ├── library.py       #   DetFormula wrappers (must_precede, rate_limit, arg_blacklist, etc.)
 │   ├── soft.py          #   Soft constraint types
 │   ├── soft_catalog.py  #   Soft constraint catalog helpers
@@ -44,7 +54,10 @@ sponsio/
 │   ├── evaluators.py#   DetEvaluator (hard, binary) + StoEvaluator (soft, 0-1)
 │   ├── strategies.py#   DetBlock, EscalateToHuman, RetryWithConstraint, RedirectToSafe
 │   ├── feedback.py  #   Discriminative feedback generation for soft retry
-│   └── terminal.py  #   TerminalReporter — real-time CLI output (assume/enforce labels)
+│   ├── terminal.py  #   TerminalReporter — real-time CLI output (assume/enforce labels)
+│   ├── verifier.py  #   TraceVerifier — pure LTL evaluation, incremental grounding + G-cache
+│   └── session_log.py #  Shadow-mode JSONL session logger
+├── reporting/       # sponsio report — shadow-mode log reader (reader/aggregator/renderer)
 ├── scoring/         # Safety scoring for agent tool configurations
 │   └── scorer.py    #   score_tools(), ToolDef, ScoringReport
 ├── generation/      # NL → contract parsing (keyword-based + optional LLM)
@@ -57,9 +70,10 @@ sponsio/
 │   ├── langgraph.py #   LangGraphGuard + wrap() + wrap_graph() + monitor_graph()
 │   ├── mcp.py       #   MCPContractProxy + scan_mcp_tools
 │   ├── openai.py    #   patch_openai() / unpatch_openai() / OpenAIGuard
-│   ├── crewai.py    #   CrewAIGuard + wrap() + before/after hooks
+│   ├── crewai.py    #   CrewAIGuard + wrap() + on_tool_start/on_tool_end hooks
 │   ├── agents.py    #   OpenAI Agents SDK: AgentsSDKGuard + wrap()
 │   ├── vercel_ai.py #   Vercel AI SDK: VercelAIGuard + wrap()
+│   ├── claude_agent.py #  Claude Agent SDK guard
 │   └── otel.py      #   OTelExporter — send span trees to any OTEL backend
 └── discovery/       # Auto-extract contracts from docs/traces/code
     ├── store.py     #   PatternStore — JSON-backed at ~/.sponsio/patterns.json
@@ -70,9 +84,9 @@ sponsio/
 
 ## Key Conventions
 
-- **Zero core dependencies**: `sponsio/` has no external packages. Framework deps (langgraph, openai) are optional extras.
-- **Contract = assume-guarantee pair**: Never use bare assertions. All contracts have `assumptions` + `guarantees`.
-- **Det ≠ Sto**: Det violations MUST use DetBlock or EscalateToHuman. Sto violations MUST use RetryWithConstraint or RedirectToSafe. RuntimeMonitor enforces this — don't bypass.
+- **Zero core dependencies**: `sponsio/` has no external packages beyond `click` for the CLI. Framework deps (langgraph, openai, etc.) are optional extras.
+- **Contract = assume-guarantee pair**: Never use bare assertions. All contracts have an `assumption` + `enforcement` (or an unconditional enforcement with `assumption=None`).
+- **Det ≠ Sto**: Det violations MUST use `DetBlock` or `EscalateToHuman`. Sto violations MUST use `RetryWithConstraint` or `RedirectToSafe`. `RuntimeMonitor` enforces this — don't bypass.
 - **Trace is the single source of truth**: Every action appends to a linear trace. Grounding converts events → predicate valuations. Evaluator runs LTL over grounded trace.
 - **BaseGuard owns all contract logic**: Subclasses (LangGraph, MCP, etc.) only implement framework-specific interception. Never duplicate pre_check/post_check logic in subclasses.
 - **Pattern naming**: Use snake_case for pattern functions (`must_precede`, `rate_limit`). NL strings use backtick-wrapped tool names: `` tool `name` ``.
@@ -101,18 +115,12 @@ Cross-language parity is verified by `tests/cross_language/scenarios.json` — b
 - IMPORTANT: `DetFormula` wraps a raw `Formula` + description. Use `.formula` to get the raw LTL, `.desc` for the NL string. (`AnnotatedFormula` is a backward-compatible alias.)
 - Do NOT add external dependencies to `sponsio/` core without explicit approval. Optional deps go in `pyproject.toml [project.optional-dependencies]`.
 - When adding a new LTL pattern: update BOTH `sponsio/patterns/library.py` AND `sponsio/generation/nl_to_contract.py` (the NL parser must know about it), AND `ts-sdk/src/core/patterns.ts` + `ts-sdk/src/core/nl-parser.ts` for the TS SDK.
-- `ground()` returns `list[dict[str, bool]]` — one dict per timestep. The evaluator expects this exact shape. FOL predicates are evaluated per-event and stored under `prop.*` keys.
-- FOL predicates (`sponsio/formulas/fol.py`) are per-event, not temporal. They feed boolean results into grounding, which the LTL evaluator consumes. Don't confuse the two layers.
-- When modifying `BaseGuard`: all 6 integration subclasses depend on it. Run the full test suite after changes.
+- `ground()` returns `list[dict[str, bool]]` — one dict per timestep. The evaluator expects this exact shape. Per-event atoms are stored under the canonical predicate keys (the old `prop.*` namespace was removed).
+- When modifying `BaseGuard`: all integration subclasses depend on it. Run the full test suite after changes.
 
 ## Before Starting Any Task
 
-Read these files at the start of every session or major task, BEFORE writing any code:
-
-1. `STATUS.md` — current state, known issues, architecture invariants
-2. `PLAN.md` — sprint priorities and architecture decisions log
-
-Then, depending on what you're working on, read the relevant reference doc:
+Read the public docs relevant to what you're touching, BEFORE writing code:
 
 | If the task involves... | Read first |
 |------------------------|------------|
@@ -120,42 +128,197 @@ Then, depending on what you're working on, read the relevant reference doc:
 | Contract DSL / adding patterns | `docs/contracts.md` |
 | New integration adapter | `sponsio/integrations/base.py` (full docstring) |
 | CLI changes | `docs/cli.md` |
+| Contribution process | `CONTRIBUTING.md` |
+
+## Security Rules — Hard Blockers
+
+This is a **public** repo. Every commit is visible to the world, forever.
+
+**Never commit:**
+
+- Credentials or tokens: `sk-*`, `pypi-*`, `ghp_*`, `github_pat_*`, AWS keys, `-----BEGIN*` private keys, `.env` files.
+- Customer or user PII.
+- Unpublished security vulnerabilities — report those through GitHub Security Advisories (see `SECURITY.md`), not in a commit or public issue.
+- Internal strategy docs: roadmap, pricing plans, launch docs, investor materials, code review notes. Those live under `internal/` which is gitignored.
+
+The `Pre-push checklist` section below is how this gets enforced in practice.
+
+## Pre-push checklist
+
+Run through this before every merge to `main` — whether you're merging a PR or (as a maintainer with admin bypass) pushing directly. Steps are fast and skipping them has never saved time in aggregate.
+
+### Hard checks — every push
+
+```bash
+# 1. What am I about to ship?
+git log --oneline origin/main..HEAD
+git diff --stat origin/main..HEAD
+
+# 2. Secret scan — output MUST be empty.
+git diff origin/main..HEAD | grep -iE "sk-|pypi-|ghp_|github_pat_|api[_-]?key|-----BEGIN|aws_secret"
+
+# 3. Internal / ignored-file scan — output MUST be empty.
+git diff --stat origin/main..HEAD | grep -E "internal/|STATUS\.md|PLAN\.md|\.env($|[^.])"
+
+# 4. Tests + lint.
+pytest -v
+ruff check sponsio/ api/ tests/
+ruff format --check sponsio/ api/ tests/
+```
+
+### Sanity pass
+
+- Is the diff scope what you expected? Any file you don't remember touching?
+- If `sponsio/__init__.py` or `pyproject.toml` is in the diff, version strings must match: `grep -E '^version|__version__' pyproject.toml sponsio/__init__.py`.
+- Commit message matches the diff intent — no leftover `WIP`, `debug`, `temp`.
+- If the diff adds a public API, pattern, integration, or CLI command: `README.md` and `CHANGELOG.md` updated.
+
+### Pushing via Claude Code
+
+If you're driving the push through Claude Code, start the session with this prompt:
+
+```
+Before pushing, walk through the pre-push checklist in CLAUDE.md:
+
+1. `git status` and `git log --oneline origin/main..HEAD` — what's being shipped?
+2. `git diff --stat origin/main..HEAD` — blast radius.
+3. Run:
+   git diff origin/main..HEAD | grep -iE "sk-|pypi-|ghp_|github_pat_|api[_-]?key|-----BEGIN|aws_secret"
+   If output is non-empty, STOP and show me the hit. Do NOT push.
+4. Run:
+   git diff --stat origin/main..HEAD | grep -E "internal/|STATUS\.md|PLAN\.md|\.env"
+   If output is non-empty, STOP and show me the hit. Do NOT push.
+5. `pytest -v` and `ruff check sponsio/ api/ tests/` — both must be clean.
+6. If `sponsio/__init__.py` or `pyproject.toml` is in the diff, confirm the
+   version strings match each other.
+7. Summarize: files touched, lines +/-, any concerns.
+
+Wait for my explicit "push" before running `git push`. If any step fails,
+surface it and wait — do not "fix and retry" silently.
+```
+
+If any hard check fails, fix the root cause and restart the checklist. Never push through a red step.
+
+## PR Flow
+
+Branch protection requires a pull request before merging to `main` for all contributors. Maintainers hold admin bypass for trivial changes (docs typos, CHANGELOG edits, one-line fixes); anything non-trivial still goes through the standard PR flow below. External contributors always go through a PR.
+
+```bash
+git checkout main && git pull
+git checkout -b <prefix>/<name>      # feat, fix, docs, refactor, test, chore, perf, security
+# ... make changes ...
+ruff format sponsio/ api/ tests/
+ruff check sponsio/ api/ tests/
+pytest -v
+git commit -m "feat(area): description"    # Conventional Commits
+git push -u origin <prefix>/<name>
+gh pr create --fill                   # maintainers can self-merge after checks
+# OR for risky changes, open as Draft:
+gh pr create --draft --fill           # green Merge button disabled until `gh pr ready`
+gh pr merge --squash --delete-branch
+```
+
+**Use Draft PR when any of these are true:**
+
+- `pyproject.toml` dependencies changed
+- `.github/workflows/*` changed
+- Core runtime (`sponsio/runtime/`, `sponsio/formulas/`) changed
+- Diff deletes > 100 lines or is > 500 lines total
+- Security-adjacent change
+- You're uncertain about any part of the change
+
+## External PR Review Protocol
+
+Treat PRs from outside the core team as **potentially adversarial** until proven otherwise. Any red flag below → request changes and loop in a human maintainer. Never auto-merge external PRs.
+
+**Supply-chain / dependency:**
+
+- New entries in `pyproject.toml` (core or optional extras), `ts-sdk/package.json`, or any lockfile.
+- Typosquat-adjacent package names.
+- Dependencies pinned to a git commit or a pre-release tag.
+
+**CI / release hijack:**
+
+- Any change to `.github/workflows/*`.
+- New entries in `[project.scripts]` or install-time hooks (`setup.py` hooks, `MANIFEST.in` additions, `build-backend` changes).
+
+**Code execution / network / filesystem:**
+
+- `exec`, `eval`, `compile`, `__import__`, `importlib.import_module` with a non-literal argument.
+- `subprocess`, `os.system`, shell-injection-shaped string concatenation.
+- New outbound network calls from runtime code (anything not already in an integration shim).
+- File writes outside the expected path (anything not `~/.sponsio/`, `tests/`, or explicitly user-supplied).
+- User-controlled paths without `Path.resolve()` + an allowed-prefix check.
+
+**Obfuscation:**
+
+- Base64 / hex blobs, long one-liners, pickled objects, non-ASCII comments that obscure intent, binary files that aren't obvious assets.
+
+**Testing red flags:**
+
+- Deletes or disables existing tests.
+- `assert True` tests or trivially passing tests for a non-trivial change.
+- Weakly justified `pytest.mark.skip`.
+
+## Release Protocol
+
+Releases go through a PR — branch protection blocks direct pushes to `main`.
+
+```bash
+git checkout main && git pull
+git checkout -b release/v<X.Y.Z>
+# 1. Bump version in pyproject.toml AND sponsio/__init__.py (must match)
+# 2. Move CHANGELOG.md [Unreleased] contents under a new [X.Y.Z] - YYYY-MM-DD section
+git commit -am "release: v<X.Y.Z>"
+git push -u origin release/v<X.Y.Z>
+gh pr create --fill --title "release: v<X.Y.Z>"
+# ... CI green, reviewer approves ...
+gh pr merge --squash --delete-branch
+
+# After merge:
+git checkout main && git pull
+git tag v<X.Y.Z> && git push origin v<X.Y.Z>
+rm -rf dist/ build/ *.egg-info/
+python -m build
+twine upload dist/*
+```
+
+**PyPI versions are immutable.** Once a version is uploaded it cannot be overwritten — only yanked (which blocks new installs but leaves existing pins working). Double-check the version in all three places (`pyproject.toml`, `sponsio/__init__.py`, `CHANGELOG.md`) before `twine upload`.
 
 ## Task Completion Protocol
 
-After completing any non-trivial task, do the following:
+After completing any non-trivial task:
 
 ### Step 1: Read existing docs before updating
 
-IMPORTANT: Before updating ANY doc, read it first to match existing format, structure, and avoid duplicating content.
+Before modifying any doc, read it first to match its format and avoid duplicating content.
 
 | Doc to update | Read first to understand... |
 |---------------|----------------------------|
-| `README.md` | Existing pattern table format, architecture diagram style, Quick Start structure |
-| `CHANGELOG.md` | Existing entry format, what's already in `[Unreleased]`, Keep-a-Changelog conventions |
-| `STATUS.md` | Current known issues (don't duplicate), milestone dates, architecture invariants |
+| `README.md` | Pattern table format, architecture diagram style, Quick Start structure |
+| `CHANGELOG.md` | Keep-a-Changelog conventions, what's already in `[Unreleased]` |
+| `CONTRIBUTING.md` | Existing section layout before adding new contributor-facing guidance |
 
 ### Step 2: Update public-facing docs
 
 **README.md** — update if:
-- New pattern added → update Pattern Library table (match existing row format)
-- New integration → update Architecture diagram + integrations list
-- New CLI command → update Quick Start / usage sections
-- API surface changed → update code examples
 
-**CHANGELOG.md** — update `[Unreleased]` section if:
+- New pattern added → update Pattern Library table (match existing row format).
+- New integration → update Architecture diagram + Integrations table.
+- New CLI command → update Quick Start / usage sections.
+- Public API changed → update code examples.
+
+**CHANGELOG.md** — add an entry under `[Unreleased]` if:
+
 - Feature added → `### Added`
 - Bug fixed → `### Fixed`
 - Behavior changed → `### Changed`
 - Something removed → `### Removed`
+- Security fix → `### Security`
 
-IMPORTANT: Adding a feature without updating README.md and CHANGELOG.md is an incomplete task.
+Adding a user-visible change without updating `README.md` and `CHANGELOG.md` is an incomplete task.
 
-### Step 3: Update internal docs
-
-**STATUS.md** — update if architecture changed, features added, or new known issues found.
-
-### Step 4: Output Task Summary Block
+### Step 3: Output a Task Summary Block
 
 ```
 ## Task Summary
@@ -165,15 +328,18 @@ IMPORTANT: Adding a feature without updating README.md and CHANGELOG.md is an in
 **Tests**: [pass/fail + count]
 **Lint**: [clean / N errors]
 **Architecture impact**: [none / low / HIGH — explain if HIGH]
-**Docs updated**: [list which of README.md, CHANGELOG.md, CONTRIBUTING.md, STATUS.md were updated, or "none"]
+**Docs updated**: [README.md / CHANGELOG.md / CONTRIBUTING.md / none]
+**Security review**: [N/A / clean / flagged — required for any change touching runtime, integrations, or dependencies]
 **Open items**: [anything left undone or needing follow-up]
 ```
 
 ## Compaction Rules
 
 When compacting, ALWAYS preserve:
-- The full list of modified files from the current session
-- Any failing test names and error messages
-- Architecture decisions made during the session
-- Which public docs (README, CHANGELOG) were or were not updated
-- The last Task Summary Block
+
+- The full list of modified files from the current session.
+- Any failing test names and error messages.
+- Architecture decisions made during the session.
+- Which public docs (README, CHANGELOG) were or were not updated.
+- Any security flags raised during the session.
+- The last Task Summary Block.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,9 +209,10 @@ The test path is `tests/test_sto_*.py`.
 
 ## Reporting security issues
 
-Do **not** open a public issue for security vulnerabilities. Instead,
-email `security@sponsio.dev` with a description and a reproduction
-path. We'll acknowledge within 72 hours and coordinate disclosure.
+Do **not** open a public issue for security vulnerabilities. See
+[`SECURITY.md`](SECURITY.md) for the disclosure process — the preferred
+channel is a private [GitHub Security Advisory](https://github.com/SponsioLabs/Sponsio/security/advisories/new),
+with email as a fallback. We acknowledge within 48 hours.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security Policy
+
+Thanks for helping keep Sponsio and the teams that depend on it safe.
+
+## Supported Versions
+
+Sponsio is currently in alpha (`0.1.0aX`). Until we ship `0.1.0` stable, only the **latest released alpha** on PyPI receives security fixes. Patch releases for older alphas are best-effort.
+
+| Version            | Supported     |
+| ------------------ | ------------- |
+| `0.1.0aX` (latest) | Yes           |
+| Older alphas       | Best-effort   |
+| `< 0.1.0a0`        | No            |
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security reports.** Public issues give attackers a head start on users who haven't upgraded yet.
+
+### Preferred: GitHub Security Advisories
+
+Report privately via GitHub's built-in advisory flow:
+
+→ **<https://github.com/SponsioLabs/Sponsio/security/advisories/new>**
+
+This is the fastest path — the reporter and maintainers can discuss the issue inside a private advisory attached to the repo, and GitHub can request a CVE on the maintainer's behalf once the advisory is published.
+
+### Fallback: Email
+
+If you cannot use GitHub Security Advisories (no GitHub account, legal constraints, etc.), email **folio.ai.initial@gmail.com** with the subject line beginning `[sponsio-security]`.
+
+Either way, please include:
+
+1. A description of the issue and the impact you believe it has.
+2. Minimal steps to reproduce (a code snippet or failing test is ideal).
+3. The Sponsio version, Python version, and any framework (LangGraph, OpenAI SDK, MCP, etc.) involved.
+4. Your name / handle if you'd like credit in the advisory (optional).
+
+If you need to send anything sensitive through email, ask us first and we'll share a PGP key or a one-time upload link.
+
+## Response Timeline
+
+We aim to:
+
+- **Acknowledge** your report within **48 hours**.
+- Confirm whether we consider it a vulnerability within **5 business days**.
+- Ship a fix or mitigation within **30 days** for high-severity issues; lower-severity issues may follow the normal release cadence. Complex issues may take longer; we'll keep you updated.
+- Coordinate a disclosure date with you before publishing the advisory.
+
+Security fixes are released as a patch version (e.g., `0.1.0a2` → `0.1.0a3`) and announced in the [CHANGELOG](CHANGELOG.md) under a `### Security` section, alongside a GitHub Security Advisory. We credit reporters unless you ask us not to.
+
+## What's In Scope
+
+We care about reports affecting any of:
+
+- The `sponsio` Python package and its framework integrations (`langgraph`, `openai`, `crewai`, `agents`, `vercel_ai`, `mcp`, `claude_agent`).
+- The `ts-sdk` TypeScript runtime.
+- The `sponsio serve` dashboard and its FastAPI backend (`api/`).
+- The contract parser and LTL evaluator, including bypasses of deterministic contracts, grounding errors that cause false allows, and injection via natural-language contract strings.
+- Supply-chain issues: package signing, GitHub Actions, PyPI release hygiene.
+
+Bypasses of **soft (sto) contracts** enforced by an LLM judge are interesting, but since those are probabilistic by design we treat them as quality bugs rather than vulnerabilities unless they are trivially deterministic (e.g., a prompt injection that always succeeds on a default config).
+
+## What's Out of Scope
+
+- Vulnerabilities in third-party integrations themselves (LangGraph, OpenAI SDK, CrewAI, etc.) — please report those to their respective maintainers.
+- Issues that require a malicious local attacker who already has code execution on the user's machine.
+- Missing security headers or TLS configuration on `sponsio.dev` (that's a static site — report to the same channels if you find something, but it won't be tracked as a library vulnerability).
+- Findings from automated scanners without a working proof of concept.
+- Social engineering of Sponsio contributors.
+
+## Safe Harbor
+
+If you make a good-faith effort to comply with this policy, we will:
+
+- Not pursue or support legal action against you.
+- Work with you to understand and resolve the issue quickly.
+- Recognize your contribution publicly (with your consent) in the advisory and CHANGELOG.
+
+---
+
+Thanks again. Responsible disclosure is what makes open source safe to depend on.

--- a/sponsio/__init__.py
+++ b/sponsio/__init__.py
@@ -25,7 +25,7 @@ Direct guard import (advanced)::
     guard = LangGraphGuard(contracts=[...])
 """
 
-__version__ = "0.1.0a0"
+__version__ = "0.1.0a2"
 
 # --- Main entry point ---
 from sponsio.core import init


### PR DESCRIPTION
## Summary

Pre-launch hygiene sweep before the repo flips public. ring
mismatch, adds a security policy + private-reporting config, tightens CLAUDE.md
so it stops referencing gitignored internal docs, adds a pre-push checklist,
and consolidates CHANGELOG + gitignore.

## What changed

**Version fix (blocker)**
- `sponsio/__init__.py`: `__version__` was `0.1.0a0`, now matches
  `pyproject.toml` at `0.1.0a2`.

**Security & vulnerability reporting**
- Add `SECURITY.md` — GitHub Security Advisories as primary channel, email
  as fallback; 48h ack / 5-day assessment / 30-day high-severity fix target.
- Add `.github/ISSUE_TEMPLATE/config.yml` — blank issues disabled; security
  reports routed to private advisories, open questions to Discussions.
- Fix `CONTRIBUTING.md` security section to point at `SECURITY.md`
  (was pointing at a non-existent address).

**CLAUDE.md (public-repo hardening)**
- Remove required-reading references to gitignored internal files
  (`STATUS.md`, `PLAN.md`) that OSS contributors can't see.
- Add Repo State, Security Rules, PR Flow (with Draft-PR ters),
  External PR Review Protocol, and Release Protocol sections.
- Add a new Pre-push checklist section: secret scan, internal-file scan,
  tests + lint, sanity pass, plus a Claude Code prompt template for driving
  pushes through the assistant.
- Soften the PR Flow opening to reflect that maintainers hold admin bypass
  for trivial changes (docs typos, CHANGELOG edits); non-trivial work and
  all external contributions still go through the standard PR flow.
- Add a public-repo warning at the top.

**CHANGELOG.md**
- Consolidate the `[0.1.0a2]` section (it previously had 14+ duplicate
  `### Added/Changed/Fixed` subsections that should have merged at release).
- Keep-a-Changelog order: Added / Changed / Fixed / Removed / Security.

**.gitignore**
- Add canonical `internal/` rule + comment telling future contributors no
  more colocated exceptions.
- Migrate 5 legacy internal entries under `internal/`.
- Remove a duplicate `.DS_Store`.

## Test plan

- [x] `pytest -v` — all existing tests pass (no `spono/` code changes).
- [x] `ruff check sponsio/ api/ tests/` — clean.
- [x] `ruff format --check sponsio/ api/ tests/` — clean.
- [x] `python -c "import sponsio; print(sponsio.__version__)"` → `0.1.0a2`.

## Risk

Low — docs + metadata + one-line version bump. No runtime changes, no
dependency changes, no public API surface change.

## Linked issue

N/A — pre-launch hygiene.
