### PR TITLE
Repo hygiene: docs/CLI accuracy, ruff config, trace-mining fail-open, sdk tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,23 @@ broke.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **`@sponsio/sdk` is now edge-runtime safe.** Marked the package
+  `sideEffects` (narrowed to the CLI entry) so bundlers can tree-shake
+  the Node-only YAML/config-loading path out of edge bundles (Cloudflare
+  Workers), complementing the `createRequire` deferral in `0.2.0a3`.
+- **Trace mining fails open when its extension isn't bundled.**
+  `CodeAnalyzer` imported `TraceMiner` unguarded, crashing
+  `sponsio scan --trace` with `ModuleNotFoundError` in builds without the
+  optional `trace_mining` extension; it now degrades to "no contracts
+  mined", matching the other call sites.
+
+### Changed
+
+- Added an explicit `[tool.ruff]` config to `pyproject.toml` so local
+  lint matches CI, and synced `docs/reference/cli.md` with the real CLI
+  surface (`onboard`/`serve`/`daemon`/`cursor` now documented).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,6 @@ sponsio/
 ├── patterns/          deterministic pattern library
 ├── reporting/         shadow-mode report aggregation/rendering
 ├── runtime/           monitor, verifier, strategies, feedback, session logging
-├── scoring/           tool configuration risk scoring
 └── tracer/            event collection and grounding
 
 ts/                    TypeScript workspace (npm workspaces)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,7 @@ sponsio/
 └── tracer/            event collection and grounding
 
 ts/                    TypeScript workspace (npm workspaces)
-├── packages/sdk/      @sponsio/sdk: det engine + framework integrations
-└── packages/sdk/  @sponsio/sdk: AST static scanner CLI
+└── packages/sdk/      @sponsio/sdk: det engine, framework integrations, and AST static scanner CLI
 docs/                  user-facing documentation
 scripts/               one-off maintenance utilities (e.g. plugin sync)
 tests/                 pytest suite

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -90,6 +90,30 @@ sponsio init . --plan "framework=crewai;ides=cursor:skill"                  # dr
 
 See [getting-started/quickstart.md](../getting-started/quickstart.md) for the typical interactive flow.
 
+## sponsio onboard
+
+One-shot project wire-up: composes `init` + `scan` + `doctor` into a single command so first-time users don't have to learn three subcommands. Detects the framework, picks the best available LLM provider (env → `OPENAI_BASE_URL` → local Ollama → none), writes `sponsio.yaml` in observe mode with an inferred contract set, then prints the framework-specific agent-entry patch.
+
+```bash
+sponsio onboard [TARGET] [--agent NAME] [--mode observe|enforce] [--force]
+```
+
+| Option | Description |
+|---|---|
+| `TARGET` | File or directory to scan (default: current). |
+| `--mode` | Runtime mode written into `sponsio.yaml`. Omit to be prompted; `observe` is the safe default. |
+| `--force` | Overwrite an existing `sponsio.yaml` without prompting. |
+| `--no-probe-ollama` | Skip the `localhost:11434` liveness probe. |
+| `--no-doctor` | Skip the post-onboard `sponsio doctor` run. |
+| `--emit-context` | Skip the LLM step; emit the structured inputs as JSON for the `sponsio` skill. Pair with `sponsio prompt onboard`. |
+| `--json` | Emit the structured `OnboardReport` as JSON. |
+
+```bash
+sponsio onboard
+sponsio onboard src/ --agent customer_bot
+sponsio onboard --force --no-probe-ollama
+```
+
 ## sponsio validate
 
 Parse-check contract strings. CI-friendly.
@@ -184,17 +208,6 @@ Health checks: install integrity, config syntax, framework wiring.
 ```bash
 sponsio doctor
 ```
-
-## sponsio refresh
-
-Re-mine `source: trace` contracts from recent sessions.
-
-```bash
-sponsio refresh --since 7d           # dry-run
-sponsio refresh --since 7d --apply   # write back, with .sponsio.bak
-```
-
-User-written rules and `customized:` blocks pass through unchanged. Mines your own local session log.
 
 ## sponsio packs
 
