### PR TITLE
style: ruff format code_analysis.py to fix CI Lint

### DIFF
--- a/sponsio/discovery/extractors/code_analysis.py
+++ b/sponsio/discovery/extractors/code_analysis.py
@@ -933,7 +933,9 @@ class CodeAnalyzer:
                                         func_node.end_lineno or start + 30,
                                         start + 30,
                                     )
-                                    tool_info.source = "\n".join(source_lines[start:end])
+                                    tool_info.source = "\n".join(
+                                        source_lines[start:end]
+                                    )
                             tools.append(tool_info)
         return tools
 


### PR DESCRIPTION
`ruff format --check` failed on main because `sponsio/discovery/extractors/code_analysis.py` had a line that exceeded the configured width. Rerunning `ruff format` on the file produces a 2-line wrapping change only.

This restores the required `Lint` check to green so future PRs can merge without admin override.