### PR TITLE
feat(examples): add deterministic OpenClaw social-account action recipe

### DIFF
--- a/examples/recipes/openclaw_social_actions/README.md
+++ b/examples/recipes/openclaw_social_actions/README.md
@@ -1,0 +1,87 @@
+# OpenClaw social-account actions (TweetClaw)
+
+A small, **deterministic** Sponsio recipe for OpenClaw plugins that act through a
+real, public social account. It uses [TweetClaw](https://example.invalid/tweetclaw)
+as the concrete plugin path, but the same two contracts apply to any *live,
+account-scoped side effect that follows a planning step*.
+
+## The shape
+
+| Action | Kind | Treatment |
+| --- | --- | --- |
+| `explore` | read-only discovery / planning | **open** — no contract |
+| `draft_tweet` | compose locally, no live call | **open** — no contract |
+| `tweetclaw` | live, account-scoped post | **gated** — re-confirm + capped |
+| `confirm_reconfirmed` | marker emitted on operator approval | referenced by contracts |
+
+The idea: keep endpoint review and drafting friction-free, but require a human
+in the loop — and a per-session budget — before anything reaches the live
+account.
+
+## The contracts
+
+[`sponsio.yaml`](sponsio.yaml) declares two deterministic guarantees on the
+`social_bot` agent:
+
+1. **Re-confirm before posting** — `must_precede(confirm_reconfirmed, tweetclaw)`.
+   `tweetclaw` is forbidden until a `confirm_reconfirmed` event has been
+   observed. Compiles to:
+
+   ```
+   (!called(tweetclaw) U called(confirm_reconfirmed)) | G(!called(tweetclaw))
+   ```
+
+2. **Cap live posts** — `rate_limit(tweetclaw, 3)`. At most 3 live posts per
+   session. Compiles to `G(count(tweetclaw) <= 3)`.
+
+Both are pure-Python checks — no LLM judge in the runtime hot path.
+
+`explore` and `draft_tweet` carry no contract, so the default allow policy lets
+the agent plan freely; only the live action is constrained.
+
+## Validate
+
+With the config loader and the CLI:
+
+```bash
+sponsio validate --config examples/recipes/openclaw_social_actions/sponsio.yaml
+```
+
+Expected: both guarantees report `✓ DET` and the command exits `0`.
+
+## How it behaves at runtime
+
+| Trace | `tweetclaw` outcome |
+| --- | --- |
+| `explore → draft_tweet → tweetclaw` | **blocked** — no prior `confirm_reconfirmed` |
+| `explore → confirm_reconfirmed → tweetclaw` | allowed |
+| `… → tweetclaw × 4` (after confirm) | 4th post **blocked** — cap is 3 |
+
+## Adapting it
+
+- **Layer on the full incident pack.** Add an `include:` to pull in the broader,
+  mixed det/sto OpenClaw coverage on top of these two rules:
+
+  ```yaml
+  agents:
+    social_bot:
+      include:
+        - sponsio:incident/openclaw
+      contracts:
+        # ... the two contracts above
+  ```
+
+- **Re-confirm *every* post (no reuse).** `must_precede` only requires *one*
+  confirmation before the first post. To require a fresh confirmation per post —
+  so an early approval can't be replayed — use the count-dominance form from the
+  incident pack instead:
+
+  ```yaml
+  - desc: "Each live post needs its own fresh confirmation"
+    A: "called `confirm_reconfirmed`"
+    G:
+      ltl: "G(called(tweetclaw) -> count(confirm_reconfirmed) >= count(tweetclaw))"
+  ```
+
+- **Different tool name.** Swap `tweetclaw` in both `args` lists for your
+  plugin's live-action tool name.

--- a/examples/recipes/openclaw_social_actions/sponsio.yaml
+++ b/examples/recipes/openclaw_social_actions/sponsio.yaml
@@ -1,0 +1,72 @@
+# =============================================================================
+# Recipe: OpenClaw social-account actions (TweetClaw)
+#
+# A small, fully *deterministic* example for OpenClaw plugins that act through
+# a real, public social account. The shape is the common one for live
+# account-scoped tools:
+#
+#   * discovery / planning stays open  — the agent can freely review which
+#     endpoints exist and draft a post (read-only, no side effects);
+#   * the *live* action is gated       — an account-scoped post requires an
+#     explicit human re-confirmation, and is capped per session.
+#
+# `tweetclaw` is used as the concrete plugin path, but the same two contracts
+# apply to any "live, account-scoped side effect behind a planning step".
+#
+# This recipe is intentionally det-only (pure-Python checks, no LLM judge) so
+# default OSS users can validate and adapt it before opting into the broader
+# `sponsio:incident/openclaw` pack. To layer this on top of that pack, add:
+#
+#   include:
+#     - sponsio:incident/openclaw
+#
+# under the agent and keep the contracts below.
+#
+# Validate:
+#   sponsio validate --config examples/recipes/openclaw_social_actions/sponsio.yaml
+# =============================================================================
+
+version: "1"
+
+# `confirm_reconfirmed` is a marker tool: it executes nothing. The integration
+# emits a `confirm_reconfirmed` event when a human operator approves the next
+# live action, so contracts can require it. (Same marker the OpenClaw incident
+# pack uses.)
+tools:
+  - name: explore
+    description: "Read-only discovery: list/review available social endpoints and plan a post. No side effects."
+    params: "query: str"
+  - name: draft_tweet
+    description: "Compose a tweet draft locally. No live API call."
+    params: "text: str"
+  - name: tweetclaw
+    description: "TweetClaw plugin: live, account-scoped post to the connected social account."
+    params: "text: str"
+  - name: confirm_reconfirmed
+    description: "Marker: a human operator confirmed the next live action."
+
+agents:
+  social_bot:
+    contracts:
+      # 1) Discovery stays open.
+      #    `explore` (and `draft_tweet`) carry NO contract, so the default
+      #    allow policy lets the agent review endpoints and plan freely. Only
+      #    the live action below is constrained. This is the point of the
+      #    recipe: gate the side effect, not the planning that precedes it.
+
+      # 2) A live TweetClaw post requires explicit operator re-confirmation.
+      #    `must_precede(confirm_reconfirmed, tweetclaw)`: `tweetclaw` is
+      #    forbidden until a `confirm_reconfirmed` event has been observed.
+      - desc: "Live TweetClaw post requires operator re-confirmation first"
+        G:
+          pattern: must_precede
+          args: [confirm_reconfirmed, tweetclaw]
+          source: "recipe:openclaw-social-actions.confirm_before_post"
+
+      # 3) Cap live TweetClaw calls per session.
+      #    `rate_limit(tweetclaw, 3)`: at most 3 live posts in one session.
+      - desc: "At most 3 live TweetClaw posts per session"
+        G:
+          pattern: rate_limit
+          args: [tweetclaw, 3]
+          source: "recipe:openclaw-social-actions.rate_limit"

--- a/tests/test_openclaw_social_recipe.py
+++ b/tests/test_openclaw_social_recipe.py
@@ -1,0 +1,123 @@
+"""Validates the OpenClaw social-account actions example recipe.
+
+Recipe: ``examples/recipes/openclaw_social_actions/sponsio.yaml`` — a small
+deterministic config that keeps ``explore`` open while gating the live
+``tweetclaw`` action behind operator re-confirmation and a per-session cap.
+
+These tests pin both halves of the issue: the config loads cleanly, and the two
+declared contracts actually enforce what the recipe claims (replayed over
+synthetic traces).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sponsio.config import load_config
+from sponsio.discovery.trace_replay import replay_formula
+from sponsio.models.trace import Event, Trace
+from sponsio.patterns.library import must_precede, rate_limit
+
+RECIPE = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "recipes"
+    / "openclaw_social_actions"
+    / "sponsio.yaml"
+)
+
+
+def _trace(*tools: str) -> Trace:
+    return Trace(
+        events=[
+            Event(ts=i, agent="social_bot", event_type="tool_call", tool=t)
+            for i, t in enumerate(tools)
+        ]
+    )
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    return load_config(RECIPE)
+
+
+def test_recipe_loads_and_declares_expected_surface(cfg):
+    """Config loader accepts the recipe with the expected tools + agent."""
+    assert set(t.name for t in cfg.tools) == {
+        "explore",
+        "draft_tweet",
+        "tweetclaw",
+        "confirm_reconfirmed",
+    }
+    assert list(cfg.agents) == ["social_bot"]
+
+
+def test_recipe_contracts_are_the_two_deterministic_patterns(cfg):
+    """The agent declares exactly the confirm-gate and the rate cap."""
+    guarantees = [c.guarantee for c in cfg.agents["social_bot"].contracts]
+    declared = {(g.pattern, tuple(g.args)) for g in guarantees}
+    assert declared == {
+        ("must_precede", ("confirm_reconfirmed", "tweetclaw")),
+        ("rate_limit", ("tweetclaw", 3)),
+    }
+
+
+def test_explore_and_draft_are_ungated(cfg):
+    """Discovery/drafting must carry no contract — only the live action is gated."""
+    referenced = {
+        arg
+        for c in cfg.agents["social_bot"].contracts
+        for arg in c.guarantee.args
+        if isinstance(arg, str)
+    }
+    assert "explore" not in referenced
+    assert "draft_tweet" not in referenced
+
+
+def test_confirm_gate_blocks_unconfirmed_post(cfg):
+    """`must_precede(confirm_reconfirmed, tweetclaw)` enforces the gate."""
+    entry = next(
+        c.guarantee
+        for c in cfg.agents["social_bot"].contracts
+        if c.guarantee.pattern == "must_precede"
+    )
+    formula = must_precede(*entry.args)
+
+    # A live post with no prior confirmation fails the contract.
+    assert (
+        replay_formula(
+            formula, [_trace("explore", "draft_tweet", "tweetclaw")]
+        ).fail_count
+        == 1
+    )
+    # A confirmed post passes; planning beforehand is fine.
+    assert (
+        replay_formula(
+            formula, [_trace("explore", "confirm_reconfirmed", "tweetclaw")]
+        ).pass_count
+        == 1
+    )
+    # Never posting is vacuously fine.
+    assert replay_formula(formula, [_trace("explore", "draft_tweet")]).pass_count == 1
+
+
+def test_rate_limit_caps_live_posts(cfg):
+    """`rate_limit(tweetclaw, 3)` caps live posts per session."""
+    entry = next(
+        c.guarantee
+        for c in cfg.agents["social_bot"].contracts
+        if c.guarantee.pattern == "rate_limit"
+    )
+    formula = rate_limit(*entry.args)
+
+    confirmed = ["confirm_reconfirmed"]
+    assert (
+        replay_formula(formula, [_trace(*(confirmed + ["tweetclaw"] * 3))]).pass_count
+        == 1
+    )
+    assert (
+        replay_formula(formula, [_trace(*(confirmed + ["tweetclaw"] * 4))]).fail_count
+        == 1
+    )


### PR DESCRIPTION
## Summary

Closes #76. Adds a small, **deterministic** example recipe for OpenClaw plugins that act through a real, public social account, using **TweetClaw** as the concrete plugin path.

The recipe keeps discovery/planning open while gating the live action:

- `explore` / `draft_tweet` carry no contract (default allow) — endpoint review and drafting stay friction-free
- **`must_precede(confirm_reconfirmed, tweetclaw)`** — a live post is forbidden until a human operator re-confirmation event is observed
- **`rate_limit(tweetclaw, 3)`** — caps live posts per session

Both guarantees are pure-Python deterministic checks (no LLM judge in the hot path), so default OSS users can validate and adapt them before opting into the broader, mixed det/sto `sponsio:incident/openclaw` pack.

## Maps to the issue

| Issue ask | How |
| --- | --- |
| keep `explore` available for endpoint review/planning | ungated — no contract |
| require `confirm_reconfirmed` before `tweetclaw` executes | `must_precede(confirm_reconfirmed, tweetclaw)` |
| cap live TweetClaw calls per session | `rate_limit(tweetclaw, 3)` |
| validate with Sponsio's config loader and CLI | `load_config(...)` + `sponsio validate --config ...` (both green) |

## Files

- `examples/recipes/openclaw_social_actions/sponsio.yaml` — the recipe
- `examples/recipes/openclaw_social_actions/README.md` — what it does, how to validate, and how to adapt (layer on the incident pack; require a fresh confirmation per post via the count-dominance LTL form)
- `tests/test_openclaw_social_recipe.py` — loads the recipe and replays synthetic traces

## Validation

```
$ sponsio validate --config examples/recipes/openclaw_social_actions/sponsio.yaml
Agent: social_bot
  Guarantees:
    ✓ DET: must_precede(confirm_reconfirmed, tweetclaw)
    ✓ DET: rate_limit(tweetclaw, 3)
  ✓ All 2 contract(s) validated   # exit 0
```

## Test plan

- `pytest tests/test_openclaw_social_recipe.py` — 5 passed (loads config; gate blocks an unconfirmed post; cap fires on the 4th post; `explore`/`draft_tweet` confirmed ungated)
- Full suite: `2301 passed, 26 skipped`
- `ruff check` / `ruff format --check` clean

Deterministic-only; no behavior change to existing code; no new dependencies. TS parity not applicable (example recipe, not a core pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)