### PR TITLE
fix(ts): align ordered comparison type semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ broke.
 
 ### Fixed
 
+- **TypeScript ordered comparisons now match Python on mixed operand types.**
+  `Le`, `Lt`, `Ge`, and `Gt` no longer use JavaScript coercion for
+  incompatible values such as a string tool argument and numeric constant;
+  comparisons that Python rejects now evaluate to `false` in both runtimes.
 - **`@sponsio/sdk` is now edge-runtime safe.** Marked the package
   `sideEffects` (narrowed to the CLI entry) so bundlers can tree-shake
   the Node-only YAML/config-loading path out of edge bundles (Cloudflare

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,6 +1,7 @@
 """Unit tests for sponsio/formulas/evaluator.py — finite-trace evaluation."""
 
 import pytest
+from sponsio.formulas._pred_key import pred_key
 from sponsio.formulas.evaluator import evaluate
 from sponsio.formulas.formula import (
     Atom,
@@ -19,6 +20,7 @@ from sponsio.formulas.formula import (
     Eq,
     Var,
     Const,
+    ArgValue,
 )
 
 
@@ -257,6 +259,19 @@ def test_var_missing_defaults_zero():
     # Missing var defaults to 0
     trace = [{}]
     assert evaluate(Le(Var("count", "x"), Const(0)), trace) is True
+
+
+@pytest.mark.parametrize("comparison", [Le, Lt, Ge, Gt])
+def test_ordered_comparison_mismatched_types_false(comparison):
+    value = ArgValue("pay", "amount")
+    trace = [{pred_key("arg_value", "pay", "amount"): "2"}]
+    assert evaluate(comparison(value, Const(10)), trace) is False
+
+
+def test_ordered_comparison_bool_and_number_uses_numeric_semantics():
+    value = ArgValue("pay", "amount")
+    trace = [{pred_key("arg_value", "pay", "amount"): True}]
+    assert evaluate(Lt(value, Const(2)), trace) is True
 
 
 # ---------------------------------------------------------------------------

--- a/ts/packages/sdk/src/__tests__/parity.test.ts
+++ b/ts/packages/sdk/src/__tests__/parity.test.ts
@@ -13,10 +13,13 @@
 import {
   Sponsio,
   evaluate,
-  Atom, G, Implies, X, F, And,
+  Atom, G, Implies, X, F, And, Not,
   type Valuation,
 } from "../index.js";
-import { Eq, ArgValue, CtxValue, Const, predKey } from "../core/formula.js";
+import {
+  Eq, Le, Lt, Ge, Gt,
+  ArgValue, CtxValue, Const, predKey,
+} from "../core/formula.js";
 import {
   deadline,
   requiredStepsCompletion,
@@ -399,6 +402,55 @@ function testEqValueEquality() {
   );
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Ordered-comparison parity for mixed operand types
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Python raises TypeError for ordered string/number comparisons, which
+// _safe_compare maps to False. JavaScript instead coerces the string unless
+// safeCompare rejects the incompatible pair first.
+function testOrderedComparisonTypeParity() {
+  console.log("\n[ordered-comparison type parity]");
+
+  const key = predKey("arg_value", "pay", "amount");
+  const amount = new ArgValue("pay", "amount");
+  const stringTrace = [{ [key]: "2" }] as unknown as Valuation[];
+
+  for (const [name, formula] of [
+    ["Le", new Le(amount, new Const(10))],
+    ["Lt", new Lt(amount, new Const(10))],
+    ["Ge", new Ge(amount, new Const(10))],
+    ["Gt", new Gt(amount, new Const(10))],
+  ] as const) {
+    assert(
+      evaluate(formula, stringTrace) === false,
+      `${name} over string/number operands is False`,
+    );
+  }
+
+  assert(
+    evaluate(
+      new Lt(amount, new Const(10)),
+      [{ [key]: 2 }] as unknown as Valuation[],
+    ) === true,
+    "Lt over numeric operands still works",
+  );
+  assert(
+    evaluate(
+      new Lt(amount, new Const(2)),
+      [{ [key]: true }] as unknown as Valuation[],
+    ) === true,
+    "boolean/number ordering retains Python numeric semantics",
+  );
+  assert(
+    evaluate(
+      new Not(new Gt(amount, new Const(1000))),
+      [{ [key]: "5000" }] as unknown as Valuation[],
+    ) === true,
+    "Not(Gt) over string/number operands matches Python",
+  );
+}
+
 console.log("=== TS↔Python Parity Regression Tests ===\n");
 testBoundedEventuallyDeadline();
 testRequiredStepsCompletion();
@@ -406,6 +458,7 @@ testGuardBeforeRollback();
 testDeadlineNlParity();
 testDegeneratePatternRejection();
 testEqValueEquality();
+testOrderedComparisonTypeParity();
 
 console.log(`\n${"=".repeat(40)}`);
 console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/ts/packages/sdk/src/core/evaluator.ts
+++ b/ts/packages/sdk/src/core/evaluator.ts
@@ -128,6 +128,12 @@ function valuesEqual(a: unknown, b: unknown): boolean {
 function safeCompare(op: string, left: unknown, right: unknown): boolean {
   if (left === undefined || left === null) return false;
   if (right === undefined || right === null) return false;
+  const leftType = typeof left;
+  const rightType = typeof right;
+  const numericPair =
+    (leftType === "number" || leftType === "boolean") &&
+    (rightType === "number" || rightType === "boolean");
+  if (op !== "eq" && leftType !== rightType && !numericPair) return false;
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const l = left as any;


### PR DESCRIPTION
## Summary

- make TypeScript ordered comparisons reject incompatible mixed operand types, matching Python's reference semantics
- preserve Python-compatible boolean/number ordering
- add matching Python and TypeScript regression coverage for `Le`, `Lt`, `Ge`, and `Gt`
- document the fix under `[Unreleased]`

## Why

JavaScript relational operators coerce values such as `"2"` and `10`, while
Python raises `TypeError` and Sponsio's `_safe_compare` maps that case to
`False`. This could give the same `(formula, trace)` pair opposite verdicts
across the two SDKs.

This patch follows `docs/reference/ts-sdk-parity.md`, which identifies Python
as the reference implementation. The compatibility check is intentionally
narrow and leaves `Eq`'s structural comparison unchanged. I would be happy to
adjust the type contract if the maintainers prefer the numeric-only direction
discussed in the issue.

Closes #108.

## Validation

- `python -m pytest tests/test_evaluator.py -q` — 44 passed
- `ruff check sponsio/ tests/ scripts/`
- `ruff format --check sponsio/ tests/ scripts/`
- `npm run test:parity` — 40 parity assertions and 14 shared scenarios passed
- `npm run build`
