### PR TITLE
fix(ci): green Lint + test_overrides after launch-tune drift

### DIFF
--- a/sponsio/init_wizard.py
+++ b/sponsio/init_wizard.py
@@ -487,12 +487,8 @@ def print_next_steps(picks: "InitPicks", *, ts_project: bool = False) -> None:
         # Project-framework path.
         click.echo(f"    {npx}sponsio onboard . --emit-context > /tmp/ctx.json")
         click.echo(f"    {npx}sponsio prompt onboard")
-        click.echo(
-            "      → apply the printed template to ctx.json IN this chat;"
-        )
-        click.echo(
-            "        WAIT for the user to pick proposals; merge into yaml."
-        )
+        click.echo("      → apply the printed template to ctx.json IN this chat;")
+        click.echo("        WAIT for the user to pick proposals; merge into yaml.")
         click.echo(f"    {npx}sponsio validate sponsio.yaml")
     elif picks.framework == "none":
         # Bare-loop path.  API name is language-specific: TS uses
@@ -507,10 +503,7 @@ def print_next_steps(picks: "InitPicks", *, ts_project: bool = False) -> None:
             if ts_project
             else "guard.guard_before / _after"
         )
-        click.echo(
-            "    Splice ``wrap_snippet`` from sponsio.yaml's "
-            "next-step output"
-        )
+        click.echo("    Splice ``wrap_snippet`` from sponsio.yaml's next-step output")
         click.echo(f"    into your agent loop ({guard_api}).")
         click.echo(f"    {npx}sponsio validate sponsio.yaml")
 

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -350,7 +350,7 @@ class TestLoadConfigOverrides:
         assert "sponsio:core/llm_safety" in sources
 
     def test_threshold_override_on_pattern(self, tmp_path):
-        """Loosen the rate_limit threshold across the shell pack.
+        """Loosen the rate_limit threshold across the openclaw pack.
         Verifies field-edit write-back works through the whole load
         pipeline."""
         cfg = load_config(
@@ -360,7 +360,7 @@ class TestLoadConfigOverrides:
             agents:
               bot:
                 workspace: "/proj"
-                include: [sponsio:capability/shell]
+                include: [sponsio:incident/openclaw]
                 customized:
                   - match: {pattern: rate_limit}
                     threshold: 0.42
@@ -374,7 +374,7 @@ class TestLoadConfigOverrides:
             and not isinstance(c.guarantee, list)
             and c.guarantee.pattern == "rate_limit"
         ]
-        assert rates, "expected at least one rate_limit rule in the shell pack"
+        assert rates, "expected at least one rate_limit rule in the openclaw pack"
         for c in rates:
             assert c.guarantee.threshold == 0.42
 
@@ -414,21 +414,24 @@ class TestLoadConfigOverrides:
               bot:
                 workspace: "/proj"
                 tool_rename: {exec: bash}
-                include: [sponsio:capability/shell]
+                include: [sponsio:incident/openclaw]
                 customized:
                   - match: {pattern: rate_limit}
                     threshold: 0.5
             """,
             )
         )
-        # The rate_limit rule should still be present and now
-        # references `bash` after rename
+        # openclaw ships several rate_limit rules; we want the one
+        # whose first arg was `exec` (now `bash` after the rename),
+        # not the per-tool caps for skill installs / web fetches /
+        # message sends.
         rate = next(
             c
             for c in cfg.agents["bot"].contracts
             if c.guarantee
             and not isinstance(c.guarantee, list)
             and c.guarantee.pattern == "rate_limit"
+            and c.guarantee.args[0] == "bash"
         )
         assert rate.guarantee.args[0] == "bash"
         assert rate.guarantee.threshold == 0.5


### PR DESCRIPTION
## Summary

Two CI failures on `main` (`fb3a899`) cleaned up:

1. **Lint** — `sponsio/init_wizard.py` failed `ruff format --check` (1 file would-reformat). Pure formatting, no semantic change.
2. **Test (Python 3.10/11/12)** — `tests/test_overrides.py::test_threshold_override_on_pattern` and `::test_overrides_apply_after_rewrites` both pinned to `sponsio:capability/shell` + `match: {pattern: rate_limit}`, but the launch tune intentionally removed the shell pack's session-wide `rate_limit` rules ([shell.yaml:153](https://github.com/SponsioLabs/Sponsio/blob/main/sponsio/contracts/capability/shell.yaml#L153) explains why). Repointed both tests at `sponsio:incident/openclaw`, which still ships `rate_limit(exec, 10)` plus four other caps.

## Changes

- `sponsio/init_wizard.py` — `ruff format` (whitespace only)
- `tests/test_overrides.py` — switch include from `sponsio:capability/shell` → `sponsio:incident/openclaw` for the two failing tests; add `args[0] == "bash"` filter to `next(...)` in `test_overrides_apply_after_rewrites` so it deterministically picks the renamed `exec` rate_limit rather than one of the other four (skill installs, web fetches, message sends, gateway config)

## Test plan

- [x] `ruff format --check sponsio/ tests/ scripts/` — clean
- [x] `ruff check sponsio/ tests/ scripts/` — clean
- [x] `pytest tests/test_overrides.py` — 33/33 passed
- [ ] CI (Python 3.10 / 3.11 / 3.12 + Lint + TS native) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)