### PR TITLE
docs: remove Sponsio Cloud launch plan from OSS_PROMISE

### DIFF
--- a/OSS_PROMISE.md
+++ b/OSS_PROMISE.md
@@ -86,7 +86,7 @@ Apache 2.0.
 
 ## 2. What we sell as Sponsio Cloud
 
-`pip install sponsio[cloud]`. Opens **mid-May 2026**.
+`pip install sponsio[cloud]`.
 
 These are the things that genuinely benefit from being a managed
 service — they need a backend you don't want to operate yourself, or
@@ -225,15 +225,6 @@ If you don't want either, run OSS forever. We mean that.
 | Local HTML report | OSS (`sponsio report --format html`) |
 
 The full mapping lives in [`docs/reference/oss-scope.md`](docs/reference/oss-scope.md).
-
----
-
-## 6. Cloud waitlist
-
-Sponsio Cloud opens **mid-May 2026**. Early-access pricing for the
-first 50 teams.
-
-[**Join the waitlist** →](https://sponsio.dev/cloud)
 
 ---
 


### PR DESCRIPTION
## Summary
- Drops the "Opens **mid-May 2026**." line from OSS_PROMISE.md § 2
- Drops § 6 "Cloud waitlist" (launch date + early-access pricing + waitlist link)
- Keeps the factual OSS / Cloud boundary description

Forward-looking launch marketing doesn't belong in OSS docs before the product ships.

Scope note: the original draft of this branch also edited the root READMEs + llms-full.txt; those were dropped so the root README stays owned by its separate curation worktree (and llms-full.txt's README-derived License blurb stays consistent with it). Net change is OSS_PROMISE.md only.

## Test plan
- [x] Rebased onto current main, 1 ahead / 0 behind
- [x] `git diff main` shows only OSS_PROMISE.md (+1 −10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)