### PR TITLE
ci: drop TestPyPI gate, replace with build + install smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,41 @@ jobs:
       - name: Run tests
         run: pytest --cov=sponsio --cov-report=term-missing -v
 
+  build-smoke-test:
+    name: Build wheel + install smoke test
+    runs-on: ubuntu-latest
+    # Stand-in for the TestPyPI gate we used to keep in publish.yml.
+    # `twine check` catches the same metadata regressions PyPI rejects on
+    # upload (long-description content-type, classifier validity, etc.);
+    # the install + `sponsio --version`/--help run catches packaging
+    # errors (missing modules, broken entry point) that would brick the
+    # wheel before we burn an immutable PyPI version number.
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build sdist + wheel
+        run: |
+          pip install build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Install built wheel + verify CLI
+        # Install the freshly-built wheel into a clean venv (not editable)
+        # so this catches packaging issues that `pip install -e .` skips —
+        # e.g. missing files in `tool.setuptools.package-data`.
+        run: |
+          python -m venv /tmp/smoke-venv
+          /tmp/smoke-venv/bin/pip install dist/*.whl
+          /tmp/smoke-venv/bin/sponsio --version
+          /tmp/smoke-venv/bin/sponsio --help
+
   test-typescript:
     name: Test (TypeScript — native)
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,28 +31,9 @@ jobs:
           name: dist
           path: dist/
 
-  test-publish:
-    name: Publish to TestPyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write
-    steps:
-      - name: Download distribution artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.14.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   publish:
     name: Publish to PyPI
-    needs: [build, test-publish]
+    needs: [build]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary

- Drop the `test-publish` job from `publish.yml`; PyPI publishes now flow `build → publish` instead of `build → test-publish → publish`.
- Add a `build-smoke-test` job in `ci.yml` that runs `python -m build` + `twine check` + `pip install dist/*.whl` + `sponsio --version`/`--help` on every push/PR.

## Why

The TestPyPI gate has been broken since launch: every release run failed with

```
Trusted publishing exchange failure:
  invalid-publisher: valid token, but no corresponding publisher
```

because TestPyPI's trusted-publisher config was never set up for this `repo+environment` combo. Both 0.1.0a3 and 0.1.0 ended up published to PyPI manually via `twine` because of this.

Configuring TestPyPI OIDC would fix the symptom, but TestPyPI brings little value for an OSS project of this size:
- TestPyPI is a low-priority free service that's frequently flaky and periodically purges history.
- Most upstream deps aren't mirrored on TestPyPI, so a `pip install` smoke test there has to fall back to PyPI anyway, defeating the test.
- Major Python OSS (`requests`, `flask`, `pydantic`, `langchain`) skip TestPyPI entirely and rely on local `twine check` + CI build verification + yank-and-bump if a regression slips through.

## What the new CI job catches

| Check | What it catches |
|---|---|
| `python -m build` | wheel/sdist build errors |
| `twine check` | invalid `long_description` content-type, invalid classifiers, missing fields — same things PyPI rejects on upload |
| `pip install dist/*.whl` (clean venv, **not** editable) | missing entries in `tool.setuptools.package-data`, broken entry points |
| `sponsio --version` / `--help` | entry-point wiring + module import surface |

The check now runs on **every push and PR**, not just on release — shift-left from release-time to review-time.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)` parses both YAMLs cleanly
- [x] `publish.yml` jobs reduced from 3 → 2 (`build`, `publish`)
- [x] `ci.yml` jobs grew from 3 → 4 (added `build-smoke-test`)
- [ ] Watch this PR's `build-smoke-test` job pass end-to-end
- [ ] Confirm `publish.yml` is unchanged from the publisher's perspective for the next release (still triggered on `release: published`, still uses OIDC trusted publishing for PyPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)