### PR TITLE
chore(deps): bump brace-expansion 5.0.6 to 5.0.7 to fix dependabot alert

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -531,10 +531,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },


### PR DESCRIPTION
Fixes the open dependabot alert (#15) on brace-expansion < 5.0.7:
  GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 high severity: DoS via
    exponential-time O(2^n) expansion of consecutive non-expanding {}
    groups; a ~90-byte input blocks the event loop for minutes
    (range >= 3.0.0, < 5.0.7; affects 5.0.6)

Resolution:
  ts/package.json: no change (brace-expansion is transitive via
    ts-morph -> @ts-morph/common -> minimatch, whose ^5.0.5 range
    already admits the patched version).
  ts/package-lock.json: updated to resolve brace-expansion 5.0.7 via
    npm update. Python side unaffected (npm-only package).

Verification:
  npm run build (sdk): passes
  npm test (sdk): 28 / 28 tests passing
  npm audit: 0 vulnerabilities

<!--
Thanks for the patch. A short, well-scoped PR is easier and faster
to review than a long one. If this change is large, consider splitting
it — one concern per PR.

See CONTRIBUTING.md for the full guide.
-->

## Summary

<!-- What changed, in 1–3 sentences. Focus on *why*, not *what*. -->

## Type of change

<!-- Keep the one(s) that apply, delete the rest. -->

- feat: new user-visible capability
- fix: bug fix
- refactor: no behavior change
- perf: performance improvement
- docs: documentation only
- test: adds or reworks tests only
- ci: CI / tooling only
- chore: repo hygiene

## Linked issues

<!-- e.g. Closes #123, Refs #456 -->

## Design notes

<!--
Optional. Call out anything a reviewer should know:
- Invariants touched or preserved
- Trade-offs considered and the path not taken
- Anything explicitly out of scope for this PR
-->

## Test plan

<!--
How did you verify this? Paste the commands you ran.
Example:
    pytest tests/test_shadow_mode.py -v
    pytest -k "not slow" -v
    python -m sponsio.cli check --config sponsio.yaml
-->

## Checklist

- [ ] Tests added or updated (or N/A — docs/CI only).
- [ ] `pytest -v` passes locally.
- [ ] `ruff check sponsio/ tests/ examples/ scripts/` is clean.
- [ ] `ruff format --check sponsio/ tests/ examples/ scripts/` is clean.
- [ ] `README.md` updated if a user-visible surface changed (new
      pattern, integration, CLI command, or public API).
- [ ] `CHANGELOG.md` `[Unreleased]` section updated if this is a
      user-visible change.
- [ ] No new external dependency added to `sponsio/` core (framework
      deps go in `[project.optional-dependencies]`).
- [ ] For new patterns: both `patterns/library.py` and
      `generation/dsl_to_contract.py` updated.
- [ ] For new integrations: inherits `BaseGuard`; no duplicated
      pre/post-check logic.
