### PR TITLE
chore(deps-dev): bump ruff to 0.16.0 + apply its formatting (supersedes #116)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ all = [
 ]
 # Pinned for the lint job. Ruff's `format` rules change between minor
 # versions, so a floating install drifts between local and CI.
-dev = ["ruff==0.15.22"]
+dev = ["ruff==0.16.0"]
 
 [tool.setuptools.packages.find]
 include = ["sponsio*"]

--- a/sponsio/skills/sponsio/SKILL.md
+++ b/sponsio/skills/sponsio/SKILL.md
@@ -843,6 +843,7 @@ All frameworks share the same `sponsio.yaml`; only the wiring at the agent entry
 **LangGraph** (Python):
 ```python
 from sponsio.langgraph import Sponsio
+
 guard = Sponsio(agent_id="support_bot", config="sponsio.yaml")
 graph = guard.wrap_graph(graph)
 ```
@@ -850,6 +851,7 @@ graph = guard.wrap_graph(graph)
 **OpenAI Agents SDK** (Python):
 ```python
 from sponsio.openai_agents import Sponsio
+
 guard = Sponsio(agent_id="support_bot", config="sponsio.yaml")
 agent = Agent(tools=guard.wrap(tools))
 ```
@@ -859,9 +861,10 @@ agent = Agent(tools=guard.wrap(tools))
 **No framework** (bare LLM calls):
 ```python
 from sponsio import Sponsio
+
 guard = Sponsio(agent_id="support_bot", config="sponsio.yaml")
-guard.guard_before(tool_name="...", tool_args={...})   # before the call
-guard.guard_after(output="...")                         # after
+guard.guard_before(tool_name="...", tool_args={...})  # before the call
+guard.guard_after(output="...")  # after
 ```
 
 **TypeScript** (`@sponsio/core`):


### PR DESCRIPTION
Supersedes #116.

`#116` bumped ruff 0.15.22 → 0.16.0 but its CI `Lint` job failed: ruff 0.16 now runs `ruff format` on Python code blocks embedded in **markdown**, so `sponsio/skills/sponsio/SKILL.md` was no longer format-clean. This PR does the bump **and** applies that single formatting change (blank lines after imports, normalized comment spacing in the embedded snippets).

- `ruff check sponsio/ tests/ scripts/` → no new lint violations at 0.16.
- `ruff format --check` → clean.

Once this merges, close #116 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)