@@ -293,6 +306,37 @@ sponsio prompt (onboard|refresh|scan)
 ```
 
 Output is a copy-pasteable prompt block your AI assistant can run.
+
+## sponsio serve
+
+Placeholder for the web-dashboard server. This distribution ships the contract runtime + CLI only; the long-lived HTTP backend is not bundled, so the command exits non-zero and points you at the local-inspection alternatives.
+
+```bash
+sponsio serve   # prints the alternatives below and exits 2
+```
+
+For local observability use `sponsio host trace --follow` (live stream), `sponsio report --since 1h` (session summary), `sponsio replay <session>` (re-render a recorded session), or `sponsio export-sessions` (ship to a collector).
+
+## sponsio daemon
+
+Privileged-process side of the IPC split. The daemon owns the host bucket / per-plugin yaml files and is the only entity the host agent can reach to write them, so self-modify protection becomes an OS-level guarantee (ideally a separate UID under launchd/systemd) rather than a regex-on-tool-args one.
+
+```bash
+sponsio daemon run [--socket PATH] [--mode 0600]   # foreground; used by launchd/systemd
+sponsio daemon ping [--echo VALUE]                 # round-trip health check
+sponsio daemon status                              # resolved socket path + reachability
+```
+
+Socket path resolves to `$SPONSIO_DAEMON_SOCKET`, then `/var/run/sponsio.sock` if writable, else `~/.sponsio/sponsio.sock`.
+
+## sponsio cursor
+
+Cursor IDE integration. Cursor 1.7+ ships a deny-capable hook system (`hooks.json`); Sponsio plugs in as the command for the relevant pre-* events so every Shell/Read/Write/MCP call is evaluated against the contract library before Cursor executes it.
+
+```bash
+sponsio cursor install-hooks            # writes ~/.cursor/hooks.json (or project .cursor/hooks.json)
+sponsio cursor guard --event <name>     # runtime hook handler; reads payload on stdin, denies via exit 2
+```
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,5 +139,19 @@ sponsio = [
     "skills/*/*.md",
 ]
 
+# Ruff config. The lint job (and `ruff format`) runs against a pinned
+# ruff (see the `dev` extra above). Defaults drift between ruff
+# versions, so pin the knobs the CI relies on explicitly here rather
+# than inheriting whatever the installed ruff happens to default to.
+# This codifies *current* behaviour (88-col, default E/F lint set) so
+# the config commit is a no-op against the existing tree — widening the
+# rule set (e.g. enabling `I` import sorting) is a separate change.
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/sponsio/discovery/extractors/code_analysis.py
+++ b/sponsio/discovery/extractors/code_analysis.py
@@ -2134,7 +2134,21 @@ class CodeAnalyzer:
             already present in ``existing``.  Empty if no trace files
             matched or every mined pattern was a duplicate.
         """
-        from sponsio.discovery.extractors.trace_mining import TraceMiner
+        # Cross-trace mining is an extension point not shipped in every
+        # build (see sponsio/discovery/extractors/__init__.py). Fail open
+        # — same as trace loading below — so `scan --trace` / `refresh`
+        # degrade to "no mined contracts" instead of crashing when the
+        # module is absent.
+        try:
+            from sponsio.discovery.extractors.trace_mining import (  # type: ignore[import-not-found]
+                TraceMiner,
+            )
+        except ImportError:
+            self._emit(
+                "Trace mining unavailable (trace_mining extension not "
+                "installed in this build); skipping."
+            )
+            return []
         from sponsio.discovery.loaders import load_traces
 
         self._emit(f"Loading traces from {len(trace_paths)} path(s)…")

--- a/sponsio/discovery/extractors/code_analysis.py
+++ b/sponsio/discovery/extractors/code_analysis.py
@@ -1779,7 +1779,7 @@ class CodeAnalyzer:
                 if t.get("params"):
                     lines.append(f'    params: "{t["params"]}"')
 
-        # Agents section — emit `contracts:` with `E:` short-keys (YAML
+        # Agents section — emit `contracts:` with `G:` short-keys (YAML
         # schema). Each proposal becomes one unconditional contract entry.
         lines.append("")
         lines.append("agents:")

--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/SponsioLabs/Sponsio#readme",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": ["./dist/cli/**"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://github.com/SponsioLabs/Sponsio#readme",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

Adopts the well-scoped cleanup commits from #82 (with attribution), leaving the larger changes out of scope.

- **docs**: fix CLAUDE.md repo map (duplicate `packages/sdk` line, stale `scoring/` entry); sync `docs/reference/cli.md` with the real CLI surface (`onboard`/`serve`/`daemon`/`cursor` now documented).
- **build**: add an explicit `[tool.ruff]` config so local lint matches CI.
- **fix(discovery)**: `CodeAnalyzer` imported `TraceMiner` unguarded, crashing `sponsio scan --trace` with `ModuleNotFoundError` in builds without the optional `trace_mining` extension. Now fails open to "no contracts mined", matching the other call sites.
- **fix(sdk)**: mark `@sponsio/sdk` `sideEffects` (narrowed to the CLI entry) so bundlers can tree-shake the Node-only YAML/config path out of edge bundles, complementing the `createRequire` deferral in 0.2.0a3.

## Test plan

- `ruff check` / `ruff format --check` (0.15.16): clean
- `pytest -q`: 2337 passed, 2 skipped
- `(cd ts/packages/sdk && npm run build && npm test)`: build OK, all suites pass
- `sponsio demo --scenario freeze --fast`: BLOCKED as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)