### PR TITLE
docs(readme): wire up banner image reference at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Sponsio
+![Sponsio](assets/readme-banner.png)
 
 # Sponsio
 


### PR DESCRIPTION
## Summary

Follow-up to #2. The banner asset (`assets/readme-banner.png`) was included in that PR but the README's image markdown reference got stripped at some point — line 1 was left as orphan text `Sponsio` without the surrounding `![](...)` syntax, so the banner doesn't render.

This PR replaces the orphan text with the proper image markdown, matching the pattern microsoft/agent-governance-toolkit uses (banner above the H1 title).

## What changed

Line 1 of `README.md`:

```diff
-Sponsio
+![Sponsio](assets/readme-banner.png)
```

One-line change, single commit.

## Test plan

- [ ] Verify the banner renders at the top of the README on GitHub
- [ ] Confirm no other layout shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)