### PR TITLE
Evidence output lane, enforcement fixes, and cloud-ref agent binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ LAUNCH_PLAN.md
 docs/demo-video-script.md
 # Full benchmark write-ups / model-by-model tables — private; do not force-add
 docs/benchmark-results.md
+# Integration-internals audit for the evidence work — names unfixed
+# fail-open paths per integration; keep private
+docs/evidence_integration_audit.md
 examples/scan_test_agent_run_debug.py
 sponsio-code-review.md
 

--- a/docs/overnight_report.md
+++ b/docs/overnight_report.md
@@ -1,0 +1,97 @@
+# Overnight Report — fix/enforcement-and-evidence-mw
+
+Branch: `fix/enforcement-and-evidence-mw` (off `main`). No push, no merge.
+Baseline before any change: **2399 passed, 26 skipped**.
+
+---
+
+## Phase 1 — canonical stopping set + stop_original gating
+
+Status: **complete, suite green (2407 passed, 26 skipped; +8 new tests).**
+Commit: `fix(enforcement): canonical stopping set + stop_original gating`.
+
+### What changed
+
+* `integrations/base.py`: added the canonical predicate next to
+  `CheckResult` — `STOPPING_ACTIONS = frozenset({"blocked", "redirected"})`
+  and `is_stopping_action(action)`. `CheckResult.stop_original` now
+  derives from it. This is the ONE definition; mcp and bridge consume it.
+* Fixed every fail-open gating site (full list below).
+* `bridge/spans.py` re-exports the canonical set (counting change: see 1b).
+
+### DECISION THE INSTRUCTIONS DID NOT COVER (deliberate deviation)
+
+The instructions said: *"mcp must stop on escalated (behavior change,
+matching base)"*. **I did not make mcp stop on escalated**, because the
+premise "matching base" is contradicted by the code:
+
+* `CheckResult.stop_original` (base.py) documents *"``escalated`` is
+  intentionally excluded"*, and `guard_before`'s long comment explains
+  why: the monitor uses `EscalateToHuman()` as the **default strategy for
+  unfired-assumption verdicts**, so `escalated` results are routinely
+  vacuous (`monitor.py::_handle_assumption_failure`, strategy default at
+  monitor.py:721). Base enforcement never stops on escalated.
+* Making the MCP proxy stop on escalated would refuse **every** tool call
+  while any conditional contract's assumption is simply not yet satisfied
+  — a fleet-wide false-block regression through the proxy.
+
+So the canonical set is `{blocked, redirected}` — which is also exactly
+what mcp already stopped on, meaning mcp's behavior is unchanged and now
+single-sourced. If you want escalated to stop calls, the right fix is
+upstream (stop using EscalateToHuman as the vacuous-assumption default),
+not in the stopping set. Flagging for your morning review.
+
+Related observation: the semantics table in `runtime/strategies.py`
+(EnforcementResult docstring) claims `escalated → tool runs? no`, which
+disagrees with actual base enforcement. Not touched (docs-only conflict,
+out of scope tonight), but it is the third place this ambiguity lives.
+
+### 1a. Call-site inventory (every CheckResult gating site + disposition)
+
+| Site | Before | Disposition |
+|---|---|---|
+| openai.py `check_response` (~:257) | `check.blocked and self.on_violation` | **Fixed** → `stop_original` (callback fires on redirect refusals too) |
+| openai.py `_filter_blocked_calls` (~:401) | `results[tc_idx].blocked` | **Fixed** → `stop_original` (redirected tool_calls stripped too) |
+| openai.py `patched_create` / `patched_async_create` (~:505/:516) | `any(r.blocked …)` | **Fixed** → `any(r.stop_original …)` |
+| google_adk.py sync `guarded_sync` (~:112) | `check.blocked` | **Fixed** → `stop_original` (now matches async twin) |
+| google_adk.py async `guarded_async` (~:97) | `stop_original` | Already compliant — unchanged |
+| langgraph.py `_guard_check` (~:178, currently uncalled) | `check.blocked` | **Fixed** → `stop_original` + comment |
+| langgraph.py `guarded_func` / `guarded_coro` (~:243/:265) | redirect-substitution branch, then `check.blocked` | **Fixed** final gate → `stop_original` (substitution branch kept first; also fail-closes a redirect verdict with no usable target) |
+| langgraph.py `_invoke_safe_tool` (~:355) | `check.blocked`, then explicit chained-redirect raise | **Justified as-is** (both stopping actions covered explicitly); comment added |
+| langgraph.py callback `on_tool_start` (~:422) | `result.blocked and self._block` | **Fixed** → `stop_original` |
+| langgraph.py `_MonitoredGraph._check_node` (~:730) | `not result.blocked` | **Fixed** → `not result.stop_original` (note: callers still discard the bool — pre-existing, out of scope tonight) |
+| crewai.py :108/:193 | `stop_original` | Already compliant — unchanged |
+| vercel_ai.py :125 | `stop_original` | Already compliant — unchanged |
+| claude_agent.py :119 | `stop_original` | Already compliant — unchanged |
+| agents.py :137/:162 | `stop_original` | Already compliant — unchanged |
+| base.py `guard_before` rollback (~:1314) | `blocked or (mode != observe and redirected)` | **Justified as-is** + comment: observe-mode redirects must keep their trace event (shadow-mode semantics), so `stop_original` would be wrong here |
+| guard_stdin.py verdict gate (~:672) | `if result.allowed:` | **Fixed** → `if not result.stop_original:` (redirect now denies); deny-reason collector widened from `action == "blocked"` to `is_stopping_action` |
+| demos/replay.py :166 | `result.blocked` | **Fixed** → `stop_original` (display-only replay, aligned for consistency) |
+| mcp.py `call_tool` (~:149) | inline `("blocked", "redirected")` | **Fixed** → consumes `is_stopping_action` (same membership, now single-sourced; escalated still non-stopping — see decision above) |
+| bridge/spans.py `STOPPING_ACTIONS` | local `("blocked","escalated","redirected")` | **Fixed** → re-export of canonical set |
+| Non-CheckResult `.blocked` readers (reporting/, render/, eval_runner, otel, models/spans, monitor span attr) | — | Not gating sites (report counters / span attrs on other types); untouched |
+
+### 1b. Stopping-set consumers
+
+One definition in base.py; mcp gates through `is_stopping_action`;
+bridge re-exports `STOPPING_ACTIONS`. **Bridge counting change:** steps
+with an `escalated` enforcement action are no longer counted in
+`detBlocks` / step `blocked` booleans — previously telemetry showed
+"stopped" for calls that actually ran.
+
+### Tests added (tests/test_stopping_set.py, 8)
+
+Canonical membership; `stop_original` ≡ canonical for all 7 verdict
+values; bridge consumes the same frozenset object; mcp agrees for all 7
+values (proxy-level, mocked monitor); redirected-stops regressions for
+openai (tool_call stripped + callback fires), google_adk sync (original
+never executes), langgraph `_guard_check` (raises `ToolCallBlocked`),
+guard_stdin (deny with redirect reason).
+
+Ruff note: ruff auto-deleted the mid-file canonical import in spans.py as
+unused (it is a re-export for session.py); reinstated at the top with
+`# noqa: F401` and a comment.
+
+---
+
+*(Phase 2 section appended when reached.)*

--- a/docs/overnight_report.md
+++ b/docs/overnight_report.md
@@ -94,4 +94,107 @@ unused (it is a re-export for session.py); reinstated at the top with
 
 ---
 
-*(Phase 2 section appended when reached.)*
+## Phase 2 — evidence middleware at observe_llm_call + openai enforcement
+
+Status: **complete, suite green (2437 passed, 26 skipped; +30 new tests).**
+Commit: `feat(evidence): middleware at observe_llm_call + openai enforcement`.
+
+### What changed
+
+* New `sponsio/integrations/evidence_middleware.py`: config dataclasses
+  (`EvidenceConfig.from_value` validates at guard construction),
+  structured-output extraction (JSON message content + decoded tool_call
+  args, no free-text regex), `run_evidence` (one `verify_batch` per
+  response; verdicts fed into the trace as `evidence` events **through
+  `RuntimeMonitor.check_action`** — the guard's normal, locked event
+  path, which also means `claim_requires_evidence`-style contracts
+  evaluate on the same step), and the block/clarify notice templates
+  (module-level, single place).
+* `integrations/base.py` (additions only): `evidence=` kwarg on
+  `BaseGuard.__init__` (parsed eagerly; malformed config fails at
+  construction); `CheckResult` gains `evidence_claims`,
+  `evidence_error`, `evidence_stopped` + an `evidence_clarifications`
+  property; `observe_llm_call` gains `tool_call_args`/`session_id`
+  params and the evidence fold: a blocking verdict (or EvidenceError
+  under `on_error: block`) synthesizes a canonical `blocked` det
+  violation so the Phase-1 `stop_original` predicate agrees; clarify
+  verdicts are carried, never stop. Verdict lines render via the stored
+  `TerminalReporter.report_evidence` (middleware itself never prints).
+* `integrations/openai.py`: `check_response` decodes tool args before
+  the observation, passes them to `observe_llm_call`, and keeps the
+  per-choice results on `guard.last_llm_checks`;
+  `_apply_evidence_notices` reuses the in-place content-rewrite
+  mechanism; `patched_create`/`patched_async_create` apply it after the
+  tool-call filter; `stream=True` with an evidence config raises
+  `NotImplementedError` at call time; `patch_openai(evidence=…)`
+  passes the config through.
+
+### Decisions the instructions did not cover
+
+1. **Missing input field**: a claim whose `claim_field` is present but
+   whose configured input field is absent is sent WITHOUT that input —
+   the server's resolver answers UNAVAILABLE and the verdict lattice
+   fails closed. (Alternatives — dropping the claim or inventing a
+   value — both hide the problem.)
+2. **Source precedence**: when the same field appears in JSON message
+   content and in tool_call args, content wins; tool calls follow in
+   call order. Pinned by a test.
+3. **Multi-choice responses (`n>1`)**: each choice is observed and can
+   be rewritten independently (`last_llm_checks` is per-choice).
+4. **Both tool-block and evidence-block firing**: the tool_call filter
+   runs first, then the evidence rewrite applies on the filtered
+   response — both notices survive.
+5. **Det `<llm_response>` violations (e.g. `no_keywords`) still do NOT
+   rewrite text** — only evidence verdicts drive the new rewrite
+   (`evidence_stopped`, not `stop_original`, gates it). Making
+   pre-existing response contracts suddenly enforce would be a behavior
+   change outside this brief. Open question flagged for you.
+6. `EvidenceError` under `on_error: allow` still records the error on
+   `CheckResult.evidence_error` so callers can log it.
+
+### Tests added (tests/test_evidence_middleware.py, 30)
+
+Config parsing + defaults + five rejection shapes (incl. failure at
+guard construction); extraction from JSON content, from tool_call args,
+absent-field = no claim, non-JSON = no claim, content-over-args
+precedence, missing-input behavior; verify_batch exactly once per
+response (2 claims → 1 call); block → stopping CheckResult via the
+Phase-1 canonical predicate; PASS/clarify do not stop; on_error block vs
+allow; verdicts land in the trace as `evidence` events; unconfigured
+guard unchanged (no events, empty fields, and the untouched-response
+openai test asserts the same object comes back byte-identical);
+openai sync + async patched paths rewriting on block (real
+`patch_openai` against a mocked SDK `create`); clarify rewrite capped at
+5 candidates (+N more); error-block notice; streaming raises
+`NotImplementedError`; notice formatting edge cases.
+
+---
+
+## Wrap-up
+
+`examples/evidence_middleware_demo.py`: mocked OpenAI response claims
+zip 94103 for 2120 Oxford St, Berkeley; canned evidence backend answers
+MISMATCH/94704; the real middleware pipeline blocks and rewrites.
+Output (reporter line on stderr, rewrite on stdout):
+
+```
+  ✗ evidence "address_zip_agreement" → MISMATCH · correction "94704"
+--- assistant output (after evidence enforcement) ---
+[BLOCKED] claim 'zip_code'=94103 failed verification (address_zip_agreement: MISMATCH); evidence says: 94704
+```
+
+### Summary table
+
+| Phase | Commit | Tests before | Tests after |
+|---|---|---|---|
+| baseline | — | 2399 passed / 26 skipped | — |
+| 1 — canonical stopping set | `fix(enforcement): canonical stopping set + stop_original gating` | 2399 | 2407 passed / 26 skipped |
+| 2 — evidence middleware | `feat(evidence): middleware at observe_llm_call + openai enforcement` | 2407 | 2437 passed / 26 skipped |
+
+Branch `fix/enforcement-and-evidence-mw`, two commits, not merged, not
+pushed, `main` untouched, ~/Documents/Sponsio-cloud untouched, no real
+network in any test.
+
+**Read-first items for the morning:** the Phase-1 escalated/mcp
+deviation (top of Phase 1 section) and Phase-2 decision #5
+(det `<llm_response>` contracts still don't rewrite text).

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Offline evals for the OSS evidence thin client. Dev-only, not shipped."""

--- a/evals/extraction_coverage.py
+++ b/evals/extraction_coverage.py
@@ -1,0 +1,138 @@
+"""Extraction-coverage probe for the evidence middleware (client side).
+
+WHY THIS EXISTS
+---------------
+The verdict logic is provably correct on the claims it adjudicates
+(cloud-side tier-1 eval scores 100%). But none of that fires if a claim
+never enters the pipeline. The extractor only sees claims that arrive as
+(a) JSON-*object* message content, or (b) tool-call argument dicts;
+everything else is structurally invisible. Coverage — not comparator
+accuracy — is the real error surface of the deterministic tiers.
+
+WHAT THIS MEASURES (honestly)
+-----------------------------
+Not a population coverage %, which would need a labelled model-output
+corpus. Instead a SHAPE MATRIX: one logical claim
+(weekday=Friday, date=2000-01-01) expressed in ten output shapes a model
+actually produces, run through the REAL ``structured_sources`` +
+``extract_claims``. Each row is a deterministic fact about the extractor;
+the dropped rows are its quantified blind spots, each mapping to a
+concrete fix (lenient JSON / fence-stripping / nested lookup / free-text
+extractor / field aliases).
+
+Run:   python -m evals.extraction_coverage
+Guard: tests/test_extraction_coverage.py
+"""
+
+from __future__ import annotations
+
+from sponsio.integrations.evidence_middleware import (
+    EvidenceConfig,
+    extract_claims,
+    structured_sources,
+)
+
+# The claim we want surfaced, however the model chose to phrase the output.
+_CONFIG = EvidenceConfig.from_value(
+    {
+        "client": None,  # constructed, never called — extraction needs no network
+        "claims": [
+            {
+                "predicate": "date_weekday_agreement",
+                "claim_field": "weekday",
+                "inputs": {"date": {"field": "date", "source": "user_utterance"}},
+            }
+        ],
+    }
+)
+
+_JSON = '{"weekday": "Friday", "date": "2000-01-01"}'
+
+# (label, message content, tool_call_args, why-it-matters)
+_SHAPES = [
+    ("clean JSON object", _JSON, None, "the happy path"),
+    (
+        "JSON in ```json fence",
+        f"```json\n{_JSON}\n```",
+        None,
+        "models fence JSON constantly",
+    ),
+    (
+        "JSON with prose prefix",
+        f"Here is the result: {_JSON}",
+        None,
+        "chat models prepend prose",
+    ),
+    ("JSON array, not object", f"[{_JSON}]", None, "list wrapper -> not a dict"),
+    (
+        "nested under a key",
+        '{"result": {"weekday": "Friday", "date": "2000-01-01"}}',
+        None,
+        "claim one level deep",
+    ),
+    (
+        "tool_call args dict",
+        None,
+        [{"weekday": "Friday", "date": "2000-01-01"}],
+        "structured tool call",
+    ),
+    ("tool args as JSON string", None, [_JSON], "arg serialized, not a dict"),
+    ("prose only", "The weekday is Friday.", None, "free text — no structured field"),
+    (
+        "field-name variant",
+        '{"day_of_week": "Friday", "date": "2000-01-01"}',
+        None,
+        "model named the field differently",
+    ),
+    (
+        "field present but null",
+        '{"weekday": null, "date": "2000-01-01"}',
+        None,
+        "field emitted, value missing",
+    ),
+]
+
+
+def run_eval() -> dict:
+    rows = []
+    for label, content, tool_args, note in _SHAPES:
+        sources = structured_sources(content, tool_args)
+        claims = extract_claims(_CONFIG, sources)
+        surfaced = len(claims) > 0
+        value = claims[0].value if surfaced else None
+        rows.append(
+            {"shape": label, "surfaced": surfaced, "value": value, "note": note}
+        )
+    surfaced = sum(r["surfaced"] for r in rows)
+    return {
+        "total": len(rows),
+        "surfaced": surfaced,
+        "blind_spots": [r["shape"] for r in rows if not r["surfaced"]],
+        "rows": rows,
+    }
+
+
+def format_report(results: dict) -> str:
+    lines = ["=== Extraction coverage — output-shape matrix ==="]
+    s, t = results["surfaced"], results["total"]
+    lines.append(
+        f"one claim, {t} realistic output shapes: surfaced {s}, blind {t - s}\n"
+    )
+    for r in results["rows"]:
+        mark = "surfaced" if r["surfaced"] else "DROPPED "
+        val = f"  -> value={r['value']!r}" if r["surfaced"] else ""
+        lines.append(f"  [{mark}] {r['shape']:24} — {r['note']}{val}")
+    lines.append("\nblind spots (claim present in the output but not surfaced):")
+    for b in results["blind_spots"]:
+        lines.append(f"  · {b}")
+    lines.append(
+        "\nreading: surfaced rows are what today's extractor covers; every blind"
+        "\nspot is a way a real model can state the claim and have it go"
+        "\nUNVERIFIED. Fixes map 1:1 — lenient JSON / fence-strip / nested lookup"
+        "\n/ field aliases / a free-text extractor (the deferred text mode)."
+    )
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(format_report(run_eval()))

--- a/examples/evidence_demo.py
+++ b/examples/evidence_demo.py
@@ -1,0 +1,75 @@
+"""Cloud evidence verification, end to end from the OSS runtime.
+
+Sends two factual claims to the Sponsio Cloud evidence API and prints
+the verdicts through the standard terminal reporter:
+
+* ``date_weekday_agreement`` — claims 2000-01-01 was a Friday (it was a
+  Saturday, so the service answers MISMATCH with the correction);
+* ``city_zip_candidates`` — claims 94720 is THE zip of Berkeley, CA
+  (Berkeley has many zips, so the service answers UNDERDETERMINED with
+  the candidate set).
+
+Credentials come from the normal config path: ``SPONSIO_API_KEY`` /
+``SPONSIO_API_URL`` env vars, falling back to ``~/.sponsio/credentials``
+written by ``sponsio login``. This script is the cross-repo integration
+check for the thin client — run it against a local Sponsio-cloud stack:
+
+    SPONSIO_API_KEY=sk_sp_v1_... SPONSIO_API_URL=http://127.0.0.1:8899 \
+        python examples/evidence_demo.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sponsio.cloud.client import CloudClient, CloudError  # noqa: E402
+from sponsio.runtime.terminal import TerminalReporter  # noqa: E402
+
+
+def main() -> int:
+    client = CloudClient()
+    if not client.configured:
+        print(
+            "No API key. Set SPONSIO_API_KEY (and SPONSIO_API_URL for a "
+            "local stack) or run `sponsio login`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    reporter = TerminalReporter(verbosity=1)
+    claims = [
+        {
+            "predicate": "date_weekday_agreement",
+            "value": "Friday",
+            "inputs": {"date": ("2000-01-01", "user_utterance")},
+        },
+        {
+            "predicate": "city_zip_candidates",
+            "value": "94720",
+            "inputs": {
+                "city": ("Berkeley", "user_utterance"),
+                "state": ("CA", "user_utterance"),
+            },
+        },
+    ]
+
+    try:
+        for claim in claims:
+            result = client.evidence.verify(
+                claim["predicate"],
+                value=claim["value"],
+                inputs=claim["inputs"],
+            )
+            reporter.report_evidence(result)
+    except CloudError as exc:
+        # No verdict was produced — the fail-closed reading is "block".
+        print(f"evidence call failed (treat as block): {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/evidence_middleware_demo.py
+++ b/examples/evidence_middleware_demo.py
@@ -1,0 +1,105 @@
+"""Evidence middleware end to end, with a mocked OpenAI response.
+
+No network, no API key, no OpenAI account: the "model output" is a
+hand-built ChatCompletion-shaped object whose structured JSON claims the
+wrong ZIP for an address, and the evidence backend is a canned client
+returning the verdict the real service would produce. Everything between
+those two mocks is the real pipeline:
+
+    OpenAIGuard(evidence=...) -> check_response -> observe_llm_call
+      -> evidence middleware (extract -> verify_batch -> trace events)
+      -> stopping CheckResult -> in-place block-notice rewrite
+
+Run:
+    python examples/evidence_middleware_demo.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sponsio.cloud.evidence import EvidenceClient, EvidenceResult  # noqa: E402
+from sponsio.integrations.openai import OpenAIGuard  # noqa: E402
+
+
+class CannedEvidenceClient(EvidenceClient):
+    """Stands in for the cloud API; returns a fixed MISMATCH verdict."""
+
+    def __init__(self) -> None:  # no CloudClient — nothing does I/O
+        pass
+
+    def verify_batch(self, claims, *, session_id=None):
+        return [
+            EvidenceResult(
+                predicate="address_zip_agreement",
+                verdict="MISMATCH",
+                action="block",
+                values=("94704",),
+                source="geocode:census",
+                correction="94704",
+            )
+            for _ in claims
+        ]
+
+
+def mock_completion(content: str):
+    """The minimal ChatCompletion shape check_response consumes."""
+    message = SimpleNamespace(content=content, tool_calls=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message)],
+        usage=None,
+    )
+
+
+def main() -> int:
+    guard = OpenAIGuard(
+        contracts=[],
+        verbose=True,  # evidence verdict lines render via TerminalReporter
+        init_banner=False,
+        evidence={
+            "client": CannedEvidenceClient(),
+            "on_error": "block",
+            "claims": [
+                {
+                    "predicate": "address_zip_agreement",
+                    "claim_field": "zip_code",
+                    "inputs": {
+                        "street": {"field": "street", "source": "model_output"},
+                        "city": {"field": "city", "source": "model_output"},
+                        "state": {"field": "state", "source": "model_output"},
+                    },
+                }
+            ],
+        },
+    )
+
+    assistant_output = json.dumps(
+        {
+            "street": "2120 Oxford St",
+            "city": "Berkeley",
+            "state": "CA",
+            "zip_code": "94103",  # wrong: that's a San Francisco zip
+        }
+    )
+    response = mock_completion(assistant_output)
+
+    print("--- assistant output (before) ---")
+    print(assistant_output)
+
+    guard.check_response(response)
+    guard._apply_evidence_notices(response)
+
+    print("--- assistant output (after evidence enforcement) ---")
+    print(response.choices[0].message.content)
+
+    check = guard.last_llm_checks[0]
+    return 0 if check.evidence_stopped else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -81,6 +81,31 @@ def _say_of(response: Any) -> str:
     return joined or text
 
 
+def _own_book(stamp: str, agent: str) -> str | None:
+    """This agent's ``agent@vN`` out of a checkout stamp.
+
+    A whole-project pull is stamped "<project> a@v3 b@v1 ... sha:..."; a
+    single-agent pull "<project>@vN" with no agent prefix at all.
+    """
+    tokens = [t for t in stamp.split() if "@v" in t]
+    for token in tokens:
+        if token.startswith(f"{agent}@v"):
+            return token
+    if len(tokens) == 1:
+        version = _book_version(tokens[0])
+        if version is not None:
+            return f"{agent}@v{version}"
+    return None
+
+
+def _book_version(book: str | None) -> int | None:
+    if not book or "@v" not in book:
+        return None
+    tail = book.rsplit("@v", 1)[1]
+    digits = "".join(ch for ch in tail if ch.isdigit())
+    return int(digits) if digits else None
+
+
 def _claim_span(verified: Any) -> str:
     """What the model actually said for this claim, as display text."""
     value = getattr(verified, "value", None)
@@ -378,7 +403,18 @@ class BridgeSession:
         # would make a replay claim to reproduce something it cannot.
         stamp = os.environ.get("SPONSIO_RULEBOOK_STAMP", "").strip()
         if stamp:
-            vm["rulebook"] = stamp
+            # The checkout stamp names every agent in the project
+            # ("default a@v3 b@v1 ... sha:..."); a run is ONE agent's, so
+            # it records that agent's book — the form the console links
+            # to and the server keys tests by — and keeps the whole stamp
+            # for provenance. Without this the run named seventeen books
+            # and its version parsed as none.
+            own = _own_book(stamp, self.root_agent)
+            vm["rulebook"] = own or stamp
+            vm["rulebookRef"] = stamp
+            version = _book_version(own)
+            if version is not None:
+                vm["session"]["rulebookVersion"] = version
         return vm
 
     # -- transport ---------------------------------------------------------

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -228,7 +228,7 @@ class BridgeSession:
             if contract is not None:
                 contract["violationCount"] = contract.get("violationCount", 0) + 1
 
-        self.send()
+        self._send_soon()
         return step
 
     def note(self, agent: str, text: str, type: str = "message") -> dict:
@@ -248,7 +248,7 @@ class BridgeSession:
         }
         self.steps.append(step)
         self._ensure_agent(agent)
-        self.send()
+        self._send_soon()
         return step
 
     # Console action labels for the server's policy action. The server says
@@ -315,7 +315,7 @@ class BridgeSession:
         }
         self.steps.append(step)
         self._ensure_agent(agent_id)
-        self.send()
+        self._send_soon()
         return step
 
     def _edge(self, source: str, target: str, kind: str, label: str) -> None:
@@ -378,17 +378,59 @@ class BridgeSession:
 
     # -- transport ---------------------------------------------------------
 
+    # A frame carries the WHOLE run, so sending one per step makes a long
+    # agent upload O(steps^2) bytes: measured, 1k steps is 142 MB and 5k is
+    # 3.5 GB, and past ~27k the frame alone exceeds the 8 MB ingest cap and
+    # every later send 413s. Coalescing to at most one frame per interval
+    # keeps the console live to the eye and the traffic linear-ish; finish()
+    # always flushes, so the final state is never the stale one.
+    SEND_MIN_INTERVAL_S = 1.0
+
+    # Frames grow with the run, so a fixed interval still lets a very long
+    # agent climb: the rate, not the count, is what has to stay bounded.
+    # Backing off in proportion to the last frame holds outbound traffic
+    # near this ceiling no matter how big the session gets.
+    SEND_MAX_KB_PER_S = 250.0
+
+    def _send_interval(self) -> float:
+        last_kb = getattr(self, "_last_frame_bytes", 0) / 1024.0
+        return max(self.SEND_MIN_INTERVAL_S, last_kb / self.SEND_MAX_KB_PER_S)
+
+    def _send_soon(self) -> None:
+        """Mark the run changed; send if this frame is not too soon after the last."""
+        now = time.time()
+        if (now - getattr(self, "_last_send_at", 0.0)) < self._send_interval():
+            self._pending = True
+            return
+        self.send()
+
     def send(self) -> bool:
         """Best effort. Never raises, never blocks the agent."""
+        self._pending = False
+        self._last_send_at = time.time()
         if not getattr(self.client, "configured", False):
             return False
         payload = {"key": self.session_id, "live": self.live, "vm": self.view_model()}
+        try:
+            self._last_frame_bytes = len(json.dumps(payload))
+        except Exception:  # noqa: BLE001 - sizing is advisory only
+            self._last_frame_bytes = 0
         try:
             self.client.ingest_session(self.project, payload)
             return True
         except Exception as exc:  # noqa: BLE001 - telemetry must not break a run
             self.send_failures += 1
             self._last_error = str(exc)
+            # Losing telemetry must not change what the agent does, but it
+            # must not be invisible either: a run that silently stopped
+            # reaching the console still looks live and complete on screen.
+            if not getattr(self, "_warned_send", False):
+                self._warned_send = True
+                print(
+                    f"  sponsio: this run is no longer reaching the console "
+                    f"({exc}); the agent is unaffected.",
+                    flush=True,
+                )
             return False
 
     def finish(self) -> dict[str, Any]:

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -540,25 +540,26 @@ def attach(
         agents=agents,
         runs_dir=runs_dir,
     )
-    if not auto:
-        return session
+    if auto:
+        original = guard.guard_before
 
-    original = guard.guard_before
+        def wrapped(tool: str, args: Any = None, *rest: Any, **kwargs: Any):
+            result = original(tool, args, *rest, **kwargs)
+            try:
+                session.record(tool, args)
+            except Exception:  # noqa: BLE001 - recording must not break a run
+                session.send_failures += 1
+            return result
 
-    def wrapped(tool: str, args: Any = None, *rest: Any, **kwargs: Any):
-        result = original(tool, args, *rest, **kwargs)
-        try:
-            session.record(tool, args)
-        except Exception:  # noqa: BLE001 - recording must not break a run
-            session.send_failures += 1
-        return result
+        guard.guard_before = wrapped  # type: ignore[method-assign]
+        session._original_guard_before = original  # type: ignore[attr-defined]
 
-    guard.guard_before = wrapped  # type: ignore[method-assign]
-    session._original_guard_before = original  # type: ignore[attr-defined]
-
-    # The output lane rides the same switch. A model turn whose claims were
-    # verified becomes a step too, otherwise the verdict never leaves the
-    # process and the console shows a clean run for a false answer.
+    # The output lane does NOT ride the auto switch. `auto=False` says "I
+    # attribute my own tool steps per agent", which is a statement about the
+    # ACTION lane; it never meant "drop my claim verdicts". Returning early
+    # on it took the output lane with it, so every multi-agent run — the
+    # only reason to pass auto=False — showed a clean trace while the model
+    # was stating something false.
     observe = getattr(guard, "observe_llm_call", None)
     if callable(observe):
 

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -58,6 +58,36 @@ def _trace_id(agent: str) -> str:
     return hashlib.sha1(agent.encode()).hexdigest()[:32]
 
 
+def _say_of(response: Any) -> str:
+    """The sentence to show for a model turn.
+
+    Structured output is the normal case: prefer a headline/message-ish
+    field, else join its string values, so the console shows words rather
+    than a JSON blob. Falls back to the raw text.
+    """
+    text = response if isinstance(response, str) else ""
+    try:
+        parsed = json.loads(text) if text else response
+    except (ValueError, TypeError):
+        return text
+    if not isinstance(parsed, dict):
+        return text
+    for key in ("message", "headline", "reply", "text", "answer", "summary"):
+        value = parsed.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    joined = " · ".join(str(v) for v in parsed.values() if isinstance(v, str))
+    return joined or text
+
+
+def _claim_span(verified: Any) -> str:
+    """What the model actually said for this claim, as display text."""
+    value = getattr(verified, "value", None)
+    if value not in (None, ""):
+        return str(value)
+    return str(getattr(getattr(verified, "spec", None), "claim_field", "") or "claim")
+
+
 class BridgeSession:
     """One run being streamed to a console.
 
@@ -221,6 +251,73 @@ class BridgeSession:
         self.send()
         return step
 
+    # Console action labels for the server's policy action. The server says
+    # what it decided; the console says what the reader sees happen to the
+    # output. A block that carries a correction is a rewrite; one that does
+    # not is simply a block.
+    _EV_ACTIONS = {"release": "released", "clarify": "clarify"}
+
+    def record_output(self, response: Any, result: Any, *, agent: str | None = None) -> dict | None:
+        """Project one model turn and its claim verdicts into a step.
+
+        The action lane records tool calls; this is the output lane. Without
+        it an ``observe_llm_call`` verdict lives only in the local trace and
+        never reaches the console, so a run looks clean while the model is
+        stating something false. Returns None when the turn carried no
+        verified claims (nothing to show).
+        """
+        claims_in = list(getattr(result, "evidence_claims", None) or [])
+        if not claims_in:
+            return None
+
+        claims: list[dict] = []
+        for vc in claims_in:
+            res = getattr(vc, "result", None)
+            if res is None:
+                continue
+            verdict = str(getattr(res, "verdict", "") or "").upper()
+            correction = getattr(res, "correction", None)
+            values = list(getattr(res, "values", None) or [])
+            action = self._EV_ACTIONS.get(
+                str(getattr(res, "action", "") or "").lower(),
+                "rewritten" if correction not in (None, "") else "blocked",
+            )
+            claims.append(
+                {
+                    "span": _claim_span(vc),
+                    "predicate": str(getattr(getattr(vc, "spec", None), "predicate", "") or ""),
+                    "verdict": verdict,
+                    "source": str(getattr(res, "source", "") or ""),
+                    "freshness": "",
+                    "evidence": ("authoritative: " + ", ".join(str(v) for v in values)) if values else "",
+                    "action": action,
+                    "fix": "" if correction in (None, "") else str(correction),
+                }
+            )
+        if not claims:
+            return None
+
+        agent_id = agent or self.root_agent
+        idx = len(self.steps)
+        step = {
+            "id": f"s{idx}",
+            "ts": idx,
+            "agentId": agent_id,
+            "serviceName": agent_id,
+            "traceId": _trace_id(agent_id),
+            "spanId": f"{idx:016x}",
+            "type": "assistant_output",
+            "tool": "reply",
+            "durationMs": 1.0,
+            "status": "mismatch" if any(c["verdict"] == "MISMATCH" for c in claims) else "ok",
+            "say": _say_of(response),
+            "output": {"checked": len(claims), "claims": claims},
+        }
+        self.steps.append(step)
+        self._ensure_agent(agent_id)
+        self.send()
+        return step
+
     def _edge(self, source: str, target: str, kind: str, label: str) -> None:
         self._ensure_agent(source)
         self._ensure_agent(target, role="worker")
@@ -375,4 +472,24 @@ def attach(
 
     guard.guard_before = wrapped  # type: ignore[method-assign]
     session._original_guard_before = original  # type: ignore[attr-defined]
+
+    # The output lane rides the same switch. A model turn whose claims were
+    # verified becomes a step too, otherwise the verdict never leaves the
+    # process and the console shows a clean run for a false answer.
+    observe = getattr(guard, "observe_llm_call", None)
+    if callable(observe):
+
+        def wrapped_observe(*args: Any, **kwargs: Any):
+            result = observe(*args, **kwargs)
+            try:
+                response = kwargs.get("response")
+                if response is None and len(args) >= 2:
+                    response = args[1]
+                session.record_output(response, result)
+            except Exception:  # noqa: BLE001 - recording must not break a run
+                session.send_failures += 1
+            return result
+
+        guard.observe_llm_call = wrapped_observe  # type: ignore[method-assign]
+        session._original_observe_llm_call = observe  # type: ignore[attr-defined]
     return session

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import secrets
 import os
 import time
 from pathlib import Path
@@ -109,9 +110,13 @@ class BridgeSession:
     ) -> None:
         self.guard = guard
         self.project = project
-        self.session_id = session_id or (
-            "run-" + hashlib.sha1(f"{id(guard)}{time.time()}".encode()).hexdigest()[:8]
-        )
+        # The server keys a run by this id and upserts, so two runs sharing
+        # one id silently become one: the older is overwritten with no error.
+        # The old id was 32 bits derived from id(guard) and the clock, which
+        # collides around 65k runs by birthday alone — and worse in practice,
+        # since memory addresses get reused and a booting fleet shares the
+        # clock. 64 bits from the system CSPRNG puts a collision out of reach.
+        self.session_id = session_id or ("run-" + secrets.token_hex(8))
         self.mode = getattr(guard, "mode", None) or "observe"
         self.root_agent = getattr(guard, "agent_id", "agent")
         self.started_at = int(time.time() * 1000)

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -287,7 +287,9 @@ class BridgeSession:
     # not is simply a block.
     _EV_ACTIONS = {"release": "released", "clarify": "clarify"}
 
-    def record_output(self, response: Any, result: Any, *, agent: str | None = None) -> dict | None:
+    def record_output(
+        self, response: Any, result: Any, *, agent: str | None = None
+    ) -> dict | None:
         """Project one model turn and its claim verdicts into a step.
 
         The action lane records tool calls; this is the output lane. Without
@@ -315,11 +317,15 @@ class BridgeSession:
             claims.append(
                 {
                     "span": _claim_span(vc),
-                    "predicate": str(getattr(getattr(vc, "spec", None), "predicate", "") or ""),
+                    "predicate": str(
+                        getattr(getattr(vc, "spec", None), "predicate", "") or ""
+                    ),
                     "verdict": verdict,
                     "source": str(getattr(res, "source", "") or ""),
                     "freshness": "",
-                    "evidence": ("authoritative: " + ", ".join(str(v) for v in values)) if values else "",
+                    "evidence": ("authoritative: " + ", ".join(str(v) for v in values))
+                    if values
+                    else "",
                     "action": action,
                     "fix": "" if correction in (None, "") else str(correction),
                 }
@@ -339,7 +345,9 @@ class BridgeSession:
             "type": "assistant_output",
             "tool": "reply",
             "durationMs": 1.0,
-            "status": "mismatch" if any(c["verdict"] == "MISMATCH" for c in claims) else "ok",
+            "status": "mismatch"
+            if any(c["verdict"] == "MISMATCH" for c in claims)
+            else "ok",
             "say": _say_of(response),
             "output": {"checked": len(claims), "claims": claims},
         }

--- a/sponsio/bridge/spans.py
+++ b/sponsio/bridge/spans.py
@@ -11,13 +11,20 @@ import json
 import re
 from typing import Any
 
+# Actions that actually stopped the call — re-exported (for session.py's
+# step/summary counting) from the canonical definition next to CheckResult
+# so telemetry counts what enforcement actually does.
+# COUNTING CHANGE vs the previous local tuple: ``escalated`` is no longer
+# counted as stopped, because enforcement never stops on it (the monitor's
+# default EscalateToHuman verdict for unfired assumptions is vacuous; see
+# integrations/base.py STOPPING_ACTIONS). Dashboards that summed escalated
+# into detBlocks will show lower, truthful numbers.
+from sponsio.integrations.base import STOPPING_ACTIONS  # noqa: F401
+
 # Enforcement actions the console renders as a step status. Anything else
 # falls back to "blocked" rather than inventing a new status word the
 # frontend has no colour for.
 KNOWN_ACTIONS = ("blocked", "escalated", "redirected", "retrying", "warned", "observed")
-# Actions that actually stopped the call. `observed` is not one of them: in
-# shadow mode the contract fired and the call still ran.
-STOPPING_ACTIONS = ("blocked", "escalated", "redirected")
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 

--- a/sponsio/cloud/client.py
+++ b/sponsio/cloud/client.py
@@ -80,6 +80,11 @@ class PulledRulebook:
     versions: str | None = None
     sha: str | None = None
     agent: str | None = None
+    # "published" when the server handed out the published head, "draft"
+    # when the book has never been published and the latest version was
+    # used instead, "pinned" for an explicit @vN, "mixed" for a whole-
+    # project pull whose agents differ.
+    channel: str | None = None
 
 
 def read_api_key() -> str | None:
@@ -145,6 +150,14 @@ class CloudClient:
         from sponsio.cloud.evidence import EvidenceClient
 
         return EvidenceClient(self)
+
+    @property
+    def smt(self):
+        """SMT service calls (prove/translate/policy build) — see
+        :mod:`sponsio.cloud.smt`. Same lazy-import rule as evidence."""
+        from sponsio.cloud.smt import SmtCloudClient
+
+        return SmtCloudClient(self)
 
     # -- transport ---------------------------------------------------------
 
@@ -259,6 +272,7 @@ class CloudClient:
             or headers.get("x-rulebook-version"),
             sha=headers.get("x-rulebook-sha"),
             agent=headers.get("x-rulebook-agent"),
+            channel=headers.get("x-rulebook-channel"),
         )
 
     # -- sessions ----------------------------------------------------------

--- a/sponsio/cloud/client.py
+++ b/sponsio/cloud/client.py
@@ -135,6 +135,17 @@ class CloudClient:
         """No key means no cloud. Not an error — it is the default mode."""
         return bool(self.api_key)
 
+    @property
+    def evidence(self):
+        """Evidence verification calls — see :mod:`sponsio.cloud.evidence`.
+
+        Lazy import so the base client stays importable without pulling
+        the evidence module into code paths that never verify claims.
+        """
+        from sponsio.cloud.evidence import EvidenceClient
+
+        return EvidenceClient(self)
+
     # -- transport ---------------------------------------------------------
 
     def _request(

--- a/sponsio/cloud/evidence.py
+++ b/sponsio/cloud/evidence.py
@@ -1,0 +1,241 @@
+"""Thin client for the cloud evidence verification API.
+
+The runtime ships NO comparators, NO resolvers, NO predicate catalog and
+computes NO verdicts: this module sends a claim to the service's
+``/v1/evidence/verify`` endpoints and hands back the server's answer as
+an :class:`EvidenceResult`. All judgment is server-side — the seven-value
+verdict lattice (PASS / MISMATCH / UNDERDETERMINED / NO_EVIDENCE / STALE
+/ SOURCE_UNAVAILABLE / EXTRACTION_AMBIGUOUS) and the policy action
+(release / block / clarify / re_resolve) arrive already decided.
+
+Failure policy — explicit and conservative: a network problem, auth
+rejection, or malformed response raises :class:`EvidenceError` (a
+:class:`~sponsio.cloud.client.CloudError`). The client never fabricates
+a verdict for a check that did not run. Callers that want fail-closed
+behavior should treat the exception as a block::
+
+    try:
+        result = client.evidence.verify("order_status", value="shipped",
+                                        inputs={"order_id": (oid, "customer_db")})
+        release = result.passed
+    except CloudError:
+        release = False   # fail closed: unverified claims do not ship
+
+Inputs carry taint tags. The ergonomic form is a ``(value, source)``
+tuple per input — ``inputs={"city": ("Berkeley", "user_utterance")}`` —
+normalized here to the wire shape ``{"value": ..., "source": ...}``.
+The server rejects sources outside the predicate's allowlist.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Mapping
+
+from sponsio.cloud.client import CloudClient, CloudError
+
+if TYPE_CHECKING:
+    from sponsio.models.trace import Event
+
+
+class EvidenceError(CloudError):
+    """An evidence call did not produce a server verdict.
+
+    Raised on auth rejection, transport failure surfaced by the client,
+    non-2xx responses, and unparseable bodies. Carries ``status`` when
+    an HTTP status was involved. Never raised for a blocking verdict —
+    MISMATCH is an answer, not an error.
+    """
+
+
+@dataclass(frozen=True)
+class EvidenceResult:
+    """One server verdict, as returned by /v1/evidence/verify.
+
+    ``verdict`` and ``action`` are the server's words verbatim; the
+    convenience properties cover the three decisions callers branch on.
+    """
+
+    predicate: str
+    verdict: str
+    action: str
+    values: tuple[Any, ...] = ()
+    evidence_ts: float | None = None
+    source: str | None = None
+    table_version: str | None = None
+    correction: Any = None
+    clarify_on: tuple[Any, ...] = field(default_factory=tuple)
+    attestation_id: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        """Claim matched fresh evidence; the server says release."""
+        return self.verdict == "PASS"
+
+    @property
+    def blocked(self) -> bool:
+        """The server's policy action is a hard block."""
+        return self.action == "block"
+
+    @property
+    def needs_clarification(self) -> bool:
+        """Evidence was ambiguous; ``clarify_on`` holds the candidates."""
+        return self.action == "clarify"
+
+    def to_event(self, ts: int | float, agent: str = "assistant") -> "Event":
+        """This verdict as a trace event, for the DFA contract layer.
+
+        Feeding the returned event through the normal trace path grounds
+        the ``claim_emitted(pred)`` / ``evidence_verdict(pred, V)`` /
+        ``evidence_action(pred, a)`` atoms, so contracts built from
+        :func:`sponsio.patterns.library.claim_requires_evidence` and
+        :func:`~sponsio.patterns.library.underdetermined_must_clarify`
+        can reference the verdict.
+        """
+        from sponsio.models.trace import Event
+
+        return Event(
+            ts=ts,
+            agent=agent,
+            event_type="evidence",
+            key=self.predicate,
+            args={"verdict": self.verdict, "action": self.action},
+        )
+
+
+def _normalize_inputs(inputs: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """Ergonomic input forms -> the wire's tagged shape.
+
+    Accepted per input: ``(value, source)`` tuple/list, or an already
+    wire-shaped ``{"value": ..., "source": ...}`` mapping. Anything
+    without a source tag is rejected here — the server would refuse it
+    anyway (taint rule), and a local error names the input.
+    """
+    wire: dict[str, dict[str, Any]] = {}
+    for name, spec in (inputs or {}).items():
+        if isinstance(spec, Mapping) and "source" in spec:
+            wire[name] = {"value": spec.get("value"), "source": str(spec["source"])}
+        elif isinstance(spec, (tuple, list)) and len(spec) == 2:
+            value, source = spec
+            wire[name] = {"value": value, "source": str(source)}
+        else:
+            raise ValueError(
+                f"input {name!r} needs a source tag: pass (value, source) "
+                'or {"value": ..., "source": ...} — the server rejects '
+                "untagged inputs (taint rule)"
+            )
+    return wire
+
+
+def _parse_result(data: Mapping[str, Any]) -> EvidenceResult:
+    evidence = data.get("evidence") or {}
+    return EvidenceResult(
+        predicate=str(data.get("predicate", "")),
+        verdict=str(data.get("verdict", "")),
+        action=str(data.get("action", "")),
+        values=tuple(evidence.get("values") or ()),
+        evidence_ts=evidence.get("ts"),
+        source=evidence.get("source"),
+        table_version=evidence.get("table_version"),
+        correction=data.get("correction"),
+        clarify_on=tuple(data.get("clarify_on") or ()),
+        attestation_id=data.get("attestation_id"),
+    )
+
+
+class EvidenceClient:
+    """Namespace object reached as ``CloudClient.evidence``."""
+
+    def __init__(self, client: CloudClient) -> None:
+        self._client = client
+
+    def _post(self, path: str, body: dict) -> dict:
+        try:
+            status, payload, _ = self._client._request(
+                "POST",
+                path,
+                body=json.dumps(body).encode(),
+                content_type="application/json",
+            )
+        except EvidenceError:
+            raise
+        except CloudError as exc:
+            # Re-type transport failures so callers can catch one class,
+            # keeping the original message (and cause) intact.
+            raise EvidenceError(str(exc)) from exc
+        if status in (401, 403):
+            raise EvidenceError("key rejected", status=status)
+        if not 200 <= status < 300:
+            raise EvidenceError(
+                self._client._detail(payload, f"evidence call failed ({status})"),
+                status=status,
+            )
+        try:
+            return json.loads(payload.decode())
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise EvidenceError("evidence call returned a non-JSON body") from exc
+
+    def verify(
+        self,
+        predicate: str,
+        *,
+        value: Any = None,
+        text: str | None = None,
+        inputs: Mapping[str, Any] | None = None,
+        session_id: str | None = None,
+    ) -> EvidenceResult:
+        """Verify one claim against fresh evidence, server-side.
+
+        Args:
+            predicate: Catalog predicate name (``GET /v1/evidence/predicates``
+                lists them).
+            value: The claimed value (structured-output path; recommended).
+            text: Free-text claim (server support pending; sent verbatim).
+            inputs: Resolver inputs with taint tags — see module docstring.
+            session_id: Optional session correlation id for attestations.
+
+        Raises:
+            EvidenceError: The check did not run to a verdict. Decide
+                fail-open/fail-closed at the call site; fail closed
+                means treating this as a block.
+        """
+        body: dict[str, Any] = {
+            "predicate": predicate,
+            "claim": {"value": value, "text": text},
+            "inputs": _normalize_inputs(inputs),
+        }
+        if session_id:
+            body["session_id"] = session_id
+        return _parse_result(self._post("/v1/evidence/verify", body))
+
+    def verify_batch(
+        self,
+        claims: list[Mapping[str, Any]],
+        *,
+        session_id: str | None = None,
+    ) -> list[EvidenceResult]:
+        """Verify several claims in one call (one attestation each).
+
+        Each claim is a mapping with ``predicate`` and ``value`` (or
+        ``text``), plus optional ``inputs`` in any form
+        :func:`_normalize_inputs` accepts. The server is strict: one bad
+        claim (unknown predicate, taint violation) fails the whole batch.
+        """
+        wire_claims = []
+        for claim in claims:
+            wire_claims.append(
+                {
+                    "predicate": claim["predicate"],
+                    "claim": {
+                        "value": claim.get("value"),
+                        "text": claim.get("text"),
+                    },
+                    "inputs": _normalize_inputs(claim.get("inputs")),
+                }
+            )
+        body: dict[str, Any] = {"claims": wire_claims}
+        if session_id:
+            body["session_id"] = session_id
+        data = self._post("/v1/evidence/verify_batch", body)
+        return [_parse_result(item) for item in data.get("results") or []]

--- a/sponsio/cloud/ref.py
+++ b/sponsio/cloud/ref.py
@@ -162,7 +162,9 @@ def resolve_config_ref(
                 if channel == "draft"
                 else (f" · {channel}" if channel and channel != "published" else "")
             )
-            _say(f"rulebook ← cloud checkout · {ref.project} {stamp}{head}", quiet=quiet)
+            _say(
+                f"rulebook ← cloud checkout · {ref.project} {stamp}{head}", quiet=quiet
+            )
             return cached
     else:
         _say(

--- a/sponsio/cloud/ref.py
+++ b/sponsio/cloud/ref.py
@@ -153,7 +153,16 @@ def resolve_config_ref(
             os.environ["SPONSIO_RULEBOOK_STAMP"] = f"{ref.project} {stamp}" + (
                 f" sha:{pulled.sha}" if pulled.sha else ""
             )
-            _say(f"rulebook ← cloud checkout · {ref.project} {stamp}", quiet=quiet)
+            channel = getattr(pulled, "channel", None)
+            # Say which head this is. A book that has never been published
+            # hands out its draft, and a run should know it is enforcing
+            # edits nobody tested or shipped.
+            head = (
+                " · DRAFT (nothing published yet; publish a tested book to pin what runs pull)"
+                if channel == "draft"
+                else (f" · {channel}" if channel and channel != "published" else "")
+            )
+            _say(f"rulebook ← cloud checkout · {ref.project} {stamp}{head}", quiet=quiet)
             return cached
     else:
         _say(

--- a/sponsio/contracts/capability/factual-claims.yaml
+++ b/sponsio/contracts/capability/factual-claims.yaml
@@ -1,0 +1,79 @@
+# =============================================================================
+# sponsio/contracts/capability/factual-claims.yaml
+#
+# Capability pack — evidence obligations for factual claims.
+#
+# REQUIRES A SPONSIO CLOUD KEY. Verdicts are produced by the cloud
+# evidence API (POST /v1/evidence/verify); the runtime computes none of
+# them. The integration calls ``client.evidence.verify(...)`` and feeds
+# ``EvidenceResult.to_event(...)`` into the trace; that grounds three
+# atom families this pack composes:
+#
+#   claim_emitted(pred)             a claim of this predicate was emitted
+#   evidence_verdict(pred, V)       the server's verdict for it (PASS /
+#                                   MISMATCH / UNDERDETERMINED /
+#                                   NO_EVIDENCE / STALE /
+#                                   SOURCE_UNAVAILABLE /
+#                                   EXTRACTION_AMBIGUOUS)
+#   evidence_action(pred, a)        the server's policy action
+#                                   (release / block / clarify /
+#                                   re_resolve)
+#
+# Two shapes:
+#
+#   § A — claim_requires_evidence(pred):
+#         G(claim_emitted(pred) -> evidence_verdict(pred, PASS)).
+#         Any claim whose verdict is not PASS violates at the timestep
+#         the verdict lands.
+#
+#   § B — underdetermined_must_clarify(pred):
+#         G(evidence_verdict(pred, UNDERDETERMINED) ->
+#           evidence_action(pred, clarify)).
+#         Guards the policy wiring: ambiguous evidence must resolve to
+#         a clarify action, never a silent release.
+#
+# Without a cloud key no ``evidence`` events exist, both atom families
+# stay un-grounded, and every rule below is vacuously satisfied — the
+# pack does nothing rather than something wrong.
+#
+# The predicate names below are the two self-serve built-ins used across
+# the docs; replace them with the predicates your project actually
+# protects (GET /v1/evidence/predicates lists them).
+#
+# Include via:
+#   include:
+#     - sponsio:capability/factual-claims
+# =============================================================================
+
+agents:
+  "*":
+    contracts:
+
+      # ===================================================================
+      # § A — claims must verify (PASS or it doesn't ship)
+      # ===================================================================
+
+      - desc: "Weekday claims must match the calendar (cloud-verified)"
+        G:
+          pattern: claim_requires_evidence
+          args:
+            - date_weekday_agreement
+        source: "library:evidence.factual-claims"
+
+      - desc: "ZIP claims for a city must verify against reference data (cloud-verified)"
+        G:
+          pattern: claim_requires_evidence
+          args:
+            - city_zip_candidates
+        source: "library:evidence.factual-claims"
+
+      # ===================================================================
+      # § B — ambiguous evidence must clarify, never silently release
+      # ===================================================================
+
+      - desc: "Ambiguous city→ZIP evidence must trigger clarification"
+        G:
+          pattern: underdetermined_must_clarify
+          args:
+            - city_zip_candidates
+        source: "library:evidence.factual-claims"

--- a/sponsio/core.py
+++ b/sponsio/core.py
@@ -451,7 +451,48 @@ def Sponsio(  # noqa: N802 (branded factory function)
         # in sync with the demo's hardcoded id.  Multi-agent configs
         # still require an explicit pick (no good default).
         if agent_id not in parsed.agents:
-            if len(parsed.agents) == 1:
+            # A cloud checkout is a whole project's book: the "only agent"
+            # in it is whichever sibling exists — the seeded welcome sample,
+            # every time a tenant's first real agent starts. Rebinding there
+            # ran the user's agent under the sample's rules and reported it
+            # AS the sample, with nothing but a UserWarning to say so.
+            # Under a cloud ref an explicit agent_id is never rebound: use
+            # the local sponsio.yaml for that agent if there is one (and
+            # say so), else stop with the fix in hand.
+            from sponsio.cloud.ref import is_cloud_ref
+
+            if (
+                agent_id != "agent"
+                and isinstance(config, str)
+                and is_cloud_ref(config)
+            ):
+                from pathlib import Path as _Path
+
+                local_yaml = _Path.cwd() / "sponsio.yaml"
+                local = None
+                if local_yaml.is_file():
+                    try:
+                        local = load_config(str(local_yaml))
+                    except Exception:  # noqa: BLE001 - a broken local file is not our call here
+                        local = None
+                if local is not None and agent_id in local.agents:
+                    print(
+                        f"  sponsio: {config} has no book for agent {agent_id!r} yet "
+                        f"(it has: {', '.join(parsed.agents)}); using ./sponsio.yaml. "
+                        f"Push it to publish: sponsio push sponsio.yaml",
+                        flush=True,
+                    )
+                    parsed = local
+                else:
+                    raise ValueError(
+                        f"{config} has no rulebook for agent {agent_id!r} "
+                        f"(agents with a book there: {', '.join(parsed.agents) or 'none'}), "
+                        f"and no ./sponsio.yaml defines it. Push this agent's book "
+                        f"(sponsio push sponsio.yaml) or pass the agent_id that owns one."
+                    )
+            if agent_id in parsed.agents:
+                pass
+            elif len(parsed.agents) == 1:
                 only_agent = next(iter(parsed.agents))
                 # Surface the fallback when the user actively asked
                 # for a non-default name (likely a typo or a stale

--- a/sponsio/core.py
+++ b/sponsio/core.py
@@ -461,35 +461,42 @@ def Sponsio(  # noqa: N802 (branded factory function)
             # say so), else stop with the fix in hand.
             from sponsio.cloud.ref import is_cloud_ref
 
-            if (
-                agent_id != "agent"
-                and isinstance(config, str)
-                and is_cloud_ref(config)
-            ):
+            explicit_agent = agent_id != "agent"
+            from_cloud_ref = isinstance(config, str) and is_cloud_ref(config)
+            local = None
+            local_yaml = None
+            if explicit_agent:
                 from pathlib import Path as _Path
 
                 local_yaml = _Path.cwd() / "sponsio.yaml"
-                local = None
                 if local_yaml.is_file():
                     try:
                         local = load_config(str(local_yaml))
                     except Exception:  # noqa: BLE001 - a broken local file is not our call here
                         local = None
-                if local is not None and agent_id in local.agents:
-                    print(
-                        f"  sponsio: {config} has no book for agent {agent_id!r} yet "
-                        f"(it has: {', '.join(parsed.agents)}); using ./sponsio.yaml. "
-                        f"Push it to publish: sponsio push sponsio.yaml",
-                        flush=True,
-                    )
-                    parsed = local
-                else:
-                    raise ValueError(
-                        f"{config} has no rulebook for agent {agent_id!r} "
-                        f"(agents with a book there: {', '.join(parsed.agents) or 'none'}), "
-                        f"and no ./sponsio.yaml defines it. Push this agent's book "
-                        f"(sponsio push sponsio.yaml) or pass the agent_id that owns one."
-                    )
+            # A checkout that does not carry the agent you named is served
+            # by the local book when there is one.  This is a project's
+            # first EXTRA agent, every time: the whole-project checkout
+            # answers 200 with the siblings' books, so nothing 404s and
+            # nothing gets pushed, and the agent's own rules sit on disk
+            # unused.  It reaches here as a plain file path (the caller
+            # wrote the checkout down before loading it), so keying this
+            # on `sponsio://` alone left that path erroring out.
+            if local is not None and agent_id in local.agents:
+                print(
+                    f"  sponsio: {config} has no book for agent {agent_id!r} yet "
+                    f"(it has: {', '.join(parsed.agents)}); using ./sponsio.yaml. "
+                    f"Push it to publish: sponsio push sponsio.yaml",
+                    flush=True,
+                )
+                parsed = local
+            elif explicit_agent and from_cloud_ref:
+                raise ValueError(
+                    f"{config} has no rulebook for agent {agent_id!r} "
+                    f"(agents with a book there: {', '.join(parsed.agents) or 'none'}), "
+                    f"and no ./sponsio.yaml defines it. Push this agent's book "
+                    f"(sponsio push sponsio.yaml) or pass the agent_id that owns one."
+                )
             if agent_id in parsed.agents:
                 pass
             elif len(parsed.agents) == 1:
@@ -512,6 +519,16 @@ def Sponsio(  # noqa: N802 (branded factory function)
                 agent_id = only_agent
             elif len(parsed.agents) > 1:
                 available = list(parsed.agents.keys())
+                if explicit_agent:
+                    # "specify an agent_id" is useless advice to someone who
+                    # already did; the book is what is missing, not the flag
+                    raise ValueError(
+                        f"agent_id={agent_id!r} has no rulebook in {config} "
+                        f"(agents there: {available}), and no ./sponsio.yaml "
+                        f"defines it either. Add a block for {agent_id!r} to "
+                        f"your rulebook and push it (sponsio push sponsio.yaml), "
+                        f"or pass an agent_id that already has a book."
+                    )
                 raise ValueError(
                     f"agent_id={agent_id!r} not found in config and "
                     f"the config defines multiple agents {available}. "

--- a/sponsio/demos/replay.py
+++ b/sponsio/demos/replay.py
@@ -163,7 +163,9 @@ def _run_steps(
 
     for step in steps:
         result = guard.guard_before(step.tool, step.args)
-        if result.blocked:
+        # ``stop_original``: replay renders what enforcement would do, so
+        # a redirected verdict ends the run the same way a block does.
+        if result.stop_original:
             break
 
     # Direct invocation — works in pipes / CI where stderr.isatty() is False.

--- a/sponsio/generation/dsl_to_contract.py
+++ b/sponsio/generation/dsl_to_contract.py
@@ -67,6 +67,7 @@ from sponsio.patterns.library import (
     arg_value_range,
     audit_after,
     backup_before_destructive,
+    claim_requires_evidence,
     confirm_after_source,
     cooldown,
     ctx_matches_required,
@@ -98,6 +99,7 @@ from sponsio.patterns.library import (
     segregation_of_duty,
     token_budget,
     tool_allowlist,
+    underdetermined_must_clarify,
     untrusted_source_gate,
 )
 
@@ -219,6 +221,10 @@ _PATTERN_REGISTRY: dict[str, Callable[..., DetFormula]] = {
     # workflow_step is bounded (decided at the very next event), F is
     # unbounded (decided at trace end).
     "workflow_step": workflow_step,
+    # Evidence obligations — verdicts come from the cloud verify API
+    # (``evidence`` events); these only reference the grounded atoms.
+    "claim_requires_evidence": claim_requires_evidence,
+    "underdetermined_must_clarify": underdetermined_must_clarify,
 }
 
 

--- a/sponsio/guard_stdin.py
+++ b/sponsio/guard_stdin.py
@@ -669,7 +669,11 @@ def evaluate_event(event: dict) -> GuardOutcome:
             os.environ.pop("SPONSIO_MODE", None)
         else:
             os.environ["SPONSIO_MODE"] = saved_env
-    if result.allowed:
+    # ``not stop_original`` rather than ``allowed``: ``allowed`` is False
+    # only on ``blocked``, so a redirected verdict fell through here as a
+    # permit — a fail-open hole for a hook adapter with no substitution
+    # path. Redirects must deny.
+    if not result.stop_original:
         # Append the now-permitted event to the trace log so the next
         # PreToolUse subprocess sees it.  Use the ts BaseGuard actually
         # assigned (== ``len(trace.events) - 1`` after the append).  If
@@ -704,9 +708,13 @@ def evaluate_event(event: dict) -> GuardOutcome:
     # compact rule-shaped explanation rather than a stack trace.
     # ``CheckResult.det_violations`` items expose ``.message`` (the
     # rendered "BLOCKED: agent.tool — …" line built by the monitor).
+    from sponsio.integrations.base import is_stopping_action
+
     reasons = []
     for v in result.det_violations:
-        if getattr(v, "action", None) == "blocked":
+        # Canonical stopping set: a redirected verdict denies here too,
+        # so its message must be eligible as the deny reason.
+        if is_stopping_action(getattr(v, "action", "") or ""):
             msg = getattr(v, "message", "") or ""
             # Strip the redundant ``BLOCKED: …`` prefix Claude Code's
             # UI will render the deny separately.

--- a/sponsio/integrations/base.py
+++ b/sponsio/integrations/base.py
@@ -310,6 +310,16 @@ class CheckResult:
     feedback: str | None = None
     rollback_performed: bool = False
     redirected_to: str | None = None
+    # --- Evidence verification (opt-in; empty/None when unconfigured) ---
+    # ``evidence_claims`` holds VerifiedClaim records (spec + value +
+    # server verdict). ``evidence_stopped`` is the middleware's already-
+    # decided stop (blocked claim, or EvidenceError under on_error=block);
+    # a synthesized ``blocked`` det violation accompanies it so
+    # ``stop_original`` agrees. Clarify verdicts do NOT stop — read them
+    # via ``evidence_clarifications`` to render a question.
+    evidence_claims: list = field(default_factory=list)
+    evidence_error: str | None = None
+    evidence_stopped: bool = False
 
     @property
     def blocked(self) -> bool:
@@ -358,6 +368,11 @@ class CheckResult:
     def needs_retry(self) -> bool:
         """True if any sto violation returned a retry with feedback."""
         return any(r.action == "retrying" for r in self.sto_violations)
+
+    @property
+    def evidence_clarifications(self) -> list:
+        """Evidence claims whose server action is ``clarify`` (non-stopping)."""
+        return [c for c in self.evidence_claims if c.needs_clarification]
 
     @property
     def all_violations(self) -> list[EnforcementResult]:
@@ -491,6 +506,14 @@ class BaseGuard:
             still wins.
         store: Optional PatternStore. If provided, user-written NL
             contracts are automatically registered as ``user_defined``.
+        evidence: Optional cloud claim-verification config (opt-in;
+            no behavior changes when omitted). An
+            :class:`~sponsio.integrations.evidence_middleware.EvidenceConfig`
+            or the equivalent mapping — see that module's docstring for
+            the shape. When set, ``observe_llm_call`` extracts the
+            configured claims from structured assistant output, verifies
+            them server-side, and folds blocking verdicts into the
+            returned :class:`CheckResult`.
     """
 
     def __init__(
@@ -514,6 +537,7 @@ class BaseGuard:
         tag_outputs: bool = True,
         tag_pii: bool = False,
         tool_policy: Any | None = None,
+        evidence: Any | None = None,
     ) -> None:
         # --- Config file support ---
         if config is not None:
@@ -817,6 +841,7 @@ class BaseGuard:
         if init_banner:
             print_banner(contracts_list)
 
+        self._terminal_reporter: TerminalReporter | None = None
         if self._verbose:
             reporter = TerminalReporter(
                 verbosity=self._verbosity,
@@ -827,6 +852,18 @@ class BaseGuard:
             reporter._header_printed = True
             reporter._build_label_map()
             self._monitor.register_callback(reporter)
+            # Kept for evidence verdict lines (report_evidence) — the
+            # middleware itself never prints.
+            self._terminal_reporter = reporter
+
+        # --- Evidence verification config (opt-in) ---
+        # Parsed eagerly so a malformed config fails at construction,
+        # not on the first verified turn.
+        self._evidence_config = None
+        if evidence is not None:
+            from sponsio.integrations.evidence_middleware import EvidenceConfig
+
+            self._evidence_config = EvidenceConfig.from_value(evidence)
 
         # --- Shadow-mode session logger ---
         # Always attach the JSONL logger in observe mode so users have a
@@ -1638,6 +1675,8 @@ class BaseGuard:
         response: str | None = None,
         input_tokens: int | None = None,
         output_tokens: int | None = None,
+        tool_call_args: list[dict] | None = None,
+        session_id: str | None = None,
     ) -> CheckResult:
         """Record an LLM request/response pair in the trace and evaluate
         any contracts that apply to those events.
@@ -1657,12 +1696,27 @@ class BaseGuard:
             response: The LLM's completion text.
             input_tokens: Token count for the prompt.
             output_tokens: Token count for the completion.
+            tool_call_args: Decoded argument dicts of the response's
+                tool calls, if any — an extraction source for evidence
+                claims (structured output only).
+            session_id: Optional session correlation id forwarded to the
+                evidence service for attestations.
 
         Returns:
             CheckResult aggregating violations from both the request-
             and response-side contracts (det violations first, then sto).
             Callers can inspect ``.all_violations`` for the full list
             including confidence / threshold information.
+
+        Evidence (opt-in): when the guard was constructed with an
+        ``evidence=`` config and ``response`` is present, the configured
+        claims are extracted from the structured output, verified
+        server-side in one batch, and folded into the returned
+        CheckResult — a blocking verdict (or an EvidenceError under
+        ``on_error: block``) makes it a stopping result
+        (``stop_original`` True via a synthesized blocked violation).
+        Adapters that hold the response at this point must honor that
+        instead of discarding it.
         """
         total = None
         if input_tokens is not None and output_tokens is not None:
@@ -1716,6 +1770,63 @@ class BaseGuard:
                 elif r.action in ("blocked", "escalated"):
                     det_violations.append(r)
 
+        # --- Evidence verification (opt-in) ------------------------------
+        evidence_claims: list = []
+        evidence_error: str | None = None
+        evidence_stopped = False
+        if self._evidence_config is not None and response:
+            from sponsio.integrations.evidence_middleware import run_evidence
+
+            outcome = run_evidence(
+                self,
+                self._evidence_config,
+                content=response,
+                tool_call_args=tool_call_args,
+                session_id=session_id,
+            )
+            evidence_claims = list(outcome.claims)
+            evidence_error = str(outcome.error) if outcome.error else None
+            evidence_stopped = outcome.stops(self._evidence_config.on_error)
+            if evidence_stopped:
+                # Synthesize a canonical ``blocked`` violation per stop
+                # cause so ``stop_original`` (Phase-1 predicate) agrees
+                # with the middleware's decision.
+                for claim in outcome.blocked_claims:
+                    det_violations.append(
+                        EnforcementResult(
+                            action="blocked",
+                            message=(
+                                f"evidence: claim "
+                                f"{claim.spec.claim_field!r}={claim.value!r} "
+                                f"-> {claim.result.verdict}"
+                            ),
+                            rule_id=f"evidence:{claim.result.predicate}",
+                            agent_msg=(
+                                "The claim did not match authoritative "
+                                "evidence; correct it before releasing."
+                            ),
+                        )
+                    )
+                if outcome.error is not None:
+                    det_violations.append(
+                        EnforcementResult(
+                            action="blocked",
+                            message=(
+                                f"evidence: verification unavailable "
+                                f"({outcome.error}); on_error=block"
+                            ),
+                            rule_id="evidence:error",
+                        )
+                    )
+            # Reporting stays out of the middleware: verdict lines render
+            # through the same reporter det verdicts use.
+            if self._terminal_reporter is not None:
+                for claim in evidence_claims:
+                    try:
+                        self._terminal_reporter.report_evidence(claim.result)
+                    except Exception:  # noqa: BLE001 - display must not break
+                        pass
+
         allowed = len(det_violations) == 0
         feedback = None
         if sto_violations:
@@ -1727,6 +1838,9 @@ class BaseGuard:
             det_violations=det_violations,
             sto_violations=sto_violations,
             feedback=feedback,
+            evidence_claims=evidence_claims,
+            evidence_error=evidence_error,
+            evidence_stopped=evidence_stopped,
         )
 
     def observe_tool_output(self, tool_name: str, output: str) -> None:

--- a/sponsio/integrations/base.py
+++ b/sponsio/integrations/base.py
@@ -320,6 +320,16 @@ class CheckResult:
     evidence_claims: list = field(default_factory=list)
     evidence_error: str | None = None
     evidence_stopped: bool = False
+    # --- SMT policy findings (opt-in; empty/None when unconfigured) ---
+    # ``smt_claims`` holds CheckedClaim records (binding + value + local
+    # solver finding). Same stop contract as evidence: ``smt_stopped``
+    # is the middleware's already-decided stop and a synthesized
+    # ``blocked`` det violation accompanies it so ``stop_original``
+    # agrees. SATISFIABLE findings do NOT stop by default — read their
+    # ``claims_false_scenario`` to caveat or rewrite the response.
+    smt_claims: list = field(default_factory=list)
+    smt_error: str | None = None
+    smt_stopped: bool = False
 
     @property
     def blocked(self) -> bool:
@@ -373,6 +383,18 @@ class CheckResult:
     def evidence_clarifications(self) -> list:
         """Evidence claims whose server action is ``clarify`` (non-stopping)."""
         return [c for c in self.evidence_claims if c.needs_clarification]
+
+    @property
+    def evidence_blocked(self) -> list:
+        """Evidence claims whose server action is ``block`` (stopping).
+
+        The counterpart of ``evidence_clarifications``: once a caller has
+        withheld a response because ``stop_original`` is set, this is what
+        says WHICH claim was wrong and what the authority answered, so the
+        turn can be corrected instead of merely dropped. Each entry carries
+        ``result.correction`` when the authority named the right value.
+        """
+        return [c for c in self.evidence_claims if c.blocked]
 
     @property
     def all_violations(self) -> list[EnforcementResult]:
@@ -538,6 +560,7 @@ class BaseGuard:
         tag_pii: bool = False,
         tool_policy: Any | None = None,
         evidence: Any | None = None,
+        smt: Any | None = None,
     ) -> None:
         # --- Config file support ---
         if config is not None:
@@ -864,6 +887,23 @@ class BaseGuard:
             from sponsio.integrations.evidence_middleware import EvidenceConfig
 
             self._evidence_config = EvidenceConfig.from_value(evidence)
+
+        # --- SMT policy config (opt-in) ---
+        # Parsed eagerly: this compiles the policy and imports z3, so a
+        # broken rule or a missing solver fails at construction, not
+        # mid-conversation.
+        self._smt_config = None
+        self._smt_session = None
+        if smt is not None:
+            from sponsio.integrations.smt_middleware import (
+                SmtMiddlewareConfig,
+                SmtSession,
+            )
+
+            self._smt_config = SmtMiddlewareConfig.from_value(smt)
+            # Always constructed; only consulted when config.session is
+            # True, so the flag can be flipped without re-plumbing.
+            self._smt_session = SmtSession()
 
         # --- Shadow-mode session logger ---
         # Always attach the JSONL logger in observe mode so users have a
@@ -1717,6 +1757,14 @@ class BaseGuard:
         (``stop_original`` True via a synthesized blocked violation).
         Adapters that hold the response at this point must honor that
         instead of discarding it.
+
+        SMT (opt-in): when the guard was constructed with an ``smt=``
+        config and ``response`` is present, configured claims are
+        extracted from the same structured output and checked locally
+        against the SMT policy (:mod:`sponsio.smt`). INVALID /
+        IMPOSSIBLE findings (and UNKNOWN under ``on_unknown: block``,
+        the default) make the result stopping through the same
+        synthesized-violation contract as evidence.
         """
         total = None
         if input_tokens is not None and output_tokens is not None:
@@ -1827,6 +1875,73 @@ class BaseGuard:
                     except Exception:  # noqa: BLE001 - display must not break
                         pass
 
+        # --- SMT policy findings (opt-in) -------------------------------
+        # Same contract as the evidence block above: findings entered the
+        # trace inside run_smt; a stopping finding (or a checker error
+        # under on_error=block) synthesizes a canonical ``blocked``
+        # violation so ``stop_original`` agrees with the middleware.
+        smt_claims: list = []
+        smt_error: str | None = None
+        smt_stopped = False
+        if self._smt_config is not None and response:
+            from sponsio.integrations.smt_middleware import run_smt
+
+            smt_outcome = run_smt(
+                self,
+                self._smt_config,
+                content=response,
+                tool_call_args=tool_call_args,
+                session=self._smt_session,
+            )
+            smt_claims = list(smt_outcome.claims)
+            smt_error = smt_outcome.error
+            smt_stopped = smt_outcome.stops(self._smt_config)
+            if smt_stopped:
+                policy_name = self._smt_config.checker.policy.name
+                for claim in smt_outcome.blocked_claims(self._smt_config):
+                    agent_msg = (
+                        "The claim is not entailed by the policy; correct "
+                        "it before releasing."
+                    )
+                    if claim.finding.claims_false_scenario:
+                        agent_msg = (
+                            "The claim fails under: "
+                            f"{claim.finding.claims_false_scenario}. "
+                            "Address the missing condition before releasing."
+                        )
+                    det_violations.append(
+                        EnforcementResult(
+                            action="blocked",
+                            message=(
+                                f"smt: claim "
+                                f"{claim.binding.claim_field!r}"
+                                f"={claim.value!r} -> {claim.finding.result} "
+                                f"({policy_name})"
+                            ),
+                            rule_id=f"smt:{claim.binding.variable}",
+                            agent_msg=agent_msg,
+                        )
+                    )
+                if smt_error is not None:
+                    det_violations.append(
+                        EnforcementResult(
+                            action="blocked",
+                            message=(
+                                f"smt: policy check unavailable "
+                                f"({smt_error}); on_error=block"
+                            ),
+                            rule_id="smt:error",
+                        )
+                    )
+            # Reporting stays out of the middleware: finding lines render
+            # through the same reporter det and evidence verdicts use.
+            if self._terminal_reporter is not None:
+                for claim in smt_claims:
+                    try:
+                        self._terminal_reporter.report_smt(claim)
+                    except Exception:  # noqa: BLE001 - display must not break
+                        pass
+
         allowed = len(det_violations) == 0
         feedback = None
         if sto_violations:
@@ -1841,6 +1956,9 @@ class BaseGuard:
             evidence_claims=evidence_claims,
             evidence_error=evidence_error,
             evidence_stopped=evidence_stopped,
+            smt_claims=smt_claims,
+            smt_error=smt_error,
+            smt_stopped=smt_stopped,
         )
 
     def observe_tool_output(self, tool_name: str, output: str) -> None:

--- a/sponsio/integrations/base.py
+++ b/sponsio/integrations/base.py
@@ -262,6 +262,26 @@ def format_sto_retry_message(feedback: str, original: Any) -> str:
 # Check result (returned by guard_before / guard_after)
 # ---------------------------------------------------------------------------
 
+# THE canonical stopping set — the single definition of "this verdict must
+# stop the original action". ``CheckResult.stop_original``, the MCP proxy,
+# and the bridge span projection all consume this; do not restate the
+# membership anywhere else (three copies drifted apart once already).
+#
+# ``redirected`` is stopping because the contract forbade the original
+# call; adapters with a real substitution path branch on ``redirected_to``
+# BEFORE this predicate and run the substitute instead.
+# ``escalated`` is deliberately NOT stopping: the monitor uses
+# ``EscalateToHuman()`` as the default strategy for unfired-assumption
+# verdicts, so an escalated result is routinely vacuous — gating on it
+# would refuse every action while a conditional contract's assumption is
+# simply not yet satisfied (see the long note in ``guard_before``).
+STOPPING_ACTIONS: frozenset[str] = frozenset({"blocked", "redirected"})
+
+
+def is_stopping_action(action: str) -> bool:
+    """True when a det verdict action must stop the original call."""
+    return action in STOPPING_ACTIONS
+
 
 @dataclass
 class CheckResult:
@@ -332,7 +352,7 @@ class CheckResult:
         redirect. ``escalated`` is intentionally excluded — see
         ``guard_before`` for why escalation does not gate execution.
         """
-        return self.blocked or self.redirected
+        return any(is_stopping_action(r.action) for r in self.det_violations)
 
     @property
     def needs_retry(self) -> bool:
@@ -1311,6 +1331,9 @@ class BaseGuard:
             # call from running.
             # Observe mode never rolls back. the whole point is to
             # show users the trace their agent would have produced.
+            # Deliberately NOT ``stop_original``: observe-mode redirects
+            # must keep their event in the trace (the whole point of
+            # shadow mode), so only the enforce-mode redirect rolls back.
             should_rollback = result.blocked or (
                 self._mode != "observe" and result.redirected
             )

--- a/sponsio/integrations/base.py
+++ b/sponsio/integrations/base.py
@@ -1834,15 +1834,28 @@ class BaseGuard:
             )
             evidence_claims = list(outcome.claims)
             evidence_error = str(outcome.error) if outcome.error else None
-            evidence_stopped = outcome.stops(self._evidence_config.on_error)
-            if evidence_stopped:
-                # Synthesize a canonical ``blocked`` violation per stop
-                # cause so ``stop_original`` (Phase-1 predicate) agrees
-                # with the middleware's decision.
+            # Observe mode is a promise the whole product makes: everything
+            # is watched, nothing is withheld. The action lane keeps it by
+            # downgrading its verdicts to ``observed``; the output lane has
+            # to keep it the same way, or a shadow rollout starts rewriting
+            # customer-facing answers on day one.
+            _ev_observe = self._mode == "observe"
+            _ev_action = "observed" if _ev_observe else "blocked"
+            evidence_stopped = outcome.stops(
+                self._evidence_config.on_error
+            ) and not _ev_observe
+            if outcome.blocked_claims or (
+                outcome.error is not None
+                and self._evidence_config.on_error == "block"
+            ):
+                # Synthesize a canonical violation per stop cause so
+                # ``stop_original`` (Phase-1 predicate) agrees with the
+                # middleware's decision. In observe mode the same finding
+                # is recorded as non-stopping.
                 for claim in outcome.blocked_claims:
                     det_violations.append(
                         EnforcementResult(
-                            action="blocked",
+                            action=_ev_action,
                             message=(
                                 f"evidence: claim "
                                 f"{claim.spec.claim_field!r}={claim.value!r} "
@@ -1855,10 +1868,13 @@ class BaseGuard:
                             ),
                         )
                     )
-                if outcome.error is not None:
+                if (
+                    outcome.error is not None
+                    and self._evidence_config.on_error == "block"
+                ):
                     det_violations.append(
                         EnforcementResult(
-                            action="blocked",
+                            action=_ev_action,
                             message=(
                                 f"evidence: verification unavailable "
                                 f"({outcome.error}); on_error=block"

--- a/sponsio/integrations/base.py
+++ b/sponsio/integrations/base.py
@@ -1841,12 +1841,11 @@ class BaseGuard:
             # customer-facing answers on day one.
             _ev_observe = self._mode == "observe"
             _ev_action = "observed" if _ev_observe else "blocked"
-            evidence_stopped = outcome.stops(
-                self._evidence_config.on_error
-            ) and not _ev_observe
+            evidence_stopped = (
+                outcome.stops(self._evidence_config.on_error) and not _ev_observe
+            )
             if outcome.blocked_claims or (
-                outcome.error is not None
-                and self._evidence_config.on_error == "block"
+                outcome.error is not None and self._evidence_config.on_error == "block"
             ):
                 # Synthesize a canonical violation per stop cause so
                 # ``stop_original`` (Phase-1 predicate) agrees with the

--- a/sponsio/integrations/evidence_middleware.py
+++ b/sponsio/integrations/evidence_middleware.py
@@ -339,7 +339,17 @@ def run_evidence(
             event_type="evidence",
             metadata={
                 "key": result.predicate,
-                "args": {"verdict": result.verdict, "action": result.action},
+                # Grounding reads only verdict/action; the rest rides along
+                # for the console's output layer (what the model said, the
+                # authoritative value(s), their source, and the correction).
+                "args": {
+                    "verdict": result.verdict,
+                    "action": result.action,
+                    "claim": claim.value,
+                    "correction": result.correction,
+                    "source": result.source,
+                    "values": list(result.values) if result.values else [],
+                },
             },
         )
     return EvidenceOutcome(claims=tuple(verified))

--- a/sponsio/integrations/evidence_middleware.py
+++ b/sponsio/integrations/evidence_middleware.py
@@ -1,0 +1,394 @@
+"""Evidence middleware — claim verification at the observe_llm_call chokepoint.
+
+Pure logic between a parsed assistant response and the cloud evidence
+API (``sponsio/cloud/evidence.py``): extract configured claims from
+structured output, verify them in ONE ``verify_batch`` call, feed each
+verdict into the trace as an ``evidence`` event through the guard's
+normal event path, and report whether the response must stop.
+
+Everything here follows the thin-client rule: no comparators, no verdict
+computation — the server's verdict/action words are consumed verbatim.
+No printing either; terminal output goes through the existing
+``TerminalReporter.report_evidence`` from the guard layer.
+
+Opt-in and fail closed:
+
+* A guard without an ``evidence=`` config never reaches this module —
+  zero behavior change.
+* ``on_error: block`` (the default) turns an :class:`EvidenceError`
+  (network, auth, bad response) into a stop; ``allow`` releases but the
+  error is still recorded on the CheckResult.
+* Claims are extracted ONLY from structured output: assistant message
+  content that parses as a JSON object, plus decoded tool_call argument
+  dicts. A configured ``claim_field`` absent from the output is simply
+  not a claim. No free-text regex extraction here.
+* Input source tags are sent exactly as declared (e.g. ``model_output``).
+  If the server's taint allowlist rejects the source, that rejection is
+  the correct outcome and surfaces as the server's error — the
+  middleware never spoofs source tags.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Mapping
+
+from sponsio.cloud.evidence import EvidenceClient, EvidenceError, EvidenceResult
+
+if TYPE_CHECKING:
+    from sponsio.integrations.base import BaseGuard
+
+# ---------------------------------------------------------------------------
+# Notice templates — the single place adapters take their user-facing
+# rewrite text from, so wording can be customized later without touching
+# each integration.
+# ---------------------------------------------------------------------------
+
+BLOCK_NOTICE_TEMPLATE = (
+    "[BLOCKED] claim '{claim_field}'={value} failed verification "
+    "({predicate}: {verdict})"
+)
+BLOCK_NOTICE_CORRECTION_SUFFIX = "; evidence says: {correction}"
+BLOCK_NOTICE_ERROR_TEMPLATE = (
+    "[BLOCKED] claim verification unavailable ({error}); "
+    "failing closed per on_error=block"
+)
+CLARIFY_NOTICE_TEMPLATE = (
+    "Before I can confirm '{claim_field}'={value}: the evidence for "
+    "{predicate} is ambiguous. Did you mean one of: {candidates}?"
+)
+CLARIFY_CANDIDATE_LIMIT = 5
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class EvidenceConfigError(ValueError):
+    """The evidence config is malformed. Raised at guard construction."""
+
+
+@dataclass(frozen=True)
+class EvidenceInputSpec:
+    """One resolver input: which output field feeds it, tagged how."""
+
+    field: str
+    source: str
+
+
+@dataclass(frozen=True)
+class EvidenceClaimSpec:
+    """One configured claim: predicate + the output field that carries it."""
+
+    predicate: str
+    claim_field: str
+    inputs: Mapping[str, EvidenceInputSpec] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EvidenceConfig:
+    """Guard-level evidence configuration (see BaseGuard ``evidence=``)."""
+
+    client: EvidenceClient
+    claims: tuple[EvidenceClaimSpec, ...]
+    on_error: str = "block"
+
+    @classmethod
+    def from_value(cls, value: Any) -> "EvidenceConfig":
+        """Normalize the construction-time value into a validated config.
+
+        Accepts an :class:`EvidenceConfig` (passed through) or a mapping
+        shaped like::
+
+            {"client": <EvidenceClient | {"api_key":..., "url":...} | None>,
+             "on_error": "block" | "allow",
+             "claims": [{"predicate": ..., "claim_field": ...,
+                         "inputs": {name: {"field":..., "source":...}}}]}
+
+        ``client: None`` builds a default CloudClient (env/credentials).
+        """
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            raise EvidenceConfigError(
+                f"evidence config must be a mapping or EvidenceConfig, "
+                f"got {type(value).__name__}"
+            )
+
+        on_error = value.get("on_error", "block")
+        if on_error not in ("block", "allow"):
+            raise EvidenceConfigError(
+                f"evidence.on_error must be 'block' or 'allow', got {on_error!r}"
+            )
+
+        raw_client = value.get("client")
+        if isinstance(raw_client, EvidenceClient):
+            client = raw_client
+        elif raw_client is None or isinstance(raw_client, Mapping):
+            from sponsio.cloud.client import CloudClient
+
+            kwargs = dict(raw_client or {})
+            client = EvidenceClient(
+                CloudClient(api_key=kwargs.get("api_key"), url=kwargs.get("url"))
+            )
+        else:
+            raise EvidenceConfigError(
+                "evidence.client must be an EvidenceClient, a mapping "
+                "with api_key/url, or None for the default credentials path"
+            )
+
+        raw_claims = value.get("claims") or []
+        if not isinstance(raw_claims, (list, tuple)):
+            raise EvidenceConfigError("evidence.claims must be a list")
+        claims: list[EvidenceClaimSpec] = []
+        for raw in raw_claims:
+            if not isinstance(raw, Mapping) or not raw.get("predicate"):
+                raise EvidenceConfigError(
+                    f"each evidence claim needs a 'predicate', got {raw!r}"
+                )
+            if not raw.get("claim_field"):
+                raise EvidenceConfigError(
+                    f"claim {raw.get('predicate')!r} needs a 'claim_field'"
+                )
+            inputs: dict[str, EvidenceInputSpec] = {}
+            for name, spec in (raw.get("inputs") or {}).items():
+                if (
+                    not isinstance(spec, Mapping)
+                    or not spec.get("field")
+                    or not spec.get("source")
+                ):
+                    raise EvidenceConfigError(
+                        f"claim {raw['predicate']!r} input {name!r} needs "
+                        "'field' and 'source'"
+                    )
+                inputs[str(name)] = EvidenceInputSpec(
+                    field=str(spec["field"]), source=str(spec["source"])
+                )
+            claims.append(
+                EvidenceClaimSpec(
+                    predicate=str(raw["predicate"]),
+                    claim_field=str(raw["claim_field"]),
+                    inputs=inputs,
+                )
+            )
+        return cls(client=client, claims=tuple(claims), on_error=on_error)
+
+
+# ---------------------------------------------------------------------------
+# Extraction — structured output only
+# ---------------------------------------------------------------------------
+
+
+def structured_sources(
+    content: str | None, tool_call_args: list[Mapping[str, Any]] | None
+) -> list[Mapping[str, Any]]:
+    """The field-lookup sources, in precedence order.
+
+    Message content is a source only when it parses as a JSON object;
+    tool_call argument dicts follow in call order. First source holding
+    a field wins.
+    """
+    sources: list[Mapping[str, Any]] = []
+    if content:
+        try:
+            parsed = json.loads(content)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict):
+            sources.append(parsed)
+    for args in tool_call_args or []:
+        if isinstance(args, Mapping):
+            sources.append(args)
+    return sources
+
+
+def _lookup(sources: list[Mapping[str, Any]], field_name: str) -> tuple[bool, Any]:
+    for source in sources:
+        if field_name in source:
+            return True, source[field_name]
+    return False, None
+
+
+@dataclass(frozen=True)
+class ExtractedClaim:
+    spec: EvidenceClaimSpec
+    value: Any
+    wire: dict[str, Any]  # verify_batch item
+
+
+def extract_claims(
+    config: EvidenceConfig, sources: list[Mapping[str, Any]]
+) -> list[ExtractedClaim]:
+    """Configured claims present in the structured output.
+
+    A missing ``claim_field`` means no claim (silently skipped, per the
+    design). A missing input field sends the claim without that input —
+    the resolver answers UNAVAILABLE and the verdict lattice does the
+    fail-closed work; inventing a value here would be worse.
+    """
+    extracted: list[ExtractedClaim] = []
+    for spec in config.claims:
+        present, value = _lookup(sources, spec.claim_field)
+        if not present:
+            continue
+        inputs: dict[str, Any] = {}
+        for name, input_spec in spec.inputs.items():
+            found, input_value = _lookup(sources, input_spec.field)
+            if found:
+                inputs[name] = (input_value, input_spec.source)
+        extracted.append(
+            ExtractedClaim(
+                spec=spec,
+                value=value,
+                wire={
+                    "predicate": spec.predicate,
+                    "value": value,
+                    "inputs": inputs,
+                },
+            )
+        )
+    return extracted
+
+
+# ---------------------------------------------------------------------------
+# Verification run
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerifiedClaim:
+    """One claim paired with the server's verdict."""
+
+    spec: EvidenceClaimSpec
+    value: Any
+    result: EvidenceResult
+
+    @property
+    def blocked(self) -> bool:
+        return self.result.action == "block"
+
+    @property
+    def needs_clarification(self) -> bool:
+        return self.result.action == "clarify"
+
+
+@dataclass(frozen=True)
+class EvidenceOutcome:
+    """What one response's evidence run produced."""
+
+    claims: tuple[VerifiedClaim, ...] = ()
+    error: EvidenceError | None = None
+
+    @property
+    def blocked_claims(self) -> tuple[VerifiedClaim, ...]:
+        return tuple(c for c in self.claims if c.blocked)
+
+    @property
+    def clarify_claims(self) -> tuple[VerifiedClaim, ...]:
+        return tuple(c for c in self.claims if c.needs_clarification)
+
+    def stops(self, on_error: str) -> bool:
+        """Must the response be withheld? (Phase-1 canonical semantics —
+        this feeds a synthesized ``blocked`` det violation, so
+        ``CheckResult.stop_original`` reflects it.)"""
+        if self.blocked_claims:
+            return True
+        return self.error is not None and on_error == "block"
+
+
+def run_evidence(
+    guard: "BaseGuard",
+    config: EvidenceConfig,
+    *,
+    content: str | None,
+    tool_call_args: list[Mapping[str, Any]] | None = None,
+    session_id: str | None = None,
+) -> EvidenceOutcome:
+    """Extract, verify (one batch call), feed the trace, summarize.
+
+    Never raises: an :class:`EvidenceError` is captured on the outcome
+    (callers decide via ``on_error``). Events enter the trace through
+    ``RuntimeMonitor.check_action`` — the guard's normal event path — so
+    evidence-referencing det contracts (``claim_requires_evidence``,
+    ``underdetermined_must_clarify``) evaluate on the same step.
+    """
+    extracted = extract_claims(config, structured_sources(content, tool_call_args))
+    if not extracted:
+        return EvidenceOutcome()
+
+    try:
+        results = config.client.verify_batch(
+            [claim.wire for claim in extracted], session_id=session_id
+        )
+    except EvidenceError as exc:
+        return EvidenceOutcome(error=exc)
+
+    verified: list[VerifiedClaim] = []
+    for claim, result in zip(extracted, results):
+        verified.append(
+            VerifiedClaim(spec=claim.spec, value=claim.value, result=result)
+        )
+        # Normal event path: the verdict becomes an ``evidence`` event in
+        # the trace (same shape as EvidenceResult.to_event), evaluated
+        # under the monitor's lock like every other event.
+        guard._monitor.check_action(
+            agent_id=guard.agent_id,
+            action=f"<evidence:{result.predicate}>",
+            event_type="evidence",
+            metadata={
+                "key": result.predicate,
+                "args": {"verdict": result.verdict, "action": result.action},
+            },
+        )
+    return EvidenceOutcome(claims=tuple(verified))
+
+
+# ---------------------------------------------------------------------------
+# Notice formatting (used by adapters; templates above are the source)
+# ---------------------------------------------------------------------------
+
+
+def format_block_notice(
+    blocked: tuple[VerifiedClaim, ...] | list[VerifiedClaim],
+    error: str | None = None,
+) -> str:
+    """One line per blocked claim; the error line when the run failed."""
+    lines = []
+    for claim in blocked:
+        line = BLOCK_NOTICE_TEMPLATE.format(
+            claim_field=claim.spec.claim_field,
+            value=claim.value,
+            predicate=claim.result.predicate,
+            verdict=claim.result.verdict,
+        )
+        if claim.result.correction is not None:
+            line += BLOCK_NOTICE_CORRECTION_SUFFIX.format(
+                correction=claim.result.correction
+            )
+        lines.append(line)
+    if error:
+        lines.append(BLOCK_NOTICE_ERROR_TEMPLATE.format(error=error))
+    return "\n".join(lines)
+
+
+def format_clarify_notice(
+    clarify: tuple[VerifiedClaim, ...] | list[VerifiedClaim],
+) -> str:
+    lines = []
+    for claim in clarify:
+        candidates = [str(c) for c in claim.result.clarify_on]
+        shown = ", ".join(candidates[:CLARIFY_CANDIDATE_LIMIT])
+        remaining = len(candidates) - CLARIFY_CANDIDATE_LIMIT
+        if remaining > 0:
+            shown += f" (+{remaining} more)"
+        lines.append(
+            CLARIFY_NOTICE_TEMPLATE.format(
+                claim_field=claim.spec.claim_field,
+                value=claim.value,
+                predicate=claim.result.predicate,
+                candidates=shown,
+            )
+        )
+    return "\n".join(lines)

--- a/sponsio/integrations/google_adk.py
+++ b/sponsio/integrations/google_adk.py
@@ -109,7 +109,9 @@ class GoogleADKGuard(BaseGuard):
         def guarded_sync(*args: Any, **kwargs: Any) -> Any:
             check = guard.guard_before(tool_name, _call_args(tool, args, kwargs))
             guard.last_check = check
-            if check.blocked:
+            # ``stop_original`` matches the async twin above: redirects
+            # fail closed here too (no substitution path in this adapter).
+            if check.stop_original:
                 return _blocked_result(check)
 
             result = tool(*args, **kwargs)

--- a/sponsio/integrations/langgraph.py
+++ b/sponsio/integrations/langgraph.py
@@ -175,7 +175,9 @@ class LangGraphGuard(BaseGuard):
     def _guard_check(self, tool_name: str, kwargs: dict):
         """Run guard_before and raise if blocked."""
         check = self.guard_before(tool_name, kwargs)
-        if check.blocked:
+        # ``stop_original``: this helper has no substitution path, so a
+        # redirected verdict must raise too (fail closed).
+        if check.stop_original:
             msg = select_agent_message(
                 check.det_violations, fallback="contract violated"
             )
@@ -240,7 +242,10 @@ class LangGraphGuard(BaseGuard):
                     registry=registry,
                     sync=True,
                 )
-            if check.blocked:
+            # ``stop_original`` after the substitution branch above: it
+            # also catches a redirected verdict with no usable target
+            # (fail closed instead of falling through to execution).
+            if check.stop_original:
                 msg = select_agent_message(
                     check.det_violations, fallback="contract violated"
                 )
@@ -262,7 +267,8 @@ class LangGraphGuard(BaseGuard):
                     registry=registry,
                     sync=False,
                 )
-            if check.blocked:
+            # Same ``stop_original`` gate as the sync twin above.
+            if check.stop_original:
                 msg = select_agent_message(
                     check.det_violations, fallback="contract violated"
                 )
@@ -352,6 +358,9 @@ class LangGraphGuard(BaseGuard):
                 ),
             )
         check = self.guard_before(safe_name, kwargs)
+        # Gating on ``blocked`` alone is correct HERE: the chained-redirect
+        # case is handled explicitly right below, so both stopping actions
+        # are covered without ``stop_original``.
         if check.blocked:
             msg = select_agent_message(
                 check.det_violations, fallback="safe tool also blocked"
@@ -419,7 +428,9 @@ class LangGraphGuard(BaseGuard):
 
         result = self.guard_before(tool_name, {"input": input_str})
 
-        if result.blocked and self._block:
+        # ``stop_original``: the callback handler has no substitution
+        # path, so redirected verdicts raise too (fail closed).
+        if result.stop_original and self._block:
             msg = select_agent_message(
                 result.det_violations, fallback="contract violated"
             )
@@ -727,7 +738,9 @@ def _build_monitored_graph(
             if span:
                 self._push_span(span.to_dict())
 
-            return not result.blocked
+            # ``stop_original``: node-level checks have no substitution
+            # path, so a redirected verdict counts as stopped as well.
+            return not result.stop_original
 
         def invoke(self, state: Any, *, config: Any = None, **kwargs: Any) -> Any:
             """Invoke the graph, enforcing contracts on each node."""

--- a/sponsio/integrations/mcp.py
+++ b/sponsio/integrations/mcp.py
@@ -17,6 +17,8 @@ Usage:
 
 from __future__ import annotations
 
+import warnings
+
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
@@ -106,6 +108,27 @@ class MCPContractProxy:
         self._client = mcp_client
         self._monitor = RuntimeMonitor(system=system)
         self._agent_id = agent_id
+        # An agent_id that names nobody in the system binds no contracts, so
+        # every call would sail through checked-by-nothing. Silence there is
+        # the fail-open case this proxy exists to prevent, so say it loudly
+        # once at construction rather than never.
+        try:
+            known = set()
+            for contract in system.contracts or []:
+                bound = getattr(contract, "agent", None)
+                name = getattr(bound, "id", None) or getattr(bound, "agent_id", None)
+                if name:
+                    known.add(str(name))
+        except Exception:  # noqa: BLE001 - a System shape we do not know
+            known = set()
+        if known and agent_id not in known:
+            warnings.warn(
+                f"MCPContractProxy(agent_id={agent_id!r}) matches no agent in "
+                f"this system ({', '.join(sorted(known))}); no contracts are "
+                f"bound and every tool call will pass unchecked.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         # Auto-tagging of tool outputs — same semantics as BaseGuard
         # but inlined here because ``MCPContractProxy`` is a standalone
         # proxy (not a BaseGuard subclass).

--- a/sponsio/integrations/mcp.py
+++ b/sponsio/integrations/mcp.py
@@ -142,11 +142,14 @@ class MCPContractProxy:
         # that proxy this to an LLM (Claude Desktop, custom orchestrators)
         # can show the agent-tuned phrasing while keeping the legacy
         # ``violations`` array of log-formatted strings for back-compat.
-        # Treat ``redirected`` the same as ``blocked`` here: this proxy
-        # has no transparent-substitution path, so a ``redirect_to_safe``
-        # redirect must refuse the unsafe call rather than fall through
-        # and execute it (a fail-open hole).
-        stopped = [r for r in results if r.action in ("blocked", "redirected")]
+        # Canonical stopping set (integrations/base.py STOPPING_ACTIONS):
+        # this proxy has no transparent-substitution path, so a
+        # ``redirect_to_safe`` redirect refuses the unsafe call rather
+        # than falling through and executing it. Membership lives in one
+        # place now — this file no longer restates it.
+        from sponsio.integrations.base import is_stopping_action
+
+        stopped = [r for r in results if is_stopping_action(r.action)]
         if stopped:
             return {
                 "error": "Blocked by behavioral contract",

--- a/sponsio/integrations/openai.py
+++ b/sponsio/integrations/openai.py
@@ -181,6 +181,10 @@ class OpenAIGuard(BaseGuard):
             **kwargs,
         )
         self.last_check: CheckResult | None = None
+        # Per-choice ``observe_llm_call`` results of the most recent
+        # ``check_response`` — carries the evidence verdict when the
+        # guard has an ``evidence=`` config.
+        self.last_llm_checks: list[CheckResult] = []
         self.on_violation = on_violation
         # Map of ``tool_call_id`` → ``tool_name`` captured from the
         # assistant response, used so that
@@ -222,27 +226,44 @@ class OpenAIGuard(BaseGuard):
             getattr(usage, "completion_tokens", None) if usage else None
         )
 
+        # Per-choice results of the ``<llm_response>`` observation —
+        # including the evidence verdict when the guard has an
+        # ``evidence=`` config. ``patched_create`` reads this to apply
+        # the block/clarify rewrite while the response is still in hand.
+        self.last_llm_checks = []
+
         for idx, choice in enumerate(response.choices):
             message = choice.message
-
-            # Observe LLM response content (enables llm_said, token_count)
             content = getattr(message, "content", None)
-            self.observe_llm_call(
+
+            # Decode tool_call arguments BEFORE the observation so the
+            # evidence middleware can extract claims from them as well
+            # as from JSON message content.
+            decoded_calls: list[tuple[Any, str, dict]] = []
+            if hasattr(message, "tool_calls") and message.tool_calls:
+                for tc in message.tool_calls:
+                    tool_name = tc.function.name
+                    decoded_calls.append(
+                        (
+                            tc,
+                            tool_name,
+                            _coerce_tool_arguments(
+                                tc.function.arguments, tool_name=tool_name
+                            ),
+                        )
+                    )
+
+            # Observe LLM response content (enables llm_said, token_count;
+            # runs the evidence middleware when configured).
+            llm_check = self.observe_llm_call(
                 response=content or "",
                 input_tokens=prompt_tokens_total if idx == 0 else None,
                 output_tokens=completion_tokens_total if idx == 0 else None,
+                tool_call_args=[args for _, _, args in decoded_calls],
             )
+            self.last_llm_checks.append(llm_check)
 
-            if not hasattr(message, "tool_calls") or not message.tool_calls:
-                continue
-
-            for tc in message.tool_calls:
-                tool_name = tc.function.name
-                args = _coerce_tool_arguments(
-                    tc.function.arguments,
-                    tool_name=tool_name,
-                )
-
+            for tc, tool_name, args in decoded_calls:
                 check = self.guard_before(tool_name, args)
                 results.append(check)
 
@@ -422,6 +443,37 @@ class OpenAIGuard(BaseGuard):
 
         return response
 
+    def _apply_evidence_notices(self, response: Any) -> Any:
+        """Rewrite assistant text per the evidence verdicts, in place.
+
+        Reuses the same in-place mechanism as ``_filter_blocked_calls``:
+        mutate ``message.content`` on the choice whose observation
+        stopped (block notice, with the correction when the server sent
+        one) or produced clarify verdicts (a clarifying question with up
+        to five candidates). No-op — byte-identical response — when the
+        guard has no evidence config or nothing fired. Notice wording
+        lives in ``evidence_middleware`` (module-level templates).
+        """
+        checks = getattr(self, "last_llm_checks", None)
+        if not checks:
+            return response
+        from sponsio.integrations.evidence_middleware import (
+            format_block_notice,
+            format_clarify_notice,
+        )
+
+        for choice, llm_check in zip(response.choices, checks):
+            if llm_check.evidence_stopped:
+                choice.message.content = format_block_notice(
+                    [c for c in llm_check.evidence_claims if c.blocked],
+                    error=llm_check.evidence_error,
+                )
+            elif llm_check.evidence_clarifications:
+                choice.message.content = format_clarify_notice(
+                    llm_check.evidence_clarifications
+                )
+        return response
+
 
 def patch_openai(
     agent_id: str = "agent",
@@ -431,11 +483,20 @@ def patch_openai(
     sto_evaluator: StoEvaluator | None = None,
     sto_judge: Any | None = None,
     on_violation: Any | None = None,
+    evidence: Any | None = None,
 ) -> OpenAIGuard:
     """Monkey-patch the OpenAI SDK to auto-enforce contracts on tool_calls.
 
     After calling this, every ``client.chat.completions.create()`` call
     will automatically check tool_calls against the provided contracts.
+
+    With an ``evidence=`` config (see
+    :mod:`sponsio.integrations.evidence_middleware`), configured claims in
+    the assistant's structured output are verified server-side and a
+    blocking verdict replaces the assistant text with a block notice
+    (clarify verdicts replace it with a clarifying question). Streaming
+    is out of scope for evidence: ``stream=True`` with an evidence config
+    raises ``NotImplementedError`` at call time.
 
     Args:
         agent_id: Logical agent identifier for trace/monitor.
@@ -469,6 +530,7 @@ def patch_openai(
         sto_evaluator=sto_evaluator,
         sto_judge=sto_judge,
         on_violation=on_violation,
+        evidence=evidence,
     )
     # Warn when replacing an in-flight guard — notebooks that re-run a
     # cell, test suites that don't tear down, or apps that swap
@@ -505,26 +567,43 @@ def patch_openai(
         # returning from the previous turn and run them through
         # ``guard_after`` so the trace reflects real execution.  This
         # is the OpenAI equivalent of LangGraph's post-execution hook.
+        # Streaming + evidence is explicitly out of scope: there is no
+        # buffered response object to verify before chunks reach the
+        # caller. Fail loudly at call time instead of silently skipping
+        # verification the config promised.
+        if kwargs.get("stream") and guard._evidence_config is not None:
+            raise NotImplementedError(
+                "evidence verification is not supported with stream=True; "
+                "call without stream or drop the guard's evidence config"
+            )
         guard._auto_observe_tool_messages(kwargs.get("messages"))
         response = _original_create(self_completions, *args, **kwargs)
         results = guard.check_response(response)
         # ``stop_original``: redirected verdicts must also trigger the
         # rewrite — gating on ``.blocked`` alone lets redirects fail open.
         if any(r.stop_original for r in results):
-            return guard._filter_blocked_calls(response, results)
-        return response
+            response = guard._filter_blocked_calls(response, results)
+        # Evidence verdicts rewrite the assistant text while the response
+        # is still in hand (no-op when unconfigured / nothing fired).
+        return guard._apply_evidence_notices(response)
 
     # --- Async wrapper ---
     async def patched_async_create(
         self_completions: Any, *args: Any, **kwargs: Any
     ) -> Any:
+        # Same streaming refusal as the sync twin above.
+        if kwargs.get("stream") and guard._evidence_config is not None:
+            raise NotImplementedError(
+                "evidence verification is not supported with stream=True; "
+                "call without stream or drop the guard's evidence config"
+            )
         guard._auto_observe_tool_messages(kwargs.get("messages"))
         response = await _original_async_create(self_completions, *args, **kwargs)
         results = guard.check_response(response)
         # Same ``stop_original`` gate as the sync twin above.
         if any(r.stop_original for r in results):
-            return guard._filter_blocked_calls(response, results)
-        return response
+            response = guard._filter_blocked_calls(response, results)
+        return guard._apply_evidence_notices(response)
 
     openai.resources.chat.completions.Completions.create = patched_create  # type: ignore[assignment]
     openai.resources.chat.completions.AsyncCompletions.create = patched_async_create  # type: ignore[assignment]

--- a/sponsio/integrations/openai.py
+++ b/sponsio/integrations/openai.py
@@ -254,7 +254,10 @@ class OpenAIGuard(BaseGuard):
                 if tool_call_id:
                     self._pending_tool_calls[tool_call_id] = tool_name
 
-                if check.blocked and self.on_violation:
+                # ``stop_original``: the callback must also fire for
+                # redirected verdicts — this adapter has no substitution
+                # path, so a redirect is a refusal the operator should see.
+                if check.stop_original and self.on_violation:
                     self.on_violation(tool_name, args, check)
 
         self.last_check = results[-1] if results else None
@@ -398,7 +401,10 @@ class OpenAIGuard(BaseGuard):
                 continue
             kept = []
             for tc in message.tool_calls:
-                if tc_idx < len(results) and results[tc_idx].blocked:
+                # ``stop_original`` folds in ``redirected``: no
+                # substitution path here, so a redirected tool_call must
+                # be stripped too (fail closed), not left to execute.
+                if tc_idx < len(results) and results[tc_idx].stop_original:
                     msg = select_agent_message(
                         results[tc_idx].det_violations,
                         fallback="Contract violation",
@@ -502,7 +508,9 @@ def patch_openai(
         guard._auto_observe_tool_messages(kwargs.get("messages"))
         response = _original_create(self_completions, *args, **kwargs)
         results = guard.check_response(response)
-        if any(r.blocked for r in results):
+        # ``stop_original``: redirected verdicts must also trigger the
+        # rewrite — gating on ``.blocked`` alone lets redirects fail open.
+        if any(r.stop_original for r in results):
             return guard._filter_blocked_calls(response, results)
         return response
 
@@ -513,7 +521,8 @@ def patch_openai(
         guard._auto_observe_tool_messages(kwargs.get("messages"))
         response = await _original_async_create(self_completions, *args, **kwargs)
         results = guard.check_response(response)
-        if any(r.blocked for r in results):
+        # Same ``stop_original`` gate as the sync twin above.
+        if any(r.stop_original for r in results):
             return guard._filter_blocked_calls(response, results)
         return response
 

--- a/sponsio/models/trace.py
+++ b/sponsio/models/trace.py
@@ -19,6 +19,12 @@ _VALID_EVENT_TYPES: frozenset[str] = frozenset(
         "delegation",
         "llm_response",
         "llm_request",
+        # ``evidence`` carries a cloud claim-verification verdict back
+        # into the trace (``EvidenceResult.to_event``): ``key`` is the
+        # predicate name, ``args`` holds {"verdict", "action"}. Grounds
+        # the ``claim_emitted`` / ``evidence_verdict`` /
+        # ``evidence_action`` atom families.
+        "evidence",
         # ``context_update`` carries user-pushed external facts (caller
         # identity, retrieved-content source, signed-message metadata)
         # via ``guard.observe_context({...})``. The grounding layer

--- a/sponsio/onboard.py
+++ b/sponsio/onboard.py
@@ -996,11 +996,14 @@ def _wrap_snippet(framework: str, agent_id: str) -> str:
             f"# add `sponsioMiddleware(guard)` to your generateText middleware"
         ),
         "mcp": (
+            f"from sponsio.config import config_to_system, load_config\n"
             f"from sponsio.mcp import MCPContractProxy\n"
-            f'proxy = MCPContractProxy(config="sponsio.yaml", '
+            f'system = config_to_system(load_config("sponsio.yaml"))\n'
+            f"# wrap the MCP client you already use; call the proxy instead:\n"
+            f"proxy = MCPContractProxy(mcp_client=client, system=system, "
             f'agent_id="{agent_id}")\n'
-            f"# then run the proxy in front of your upstream MCP server:\n"
-            f"#   await proxy.serve_stdio()  # or proxy.serve_sse(host=..., port=...)"
+            f"#   result = await proxy.call_tool(name, arguments)\n"
+            f"# agent_id must name an agent in the rulebook, or nothing is checked"
         ),
         "none": (
             f"import sponsio\n"

--- a/sponsio/patterns/library.py
+++ b/sponsio/patterns/library.py
@@ -2216,3 +2216,83 @@ def approval_active(
         pattern_name="approval_active",
         args=(action, role, max_seconds),
     )
+
+
+# ---------------------------------------------------------------------------
+# Evidence obligations — cloud claim-verification verdicts as trace atoms.
+#
+# These compose the ``claim_emitted`` / ``evidence_verdict`` /
+# ``evidence_action`` atom families grounded from ``evidence`` events
+# (``EvidenceResult.to_event`` in sponsio/cloud/evidence.py). The runtime
+# computes no verdicts — the atoms restate what the cloud service
+# answered, and these patterns make "the answer must be PASS" (or
+# "ambiguity must lead to clarification") checkable like any other
+# contract. Requires a Sponsio Cloud key to produce the events at all.
+# ---------------------------------------------------------------------------
+
+
+def claim_requires_evidence(pred: str, desc: str = "") -> DetFormula:
+    """Every emitted claim of this predicate must verify as PASS.
+
+    Compiles to: ``G(claim_emitted(pred) -> evidence_verdict(pred, PASS))``.
+
+    Both atoms are grounded from the same ``evidence`` event, so the
+    implication is decided at the timestep the verdict lands: a claim
+    whose verdict is anything but PASS (MISMATCH, UNDERDETERMINED,
+    NO_EVIDENCE, STALE, SOURCE_UNAVAILABLE, EXTRACTION_AMBIGUOUS)
+    violates immediately.
+
+    Args:
+        pred: Evidence predicate name (e.g. ``"date_weekday_agreement"``).
+        desc: Optional human-readable description.
+
+    Returns:
+        A ``DetFormula`` encoding the evidence obligation.
+    """
+    _ensure_non_empty(pred, pattern="claim_requires_evidence", arg="pred")
+    formula = G(
+        Implies(
+            Atom("claim_emitted", pred),
+            Atom("evidence_verdict", pred, "PASS"),
+        )
+    )
+    return DetFormula(
+        formula=formula,
+        desc=desc or f"claims of {pred} must verify against evidence (PASS)",
+        pattern_name="claim_requires_evidence",
+        args=(pred,),
+    )
+
+
+def underdetermined_must_clarify(pred: str, desc: str = "") -> DetFormula:
+    """An UNDERDETERMINED verdict must resolve to a clarify action.
+
+    Compiles to: ``G(evidence_verdict(pred, UNDERDETERMINED) ->
+    evidence_action(pred, clarify))``.
+
+    Guards the policy wiring rather than the claim itself: when the
+    evidence was ambiguous (several candidates), the recorded policy
+    action on that same event must be ``clarify`` — a project override
+    that quietly releases or hard-blocks ambiguous claims trips this
+    contract.
+
+    Args:
+        pred: Evidence predicate name.
+        desc: Optional human-readable description.
+
+    Returns:
+        A ``DetFormula`` encoding the clarify obligation.
+    """
+    _ensure_non_empty(pred, pattern="underdetermined_must_clarify", arg="pred")
+    formula = G(
+        Implies(
+            Atom("evidence_verdict", pred, "UNDERDETERMINED"),
+            Atom("evidence_action", pred, "clarify"),
+        )
+    )
+    return DetFormula(
+        formula=formula,
+        desc=desc or f"underdetermined {pred} evidence must trigger clarification",
+        pattern_name="underdetermined_must_clarify",
+        args=(pred,),
+    )

--- a/sponsio/patterns/library.py
+++ b/sponsio/patterns/library.py
@@ -554,7 +554,7 @@ def rate_limit(action: str, max_count: int, desc: str = "") -> DetFormula:
     formula = G(Le(_count_var(action), Const(max_count)))
     return DetFormula(
         formula=formula,
-        desc=desc or f"{action} limited to {max_count} invocations",
+        desc=desc or f"{action} limited to {max_count} invocation{'' if max_count == 1 else 's'}",
         pattern_name="rate_limit",
         args=(action, max_count),
     )
@@ -765,7 +765,7 @@ def bounded_retry(action: str, max_retries: int, desc: str = "") -> DetFormula:
     formula = G(Le(_count_var(action), Const(max_retries)))
     return DetFormula(
         formula=formula,
-        desc=desc or f"{action} limited to {max_retries} retries",
+        desc=desc or f"{action} limited to {max_retries} retr{'y' if max_retries == 1 else 'ies'}",
         pattern_name="bounded_retry",
         args=(action, max_retries),
     )

--- a/sponsio/patterns/library.py
+++ b/sponsio/patterns/library.py
@@ -554,7 +554,8 @@ def rate_limit(action: str, max_count: int, desc: str = "") -> DetFormula:
     formula = G(Le(_count_var(action), Const(max_count)))
     return DetFormula(
         formula=formula,
-        desc=desc or f"{action} limited to {max_count} invocation{'' if max_count == 1 else 's'}",
+        desc=desc
+        or f"{action} limited to {max_count} invocation{'' if max_count == 1 else 's'}",
         pattern_name="rate_limit",
         args=(action, max_count),
     )
@@ -765,7 +766,8 @@ def bounded_retry(action: str, max_retries: int, desc: str = "") -> DetFormula:
     formula = G(Le(_count_var(action), Const(max_retries)))
     return DetFormula(
         formula=formula,
-        desc=desc or f"{action} limited to {max_retries} retr{'y' if max_retries == 1 else 'ies'}",
+        desc=desc
+        or f"{action} limited to {max_retries} retr{'y' if max_retries == 1 else 'ies'}",
         pattern_name="bounded_retry",
         args=(action, max_retries),
     )

--- a/sponsio/render/monitor.py
+++ b/sponsio/render/monitor.py
@@ -315,3 +315,67 @@ def _contract_label(c) -> str:
     if guarantees:
         return str(getattr(guarantees[0], "desc", "") or "")
     return getattr(getattr(c, "agent", None), "id", "") or ""
+
+
+# ---------------------------------------------------------------------------
+# Evidence verdicts — cloud claim-verification results
+# (sponsio/cloud/evidence.py), rendered in the det vocabulary.
+# ---------------------------------------------------------------------------
+
+# Verdicts whose line reads as a warning rather than a hard failure.
+_EVIDENCE_WARN_VERDICTS = frozenset({"UNDERDETERMINED", "STALE"})
+
+# How many clarify candidates to show before collapsing to "+N more".
+_EVIDENCE_CANDIDATE_LIMIT = 5
+
+
+def render_evidence(result) -> Text:
+    """One line per server verdict: ``✓/⚠/✗ evidence "pred" → VERDICT``.
+
+    MISMATCH appends the server's correction; UNDERDETERMINED appends up
+    to five clarify candidates then ``+N more``. ``result`` is an
+    :class:`sponsio.cloud.evidence.EvidenceResult` (duck-typed: any
+    object with ``predicate`` / ``verdict`` / ``correction`` /
+    ``clarify_on`` renders).
+    """
+    verdict = str(result.verdict or "").upper()
+    color = STATUS.get(verdict, PALETTE["violation"])
+    if verdict == "PASS":
+        symbol, symbol_style = f"{SYMBOLS['pass']} ", f"bold {PALETTE['success']}"
+    elif verdict in _EVIDENCE_WARN_VERDICTS:
+        symbol, symbol_style = "⚠ ", f"bold {PALETTE['warning']}"
+    else:
+        symbol, symbol_style = f"{SYMBOLS['fail']} ", f"bold {color}"
+
+    parts: list[tuple[str, str]] = [
+        (_LEAD, ""),
+        (symbol, symbol_style),
+        ("evidence ", PALETTE["fg"]),
+        (f'"{result.predicate}"', PALETTE["metadata"]),
+        (" → ", PALETTE["metadata"]),
+        _bold(verdict, color),
+    ]
+
+    if verdict == "MISMATCH" and result.correction is not None:
+        parts.extend(
+            [
+                (" · ", PALETTE["metadata"]),
+                ("correction ", PALETTE["metadata"]),
+                (f'"{result.correction}"', PALETTE["fg"]),
+            ]
+        )
+    elif verdict == "UNDERDETERMINED" and result.clarify_on:
+        candidates = [str(c) for c in result.clarify_on]
+        shown = candidates[:_EVIDENCE_CANDIDATE_LIMIT]
+        parts.extend(
+            [
+                (" · ", PALETTE["metadata"]),
+                ("clarify: ", PALETTE["metadata"]),
+                (", ".join(shown), PALETTE["fg"]),
+            ]
+        )
+        remaining = len(candidates) - len(shown)
+        if remaining > 0:
+            parts.append((f" +{remaining} more", PALETTE["metadata"]))
+
+    return Text.assemble(*parts)

--- a/sponsio/render/tokens.py
+++ b/sponsio/render/tokens.py
@@ -80,6 +80,15 @@ STATUS = {
     "BLOCKED": PALETTE["violation"],
     "WARN": PALETTE["warning"],
     "EXPIRED": PALETTE["metadata"],
+    # Cloud evidence verdicts (sponsio/cloud/evidence.py). Colors reuse
+    # the existing semantics: blocking verdicts render like BLOCKED,
+    # ambiguity/staleness render like WARN — no new hues.
+    "MISMATCH": PALETTE["violation"],
+    "UNDERDETERMINED": PALETTE["warning"],
+    "NO_EVIDENCE": PALETTE["violation"],
+    "STALE": PALETTE["warning"],
+    "SOURCE_UNAVAILABLE": PALETTE["violation"],
+    "EXTRACTION_AMBIGUOUS": PALETTE["violation"],
 }
 
 

--- a/sponsio/runtime/terminal.py
+++ b/sponsio/runtime/terminal.py
@@ -34,6 +34,7 @@ from sponsio.render.monitor import (
     build_label_map,
     render_banner,
     render_event,
+    render_evidence,
 )
 
 if TYPE_CHECKING:
@@ -113,6 +114,20 @@ class TerminalReporter:
         the reporter; the new code does the work in ``__init__`` so this
         is a no-op idempotent re-builder."""
         self._assumption_to_label = build_label_map(self._contracts)
+
+    def report_evidence(self, result) -> None:
+        """Print a cloud evidence verdict in the standard verdict style.
+
+        ``result`` is an :class:`sponsio.cloud.evidence.EvidenceResult`.
+        Follows the same verbosity contract as det lines: at verbosity 0
+        only non-PASS verdicts print (violations only); PASS lines show
+        from verbosity 1 up — evidence checks fire per claim, not per
+        tool call, so they are not the noise the v<2 pass-suppression
+        exists for.
+        """
+        if self.verbosity == 0 and str(result.verdict).upper() == "PASS":
+            return
+        self._console.print(render_evidence(result))
 
 
 def print_banner(contracts: list, colorize: bool | None = None) -> None:

--- a/sponsio/tracer/grounding.py
+++ b/sponsio/tracer/grounding.py
@@ -616,6 +616,24 @@ def ground_event(
                     continue
                 state.current_ctx[str(k)] = str(val) if val is not None else ""
 
+    # ── evidence ───────────────────────────────────────────────
+    # A cloud claim-verification verdict fed back into the trace
+    # (``EvidenceResult.to_event``). ``key`` is the predicate name;
+    # ``args`` carries the server's verdict and policy action verbatim.
+    # No verdict computation happens here — the atoms only restate what
+    # the service answered, so DFA contracts (``claim_requires_evidence``,
+    # ``underdetermined_must_clarify``) can reference it. Verdict is
+    # normalized to upper-case, action to lower-case, matching the
+    # server's own vocabulary.
+    elif event.event_type == "evidence" and event.key:
+        v[pred_key("claim_emitted", event.key)] = True
+        verdict = str((event.args or {}).get("verdict") or "").upper()
+        if verdict:
+            v[pred_key("evidence_verdict", event.key, verdict)] = True
+        action = str((event.args or {}).get("action") or "").lower()
+        if action:
+            v[pred_key("evidence_action", event.key, action)] = True
+
     # ── permissions (static, from Agent model) ─────────────────
     if agents:
         agent_obj = agents.get(event.agent)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -309,8 +309,28 @@ def test_the_rulebook_stamp_rides_along_when_the_config_came_from_the_cloud(
     guard.last_check_span = FakeSpan(_clean_turn())
     guard.guard_before("t", {})
 
-    assert client.sent[-1]["vm"]["rulebook"] == "alpha quant@v7 sha:abc"
+    vm = client.sent[-1]["vm"]
+    # The run names ITS OWN book, in the form the console links to and the
+    # server keys tests by; the whole checkout rides along as provenance.
+    assert vm["rulebook"] == "quant@v7"
+    assert vm["rulebookRef"] == "alpha quant@v7 sha:abc"
+    assert vm["session"]["rulebookVersion"] == 7
     _ = run
+
+
+def test_a_single_agent_checkout_stamp_still_names_this_agents_book(
+    tmp_path, monkeypatch
+):
+    # a single-agent pull is stamped "<project>@vN" with no agent prefix
+    monkeypatch.setenv("SPONSIO_RULEBOOK_STAMP", "alpha@v5 sha:abc")
+    guard, client = FakeGuard(), FakeClient()
+    attach(guard, client=client, runs_dir=tmp_path)
+    guard.last_check_span = FakeSpan(_clean_turn())
+    guard.guard_before("t", {})
+
+    vm = client.sent[-1]["vm"]
+    assert vm["rulebook"] == "quant@v5"
+    assert vm["session"]["rulebookVersion"] == 5
 
 
 def test_a_local_run_claims_no_rulebook_version(tmp_path, monkeypatch):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -474,3 +474,65 @@ def test_a_guard_without_a_system_is_not_an_error(tmp_path):
     guard, client = FakeGuard(), FakeClient()
     run = attach(guard, client=client, runs_dir=tmp_path)
     assert run.contracts == {}
+
+
+class _FakeClaimResult:
+    def __init__(self, verdict, action, correction=None):
+        self.verdict = verdict
+        self.action = action
+        self.correction = correction
+        self.values = []
+
+
+class _FakeClaimSpec:
+    predicate = "date_weekday_agreement"
+    claim_field = "validated_weekday"
+
+
+class _FakeVerifiedClaim:
+    spec = _FakeClaimSpec()
+
+    def __init__(self, verdict="MISMATCH"):
+        self.result = _FakeClaimResult(verdict, "block", correction="tuesday")
+
+
+class _FakeObserveResult:
+    def __init__(self):
+        self.evidence_claims = [_FakeVerifiedClaim()]
+
+
+class _EvidenceGuard(FakeGuard):
+    """A guard whose output lane verifies a claim."""
+
+    def observe_llm_call(self, response=None, **kwargs):
+        return _FakeObserveResult()
+
+
+def test_output_lane_reaches_the_console_in_a_multi_agent_run(tmp_path):
+    """auto=False is about the ACTION lane; claim verdicts must still ship.
+
+    A multi-agent run attributes its own tool steps, which is the only
+    reason to pass auto=False. Taking the output lane with it made those
+    runs render as clean traces while the model stated something false.
+    """
+    guard, client = _EvidenceGuard(), FakeClient()
+    run = attach(guard, client=client, runs_dir=tmp_path, auto=False)
+
+    guard.last_check_span = FakeSpan(_clean_turn(agent="report_agent"))
+    guard.observe_llm_call(response='{"validated_weekday": "Monday"}')
+
+    outputs = [s for s in run.steps if s.get("type") == "assistant_output"]
+    assert outputs, f"no output-lane step recorded; steps={run.steps}"
+    claims = outputs[0]["output"]["claims"]
+    assert claims[0]["predicate"] == "date_weekday_agreement"
+    assert claims[0]["verdict"] == "MISMATCH"
+    assert outputs[0]["agentId"] == "quant"
+
+
+def test_auto_false_still_leaves_guard_before_alone(tmp_path):
+    """The action lane stays hand-driven: attach must not wrap it."""
+    guard, client = _EvidenceGuard(), FakeClient()
+    run = attach(guard, client=client, runs_dir=tmp_path, auto=False)
+
+    guard.guard_before("query_prices", {})
+    assert run.steps == []

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -340,13 +340,33 @@ def test_the_run_key_is_stable_across_frames(tmp_path):
 
 def test_each_frame_carries_the_whole_run_so_far(tmp_path):
     guard, client = FakeGuard(), FakeClient()
-    attach(guard, client=client, runs_dir=tmp_path)
+    run = attach(guard, client=client, runs_dir=tmp_path)
+    # Both knobs off: the floor AND the size-proportional backoff.
+    run.SEND_MIN_INTERVAL_S = 0.0
+    run.SEND_MAX_KB_PER_S = float("inf")
     guard.last_check_span = FakeSpan(_clean_turn())
 
     guard.guard_before("a", {})
     guard.guard_before("b", {})
 
+    # Frames are cumulative snapshots, never deltas.
     assert [len(f["vm"]["steps"]) for f in client.sent] == [1, 2]
+
+
+def test_frames_coalesce_so_a_long_run_does_not_upload_the_run_squared(tmp_path):
+    """Every frame is the whole run, so one frame per step costs O(steps^2)
+    bytes. Steps taken inside the interval share a frame instead."""
+    guard, client = FakeGuard(), FakeClient()
+    run = attach(guard, client=client, runs_dir=tmp_path)
+    guard.last_check_span = FakeSpan(_clean_turn())
+
+    for _ in range(50):
+        guard.guard_before("a", {})
+
+    assert len(client.sent) < 50
+    # ...and the run is still whole once it ends.
+    run.finish()
+    assert len(client.sent[-1]["vm"]["steps"]) == 50
 
 
 def test_live_flips_false_on_finish(tmp_path):

--- a/tests/test_cloud_evidence.py
+++ b/tests/test_cloud_evidence.py
@@ -1,0 +1,366 @@
+"""Thin evidence client, grounding atoms, patterns, and reporter lines.
+
+The HTTP layer is mocked by monkeypatching ``CloudClient._request`` —
+the same seam the transport uses — so no test needs a network or a real
+service. All verdict values in canned responses are copied from the
+server's verdict lattice; the client computes none of them.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from rich.console import Console
+
+from sponsio.cloud.client import CloudClient, CloudError
+from sponsio.cloud.evidence import (
+    EvidenceError,
+    EvidenceResult,
+    _normalize_inputs,
+)
+from sponsio.formulas.evaluator import evaluate
+from sponsio.models.trace import Event, Trace
+from sponsio.patterns.library import (
+    claim_requires_evidence,
+    underdetermined_must_clarify,
+)
+from sponsio.render.monitor import render_evidence
+from sponsio.render.tokens import PALETTE
+from sponsio.runtime.terminal import TerminalReporter
+from sponsio.tracer.grounding import ground
+
+
+# ---------------------------------------------------------------------------
+# harness
+# ---------------------------------------------------------------------------
+
+
+def make_client(monkeypatch, *responses, status=200):
+    """A CloudClient whose transport replays canned JSON responses."""
+    client = CloudClient(api_key="sk_test", url="https://cloud.test")
+    calls = []
+    queue = list(responses)
+
+    def fake_request(method, path, *, body=None, content_type=None, timeout=None):
+        calls.append(
+            {
+                "method": method,
+                "path": path,
+                "body": json.loads(body.decode()) if body else None,
+            }
+        )
+        payload = queue.pop(0) if queue else {}
+        return status, json.dumps(payload).encode(), {}
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    return client, calls
+
+
+PASS_RESPONSE = {
+    "predicate": "date_weekday_agreement",
+    "verdict": "PASS",
+    "action": "release",
+    "evidence": {
+        "values": ["saturday"],
+        "ts": 1787118534.0,
+        "source": "algorithmic",
+        "table_version": None,
+    },
+    "correction": None,
+    "clarify_on": None,
+    "attestation_id": "3ae09266-a341-4617-a920-40cd233283df",
+}
+
+MISMATCH_RESPONSE = {
+    **PASS_RESPONSE,
+    "verdict": "MISMATCH",
+    "action": "block",
+    "correction": "saturday",
+}
+
+UNDERDETERMINED_RESPONSE = {
+    "predicate": "city_zip_candidates",
+    "verdict": "UNDERDETERMINED",
+    "action": "clarify",
+    "evidence": {
+        "values": ["94701", "94702", "94703", "94704", "94705", "94707", "94720"],
+        "ts": 1787118534.1,
+        "source": "tables:ref_postal_codes",
+        "table_version": "geonames-2026-08-19",
+    },
+    "correction": None,
+    "clarify_on": ["94701", "94702", "94703", "94704", "94705", "94707", "94720"],
+    "attestation_id": "3212fb4b-1e39-4404-8b8c-638675db8630",
+}
+
+
+# ---------------------------------------------------------------------------
+# request shape
+# ---------------------------------------------------------------------------
+
+
+class TestRequestShape:
+    def test_tuple_inputs_normalize_to_tagged_wire_shape(self, monkeypatch):
+        client, calls = make_client(monkeypatch, PASS_RESPONSE)
+        client.evidence.verify(
+            "date_weekday_agreement",
+            value="Friday",
+            inputs={"date": ("2000-01-01", "user_utterance")},
+            session_id="s-1",
+        )
+        assert calls[0]["method"] == "POST"
+        assert calls[0]["path"] == "/v1/evidence/verify"
+        assert calls[0]["body"] == {
+            "predicate": "date_weekday_agreement",
+            "claim": {"value": "Friday", "text": None},
+            "inputs": {"date": {"value": "2000-01-01", "source": "user_utterance"}},
+            "session_id": "s-1",
+        }
+
+    def test_wire_shaped_inputs_pass_through(self, monkeypatch):
+        client, calls = make_client(monkeypatch, PASS_RESPONSE)
+        client.evidence.verify(
+            "date_weekday_agreement",
+            value="Friday",
+            inputs={"date": {"value": "2000-01-01", "source": "customer_db"}},
+        )
+        assert calls[0]["body"]["inputs"]["date"]["source"] == "customer_db"
+
+    def test_untagged_input_is_rejected_locally(self):
+        with pytest.raises(ValueError, match="source tag"):
+            _normalize_inputs({"date": "2000-01-01"})
+
+    def test_batch_request_shape(self, monkeypatch):
+        client, calls = make_client(
+            monkeypatch,
+            {"results": [PASS_RESPONSE, UNDERDETERMINED_RESPONSE]},
+        )
+        results = client.evidence.verify_batch(
+            [
+                {
+                    "predicate": "date_weekday_agreement",
+                    "value": "Friday",
+                    "inputs": {"date": ("2000-01-01", "user_utterance")},
+                },
+                {
+                    "predicate": "city_zip_candidates",
+                    "value": "94720",
+                    "inputs": {
+                        "city": ("Berkeley", "user_utterance"),
+                        "state": ("CA", "user_utterance"),
+                    },
+                },
+            ]
+        )
+        assert calls[0]["path"] == "/v1/evidence/verify_batch"
+        wire = calls[0]["body"]["claims"]
+        assert wire[0]["claim"]["value"] == "Friday"
+        assert wire[1]["inputs"]["state"] == {"value": "CA", "source": "user_utterance"}
+        assert [r.verdict for r in results] == ["PASS", "UNDERDETERMINED"]
+
+
+# ---------------------------------------------------------------------------
+# response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestResponseParsing:
+    def test_pass(self, monkeypatch):
+        client, _ = make_client(monkeypatch, PASS_RESPONSE)
+        result = client.evidence.verify("date_weekday_agreement", value="Saturday")
+        assert result.passed
+        assert not result.blocked
+        assert result.action == "release"
+        assert result.values == ("saturday",)
+        assert result.attestation_id == "3ae09266-a341-4617-a920-40cd233283df"
+
+    def test_mismatch_carries_correction(self, monkeypatch):
+        client, _ = make_client(monkeypatch, MISMATCH_RESPONSE)
+        result = client.evidence.verify("date_weekday_agreement", value="Friday")
+        assert result.verdict == "MISMATCH"
+        assert result.blocked
+        assert not result.passed
+        assert result.correction == "saturday"
+
+    def test_underdetermined_carries_candidates(self, monkeypatch):
+        client, _ = make_client(monkeypatch, UNDERDETERMINED_RESPONSE)
+        result = client.evidence.verify("city_zip_candidates", value="94720")
+        assert result.verdict == "UNDERDETERMINED"
+        assert result.needs_clarification
+        assert result.clarify_on[:2] == ("94701", "94702")
+        assert result.table_version == "geonames-2026-08-19"
+        assert result.source == "tables:ref_postal_codes"
+
+
+# ---------------------------------------------------------------------------
+# failure policy — typed exceptions, never fabricated verdicts
+# ---------------------------------------------------------------------------
+
+
+class TestFailurePolicy:
+    def test_401_raises_typed_error(self, monkeypatch):
+        client, _ = make_client(monkeypatch, {"detail": "bad key"}, status=401)
+        with pytest.raises(EvidenceError) as excinfo:
+            client.evidence.verify("date_weekday_agreement", value="x")
+        assert excinfo.value.status == 401
+
+    def test_404_raises_with_server_detail(self, monkeypatch):
+        client, _ = make_client(
+            monkeypatch, {"detail": "unknown predicate 'nope'"}, status=404
+        )
+        with pytest.raises(EvidenceError, match="unknown predicate"):
+            client.evidence.verify("nope", value="x")
+
+    def test_transport_failure_raises_typed_error(self, monkeypatch):
+        client = CloudClient(api_key="sk_test", url="https://cloud.test")
+
+        def broken_request(*args, **kwargs):
+            raise CloudError("cannot reach https://cloud.test: timed out")
+
+        monkeypatch.setattr(client, "_request", broken_request)
+        with pytest.raises(EvidenceError, match="cannot reach"):
+            client.evidence.verify("date_weekday_agreement", value="x")
+
+    def test_evidence_error_is_a_cloud_error(self):
+        # One except-clause covers both: callers catch CloudError.
+        assert issubclass(EvidenceError, CloudError)
+
+    def test_non_json_body_raises(self, monkeypatch):
+        client = CloudClient(api_key="sk_test", url="https://cloud.test")
+        monkeypatch.setattr(
+            client, "_request", lambda *a, **k: (200, b"<html>proxy</html>", {})
+        )
+        with pytest.raises(EvidenceError, match="non-JSON"):
+            client.evidence.verify("date_weekday_agreement", value="x")
+
+
+# ---------------------------------------------------------------------------
+# grounding — the fed event produces the atom family
+# ---------------------------------------------------------------------------
+
+
+def _result(verdict="PASS", action="release", predicate="date_weekday_agreement"):
+    return EvidenceResult(predicate=predicate, verdict=verdict, action=action)
+
+
+class TestGrounding:
+    def test_to_event_grounds_the_atom_family(self):
+        event = _result("MISMATCH", "block").to_event(ts=3, agent="assistant")
+        valuations = ground(Trace(events=[event]))
+        v = valuations[0]
+        assert v["claim_emitted(date_weekday_agreement)"] is True
+        assert v["evidence_verdict(date_weekday_agreement, MISMATCH)"] is True
+        assert v["evidence_action(date_weekday_agreement, block)"] is True
+        assert "evidence_verdict(date_weekday_agreement, PASS)" not in v
+
+    def test_evidence_events_coexist_with_tool_calls(self):
+        trace = Trace(
+            events=[
+                Event(ts=1, agent="a", event_type="tool_call", tool="lookup"),
+                _result("PASS").to_event(ts=2, agent="a"),
+            ]
+        )
+        valuations = ground(trace)
+        assert valuations[0]["called(lookup)"] is True
+        assert valuations[1]["evidence_verdict(date_weekday_agreement, PASS)"] is True
+
+
+# ---------------------------------------------------------------------------
+# patterns
+# ---------------------------------------------------------------------------
+
+
+class TestPatterns:
+    def test_claim_requires_evidence_satisfied_by_pass(self):
+        contract = claim_requires_evidence("date_weekday_agreement")
+        trace = ground(Trace(events=[_result("PASS").to_event(ts=1)]))
+        assert evaluate(contract.formula, trace) is True
+
+    def test_claim_requires_evidence_violated_by_mismatch(self):
+        contract = claim_requires_evidence("date_weekday_agreement")
+        trace = ground(Trace(events=[_result("MISMATCH", "block").to_event(ts=1)]))
+        assert evaluate(contract.formula, trace) is False
+
+    def test_underdetermined_must_clarify(self):
+        contract = underdetermined_must_clarify("city_zip_candidates")
+        ok = ground(
+            Trace(
+                events=[
+                    _result(
+                        "UNDERDETERMINED", "clarify", "city_zip_candidates"
+                    ).to_event(ts=1)
+                ]
+            )
+        )
+        assert evaluate(contract.formula, ok) is True
+        bad = ground(
+            Trace(
+                events=[
+                    _result(
+                        "UNDERDETERMINED", "release", "city_zip_candidates"
+                    ).to_event(ts=1)
+                ]
+            )
+        )
+        assert evaluate(contract.formula, bad) is False
+
+    def test_patterns_are_registered_for_yaml_use(self):
+        from sponsio.generation.dsl_to_contract import get_available_patterns
+
+        registry = get_available_patterns()
+        assert "claim_requires_evidence" in registry
+        assert "underdetermined_must_clarify" in registry
+
+
+# ---------------------------------------------------------------------------
+# reporter output
+# ---------------------------------------------------------------------------
+
+
+def _plain(text_obj) -> str:
+    console = Console(record=True, width=200, force_terminal=False)
+    console.print(text_obj)
+    return console.export_text().strip()
+
+
+class TestReporterLines:
+    def test_pass_line(self):
+        line = render_evidence(_result("PASS", "release"))
+        assert _plain(line) == '✓ evidence "date_weekday_agreement" → PASS'
+        assert PALETTE["success"] in str(
+            line.markup if hasattr(line, "markup") else line.spans
+        )
+
+    def test_mismatch_line_shows_correction(self):
+        result = EvidenceResult(
+            predicate="date_weekday_agreement",
+            verdict="MISMATCH",
+            action="block",
+            correction="saturday",
+        )
+        assert (
+            _plain(render_evidence(result))
+            == '✗ evidence "date_weekday_agreement" → MISMATCH · correction "saturday"'
+        )
+
+    def test_underdetermined_line_caps_candidates(self):
+        result = EvidenceResult(
+            predicate="city_zip_candidates",
+            verdict="UNDERDETERMINED",
+            action="clarify",
+            clarify_on=tuple(f"9470{i}" for i in range(9)),
+        )
+        rendered = _plain(render_evidence(result))
+        assert rendered.startswith('⚠ evidence "city_zip_candidates" → UNDERDETERMINED')
+        assert "94700, 94701, 94702, 94703, 94704 +4 more" in rendered
+
+    def test_reporter_prints_through_its_console_with_verbosity_gate(self):
+        reporter = TerminalReporter(verbosity=0, colorize=False)
+        recording = Console(record=True, width=200, force_terminal=False)
+        reporter._console = recording
+        reporter.report_evidence(_result("PASS"))  # suppressed at v0
+        reporter.report_evidence(_result("MISMATCH", "block"))
+        output = recording.export_text()
+        assert "PASS" not in output
+        assert "MISMATCH" in output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -498,3 +498,83 @@ agents:
 
         guard = sponsio.Sponsio(config=str(multi_agent_yaml), agent_id="alice")
         assert guard.agent_id == "alice"
+
+
+# --- cloud checkout must never rebind an explicit agent to a sibling -------
+
+_CLOUD_DOC_WITH_ONLY_THE_SAMPLE = """\
+version: '1'
+agents:
+  support-sample:
+    contracts:
+      - G: {nl: "G( tool `a` must precede `b` )"}
+        desc: sample rule
+"""
+
+_LOCAL_DOC_FOR_ACME = """\
+version: '1'
+agents:
+  acme:
+    contracts:
+      - G: {nl: "G( tool `x` must precede `y` )"}
+        desc: acme rule
+"""
+
+
+def _fake_cloud_checkout(tmp_path, monkeypatch, text):
+    doc = tmp_path / "cloud.yaml"
+    doc.write_text(text)
+    import sponsio.cloud.ref as ref
+
+    monkeypatch.setattr(ref, "resolve_config_ref", lambda value, **kw: doc)
+    return doc
+
+
+def test_cloud_ref_uses_the_local_book_when_the_cloud_has_none_for_this_agent(
+    tmp_path, monkeypatch
+):
+    """A tenant's first real agent starts beside the seeded welcome sample.
+    The project book then has exactly one agent — the sample — and the
+    old single-agent fallback bound the user's agent to it: it ran under
+    the sample's rules and reported as the sample. Under a cloud ref an
+    explicit agent_id is never rebound."""
+    import sponsio
+
+    _fake_cloud_checkout(tmp_path, monkeypatch, _CLOUD_DOC_WITH_ONLY_THE_SAMPLE)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sponsio.yaml").write_text(_LOCAL_DOC_FOR_ACME)
+
+    guard = sponsio.Sponsio(
+        config="sponsio://proj", agent_id="acme", init_banner=False, verbose=False
+    )
+    assert guard.agent_id == "acme"
+
+
+def test_cloud_ref_without_a_book_for_this_agent_stops_with_the_fix(
+    tmp_path, monkeypatch
+):
+    import sponsio
+
+    _fake_cloud_checkout(tmp_path, monkeypatch, _CLOUD_DOC_WITH_ONLY_THE_SAMPLE)
+    monkeypatch.chdir(tmp_path)  # no local sponsio.yaml here
+
+    with pytest.raises(ValueError, match="no rulebook for agent 'acme'"):
+        sponsio.Sponsio(
+            config="sponsio://proj", agent_id="acme", init_banner=False, verbose=False
+        )
+
+
+def test_a_local_single_agent_file_still_rebinds_a_mismatched_agent_id(
+    tmp_path, monkeypatch
+):
+    """The convenience stays for a local file: one agent block, and a
+    mismatched agent_id (a demo's hardcoded id) picks it, with a warning."""
+    import sponsio
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sponsio.yaml").write_text(_LOCAL_DOC_FOR_ACME)
+    with pytest.warns(UserWarning):
+        guard = sponsio.Sponsio(
+            config="sponsio.yaml", agent_id="typo", init_banner=False, verbose=False
+        )
+    assert guard.agent_id == "acme"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -487,11 +487,13 @@ agents:
     def test_multi_agent_mismatch_still_errors(self, multi_agent_yaml):
         # Multi-agent: there's no unambiguous fallback, raise so the
         # user fixes the call site.  Error message lists the
-        # available agents so they don't have to grep the yaml.
+        # available agents so they don't have to grep the yaml, and
+        # never tells someone who named an agent to name one.
         import sponsio
 
-        with pytest.raises(ValueError, match=r"multiple agents.*alice.*bob"):
+        with pytest.raises(ValueError, match=r"no rulebook in.*alice.*bob") as exc:
             sponsio.Sponsio(config=str(multi_agent_yaml), agent_id="not_alice_or_bob")
+        assert "specify a valid agent_id" not in str(exc.value)
 
     def test_multi_agent_explicit_match_works(self, multi_agent_yaml):
         import sponsio

--- a/tests/test_evidence_middleware.py
+++ b/tests/test_evidence_middleware.py
@@ -413,7 +413,7 @@ class TestOpenAIEnforcement:
             fake_async_create,
         )
 
-        guard = openai_integration.patch_openai(
+        openai_integration.patch_openai(
             contracts=[],
             evidence=make_config(FakeEvidenceClient([_mismatch(), _mismatch()])),
         )
@@ -443,7 +443,7 @@ class TestOpenAIEnforcement:
             "create",
             lambda self, *a, **k: _mock_response("{}"),
         )
-        guard = openai_integration.patch_openai(
+        openai_integration.patch_openai(
             contracts=[], evidence=make_config(FakeEvidenceClient())
         )
         try:

--- a/tests/test_evidence_middleware.py
+++ b/tests/test_evidence_middleware.py
@@ -1,0 +1,482 @@
+"""Phase 2: evidence middleware at observe_llm_call + openai enforcement.
+
+All HTTP is mocked at the EvidenceClient boundary (a fake with canned
+EvidenceResults); no network anywhere. Verdict/action words in the canned
+results are the server's vocabulary — the middleware computes none of
+them.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from sponsio.cloud.evidence import EvidenceClient, EvidenceError, EvidenceResult
+from sponsio.integrations.base import BaseGuard
+from sponsio.integrations.evidence_middleware import (
+    EvidenceConfig,
+    EvidenceConfigError,
+    extract_claims,
+    format_block_notice,
+    format_clarify_notice,
+    structured_sources,
+)
+
+# ---------------------------------------------------------------------------
+# canned server verdicts
+# ---------------------------------------------------------------------------
+
+
+def _pass(predicate="date_weekday_agreement"):
+    return EvidenceResult(predicate=predicate, verdict="PASS", action="release")
+
+
+def _mismatch(predicate="date_weekday_agreement", correction="saturday"):
+    return EvidenceResult(
+        predicate=predicate,
+        verdict="MISMATCH",
+        action="block",
+        correction=correction,
+    )
+
+
+def _underdetermined(predicate="city_zip_candidates", n=7):
+    return EvidenceResult(
+        predicate=predicate,
+        verdict="UNDERDETERMINED",
+        action="clarify",
+        clarify_on=tuple(f"9470{i}" for i in range(n)),
+    )
+
+
+class FakeEvidenceClient(EvidenceClient):
+    """Records verify_batch calls; replays canned results or raises."""
+
+    def __init__(self, results=None, error: Exception | None = None):
+        # No CloudClient: nothing here does I/O.
+        self.calls: list[list[dict]] = []
+        self._results = list(results or [])
+        self._error = error
+
+    def verify_batch(self, claims, *, session_id=None):
+        self.calls.append([dict(c) for c in claims])
+        if self._error is not None:
+            raise self._error
+        return list(self._results)
+
+
+WEEKDAY_CLAIM = {
+    "predicate": "date_weekday_agreement",
+    "claim_field": "weekday",
+    "inputs": {"date": {"field": "date", "source": "model_output"}},
+}
+ZIP_CLAIM = {
+    "predicate": "city_zip_candidates",
+    "claim_field": "zip_code",
+    "inputs": {
+        "city": {"field": "city", "source": "model_output"},
+        "state": {"field": "state", "source": "model_output"},
+    },
+}
+
+
+def make_config(client, claims=(WEEKDAY_CLAIM,), on_error="block"):
+    return EvidenceConfig.from_value(
+        {"client": client, "on_error": on_error, "claims": list(claims)}
+    )
+
+
+def make_guard(client, claims=(WEEKDAY_CLAIM,), on_error="block") -> BaseGuard:
+    return BaseGuard(
+        contracts=[],
+        verbose=False,
+        init_banner=False,
+        auto_summary=False,
+        evidence=make_config(client, claims, on_error),
+    )
+
+
+WEEKDAY_JSON = json.dumps({"weekday": "Friday", "date": "2000-01-01"})
+
+
+# ---------------------------------------------------------------------------
+# config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestConfigParsing:
+    def test_defaults(self):
+        config = make_config(FakeEvidenceClient())
+        assert config.on_error == "block"  # fail closed by default
+        assert config.claims[0].predicate == "date_weekday_agreement"
+        assert config.claims[0].inputs["date"].source == "model_output"
+
+    def test_config_instance_passes_through(self):
+        config = make_config(FakeEvidenceClient())
+        assert EvidenceConfig.from_value(config) is config
+
+    def test_bad_on_error_rejected(self):
+        with pytest.raises(EvidenceConfigError, match="on_error"):
+            make_config(FakeEvidenceClient(), on_error="shrug")
+
+    def test_claim_without_predicate_rejected(self):
+        with pytest.raises(EvidenceConfigError, match="predicate"):
+            make_config(FakeEvidenceClient(), claims=[{"claim_field": "x"}])
+
+    def test_claim_without_claim_field_rejected(self):
+        with pytest.raises(EvidenceConfigError, match="claim_field"):
+            make_config(FakeEvidenceClient(), claims=[{"predicate": "p"}])
+
+    def test_input_without_source_rejected(self):
+        with pytest.raises(EvidenceConfigError, match="'field' and 'source'"):
+            make_config(
+                FakeEvidenceClient(),
+                claims=[
+                    {
+                        "predicate": "p",
+                        "claim_field": "x",
+                        "inputs": {"date": {"field": "date"}},
+                    }
+                ],
+            )
+
+    def test_malformed_config_fails_at_guard_construction(self):
+        with pytest.raises(EvidenceConfigError):
+            BaseGuard(
+                contracts=[],
+                verbose=False,
+                init_banner=False,
+                auto_summary=False,
+                evidence={"on_error": "nope", "claims": []},
+            )
+
+
+# ---------------------------------------------------------------------------
+# extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtraction:
+    def test_from_json_content(self):
+        config = make_config(FakeEvidenceClient())
+        claims = extract_claims(config, structured_sources(WEEKDAY_JSON, None))
+        assert len(claims) == 1
+        assert claims[0].value == "Friday"
+        assert claims[0].wire == {
+            "predicate": "date_weekday_agreement",
+            "value": "Friday",
+            "inputs": {"date": ("2000-01-01", "model_output")},
+        }
+
+    def test_from_tool_call_args(self):
+        config = make_config(FakeEvidenceClient(), claims=[ZIP_CLAIM])
+        sources = structured_sources(
+            "plain prose, not JSON",
+            [{"zip_code": "94720", "city": "Berkeley", "state": "CA"}],
+        )
+        claims = extract_claims(config, sources)
+        assert len(claims) == 1
+        assert claims[0].wire["inputs"]["city"] == ("Berkeley", "model_output")
+
+    def test_absent_claim_field_is_no_claim(self):
+        config = make_config(FakeEvidenceClient())
+        claims = extract_claims(
+            config, structured_sources(json.dumps({"other": 1}), None)
+        )
+        assert claims == []
+
+    def test_non_json_content_and_no_tool_args_is_no_claim(self):
+        config = make_config(FakeEvidenceClient())
+        assert extract_claims(config, structured_sources("hello world", None)) == []
+
+    def test_json_content_wins_over_tool_args(self):
+        config = make_config(FakeEvidenceClient())
+        sources = structured_sources(
+            WEEKDAY_JSON, [{"weekday": "Sunday", "date": "1999-12-31"}]
+        )
+        claims = extract_claims(config, sources)
+        assert claims[0].value == "Friday"  # content JSON has precedence
+
+    def test_missing_input_field_sends_claim_without_that_input(self):
+        config = make_config(FakeEvidenceClient())
+        claims = extract_claims(
+            config, structured_sources(json.dumps({"weekday": "Friday"}), None)
+        )
+        assert claims[0].wire["inputs"] == {}  # resolver will answer UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# observe_llm_call folding
+# ---------------------------------------------------------------------------
+
+
+class TestObserveLLMCallFolding:
+    def test_verify_batch_called_once_per_response(self):
+        client = FakeEvidenceClient([_pass(), _underdetermined()])
+        guard = make_guard(client, claims=(WEEKDAY_CLAIM, ZIP_CLAIM))
+        content = json.dumps(
+            {
+                "weekday": "Saturday",
+                "date": "2000-01-01",
+                "zip_code": "94720",
+                "city": "Berkeley",
+                "state": "CA",
+            }
+        )
+        result = guard.observe_llm_call(response=content)
+        assert len(client.calls) == 1
+        assert len(client.calls[0]) == 2  # both claims in the one batch
+        assert len(result.evidence_claims) == 2
+
+    def test_block_folds_into_stopping_check_result(self):
+        client = FakeEvidenceClient([_mismatch()])
+        guard = make_guard(client)
+        result = guard.observe_llm_call(response=WEEKDAY_JSON)
+        assert result.evidence_stopped is True
+        assert result.allowed is False
+        assert result.stop_original is True  # Phase-1 canonical predicate
+        assert any(
+            v.rule_id == "evidence:date_weekday_agreement"
+            for v in result.det_violations
+        )
+
+    def test_pass_does_not_stop(self):
+        client = FakeEvidenceClient([_pass()])
+        guard = make_guard(client)
+        result = guard.observe_llm_call(response=WEEKDAY_JSON)
+        assert result.evidence_stopped is False
+        assert result.stop_original is False
+        assert result.allowed is True
+
+    def test_clarify_carries_candidates_and_does_not_stop(self):
+        client = FakeEvidenceClient([_underdetermined()])
+        guard = make_guard(client, claims=(ZIP_CLAIM,))
+        content = json.dumps({"zip_code": "94720", "city": "Berkeley", "state": "CA"})
+        result = guard.observe_llm_call(response=content)
+        assert result.evidence_stopped is False
+        assert result.stop_original is False
+        clarifications = result.evidence_clarifications
+        assert len(clarifications) == 1
+        assert clarifications[0].result.clarify_on[:2] == ("94700", "94701")
+
+    def test_on_error_block_stops(self):
+        client = FakeEvidenceClient(error=EvidenceError("cannot reach cloud"))
+        guard = make_guard(client, on_error="block")
+        result = guard.observe_llm_call(response=WEEKDAY_JSON)
+        assert result.evidence_stopped is True
+        assert result.stop_original is True
+        assert "cannot reach cloud" in (result.evidence_error or "")
+
+    def test_on_error_allow_releases_but_records_error(self):
+        client = FakeEvidenceClient(error=EvidenceError("cannot reach cloud"))
+        guard = make_guard(client, on_error="allow")
+        result = guard.observe_llm_call(response=WEEKDAY_JSON)
+        assert result.evidence_stopped is False
+        assert result.stop_original is False
+        assert "cannot reach cloud" in (result.evidence_error or "")
+
+    def test_verdicts_are_fed_into_the_trace_as_evidence_events(self):
+        client = FakeEvidenceClient([_mismatch()])
+        guard = make_guard(client)
+        guard.observe_llm_call(response=WEEKDAY_JSON)
+        evidence_events = [
+            e for e in guard._monitor.trace.events if e.event_type == "evidence"
+        ]
+        assert len(evidence_events) == 1
+        assert evidence_events[0].key == "date_weekday_agreement"
+        assert evidence_events[0].args == {"verdict": "MISMATCH", "action": "block"}
+
+    def test_no_claims_means_no_batch_call(self):
+        client = FakeEvidenceClient([_pass()])
+        guard = make_guard(client)
+        result = guard.observe_llm_call(response="free text, nothing structured")
+        assert client.calls == []
+        assert result.evidence_claims == []
+        assert result.evidence_stopped is False
+
+    def test_unconfigured_guard_is_unchanged(self):
+        guard = BaseGuard(
+            contracts=[], verbose=False, init_banner=False, auto_summary=False
+        )
+        result = guard.observe_llm_call(response=WEEKDAY_JSON)
+        assert result.allowed is True
+        assert result.evidence_claims == []
+        assert result.evidence_error is None
+        assert result.evidence_stopped is False
+        assert (
+            len([e for e in guard._monitor.trace.events if e.event_type == "evidence"])
+            == 0
+        )
+
+
+# ---------------------------------------------------------------------------
+# openai enforcement (sync + async), SDK patched — mocked transport
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(content: str):
+    message = MagicMock()
+    message.content = content
+    message.tool_calls = None
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = None
+    return response
+
+
+class TestOpenAIEnforcement:
+    def _guard(self, client, claims=(WEEKDAY_CLAIM,)):
+        from sponsio.integrations.openai import OpenAIGuard
+
+        return OpenAIGuard(
+            contracts=[],
+            verbose=False,
+            init_banner=False,
+            auto_summary=False,
+            evidence=make_config(client, claims),
+        )
+
+    def test_block_rewrites_assistant_text(self):
+        guard = self._guard(FakeEvidenceClient([_mismatch()]))
+        response = _mock_response(WEEKDAY_JSON)
+        results = guard.check_response(response)
+        assert not any(r.stop_original for r in results)  # no tool calls
+        rewritten = guard._apply_evidence_notices(response)
+        text = rewritten.choices[0].message.content
+        assert text.startswith("[BLOCKED] claim 'weekday'=Friday failed verification")
+        assert "evidence says: saturday" in text
+
+    def test_clarify_rewrites_with_question_capped_at_five(self):
+        guard = self._guard(
+            FakeEvidenceClient([_underdetermined(n=7)]), claims=(ZIP_CLAIM,)
+        )
+        response = _mock_response(
+            json.dumps({"zip_code": "94720", "city": "Berkeley", "state": "CA"})
+        )
+        guard.check_response(response)
+        text = guard._apply_evidence_notices(response).choices[0].message.content
+        assert "ambiguous" in text
+        assert "94700, 94701, 94702, 94703, 94704" in text
+        assert "(+2 more)" in text
+        assert "94706" not in text
+
+    def test_error_block_notice(self):
+        guard = self._guard(FakeEvidenceClient(error=EvidenceError("down")))
+        response = _mock_response(WEEKDAY_JSON)
+        guard.check_response(response)
+        text = guard._apply_evidence_notices(response).choices[0].message.content
+        assert "verification unavailable" in text
+        assert "on_error=block" in text
+
+    def test_unconfigured_guard_leaves_response_untouched(self):
+        from sponsio.integrations.openai import OpenAIGuard
+
+        guard = OpenAIGuard(
+            contracts=[], verbose=False, init_banner=False, auto_summary=False
+        )
+        response = _mock_response(WEEKDAY_JSON)
+        guard.check_response(response)
+        rewritten = guard._apply_evidence_notices(response)
+        assert rewritten is response
+        assert rewritten.choices[0].message.content == WEEKDAY_JSON
+
+    def test_patched_sync_and_async_paths(self, monkeypatch):
+        openai = pytest.importorskip("openai")
+        from sponsio.integrations import openai as openai_integration
+
+        response = _mock_response(WEEKDAY_JSON)
+        monkeypatch.setattr(
+            openai.resources.chat.completions.Completions,
+            "create",
+            lambda self, *a, **k: response,
+        )
+
+        async def fake_async_create(self, *a, **k):
+            return _mock_response(WEEKDAY_JSON)
+
+        monkeypatch.setattr(
+            openai.resources.chat.completions.AsyncCompletions,
+            "create",
+            fake_async_create,
+        )
+
+        guard = openai_integration.patch_openai(
+            contracts=[],
+            evidence=make_config(FakeEvidenceClient([_mismatch(), _mismatch()])),
+        )
+        try:
+            out = openai.resources.chat.completions.Completions.create(
+                MagicMock(), model="gpt-x", messages=[]
+            )
+            assert "[BLOCKED]" in out.choices[0].message.content
+
+            import asyncio
+
+            out_async = asyncio.run(
+                openai.resources.chat.completions.AsyncCompletions.create(
+                    MagicMock(), model="gpt-x", messages=[]
+                )
+            )
+            assert "[BLOCKED]" in out_async.choices[0].message.content
+        finally:
+            openai_integration.unpatch_openai()
+
+    def test_stream_with_evidence_raises_not_implemented(self, monkeypatch):
+        openai = pytest.importorskip("openai")
+        from sponsio.integrations import openai as openai_integration
+
+        monkeypatch.setattr(
+            openai.resources.chat.completions.Completions,
+            "create",
+            lambda self, *a, **k: _mock_response("{}"),
+        )
+        guard = openai_integration.patch_openai(
+            contracts=[], evidence=make_config(FakeEvidenceClient())
+        )
+        try:
+            with pytest.raises(NotImplementedError, match="stream"):
+                openai.resources.chat.completions.Completions.create(
+                    MagicMock(), model="gpt-x", messages=[], stream=True
+                )
+        finally:
+            openai_integration.unpatch_openai()
+
+
+# ---------------------------------------------------------------------------
+# notice formatting
+# ---------------------------------------------------------------------------
+
+
+class TestNotices:
+    def test_block_notice_without_correction(self):
+        from sponsio.integrations.evidence_middleware import VerifiedClaim
+
+        claim = VerifiedClaim(
+            spec=make_config(FakeEvidenceClient()).claims[0],
+            value="Friday",
+            result=EvidenceResult(
+                predicate="date_weekday_agreement",
+                verdict="NO_EVIDENCE",
+                action="block",
+            ),
+        )
+        text = format_block_notice([claim])
+        assert "NO_EVIDENCE" in text
+        assert "evidence says" not in text
+
+    def test_clarify_notice_under_limit_has_no_more_suffix(self):
+        from sponsio.integrations.evidence_middleware import VerifiedClaim
+
+        claim = VerifiedClaim(
+            spec=EvidenceConfig.from_value(
+                {"client": FakeEvidenceClient(), "claims": [ZIP_CLAIM]}
+            ).claims[0],
+            value="94720",
+            result=_underdetermined(n=3),
+        )
+        text = format_clarify_notice([claim])
+        assert "more" not in text

--- a/tests/test_evidence_middleware.py
+++ b/tests/test_evidence_middleware.py
@@ -286,7 +286,16 @@ class TestObserveLLMCallFolding:
         ]
         assert len(evidence_events) == 1
         assert evidence_events[0].key == "date_weekday_agreement"
-        assert evidence_events[0].args == {"verdict": "MISMATCH", "action": "block"}
+        # The event carries the display enrichment (claim/correction/source/
+        # values) alongside verdict/action; grounding reads only the latter.
+        assert evidence_events[0].args == {
+            "verdict": "MISMATCH",
+            "action": "block",
+            "claim": "Friday",
+            "correction": "saturday",
+            "source": None,
+            "values": [],
+        }
 
     def test_no_claims_means_no_batch_call(self):
         client = FakeEvidenceClient([_pass()])

--- a/tests/test_extraction_coverage.py
+++ b/tests/test_extraction_coverage.py
@@ -1,0 +1,43 @@
+"""Coverage ledger for the evidence extractor (evals/extraction_coverage).
+
+Pins the extractor's current blind spots so they are documented, so a
+regression can't quietly add one, and so an improvement (fence-stripping,
+nested lookup, field aliases, a free-text extractor) forces a conscious
+update to this list rather than passing unnoticed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from evals.extraction_coverage import run_eval  # noqa: E402
+
+# The claim-present-but-not-surfaced shapes as of today. Each is a way a
+# real model can state a configured claim and have it go UNVERIFIED.
+# Shrinking this set is a coverage improvement — update it deliberately.
+_KNOWN_BLIND_SPOTS = {
+    "JSON in ```json fence",
+    "JSON with prose prefix",
+    "JSON array, not object",
+    "nested under a key",
+    "tool args as JSON string",
+    "prose only",
+    "field-name variant",
+}
+
+
+def test_extractor_surfaces_the_clean_structured_shapes():
+    rows = {r["shape"]: r for r in run_eval()["rows"]}
+    assert rows["clean JSON object"]["surfaced"]
+    assert rows["tool_call args dict"]["surfaced"]
+
+
+def test_blind_spots_match_the_ledger():
+    blind = set(run_eval()["blind_spots"])
+    assert blind == _KNOWN_BLIND_SPOTS, (
+        "extractor coverage changed — update _KNOWN_BLIND_SPOTS. "
+        f"added={blind - _KNOWN_BLIND_SPOTS} removed={_KNOWN_BLIND_SPOTS - blind}"
+    )

--- a/tests/test_stopping_set.py
+++ b/tests/test_stopping_set.py
@@ -1,0 +1,198 @@
+"""Canonical stopping set + stop_original gating regressions.
+
+Phase 1 of fix/enforcement-and-evidence-mw. Two properties are pinned:
+
+1. There is exactly ONE definition of "this verdict stops the original
+   call" (``STOPPING_ACTIONS`` next to ``CheckResult``), and every
+   consumer — ``CheckResult.stop_original``, the MCP proxy, the bridge
+   span projection — agrees with it for every verdict value.
+2. A ``redirected`` verdict now stops the original call in every adapter
+   that has no substitution path (openai, google_adk sync, langgraph
+   callback/node checks, guard_stdin). Before this fix those sites gated
+   on ``.blocked``, which is False on a redirect — fail open.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from sponsio.integrations.base import (
+    STOPPING_ACTIONS,
+    CheckResult,
+    is_stopping_action,
+)
+from sponsio.runtime.strategies import EnforcementResult
+
+ALL_ACTIONS = (
+    "blocked",
+    "escalated",
+    "redirected",
+    "warned",
+    "observed",
+    "retrying",
+    "allowed",
+)
+
+
+def _violation(action: str) -> EnforcementResult:
+    return EnforcementResult(
+        action=action,
+        message=f"det verdict: {action}",
+        fallback_action="safe_tool" if action == "redirected" else None,
+    )
+
+
+def _check_result(action: str) -> CheckResult:
+    return CheckResult(
+        allowed=action != "blocked",
+        det_violations=[_violation(action)],
+        redirected_to="safe_tool" if action == "redirected" else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# one canonical definition
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalStoppingSet:
+    def test_membership(self):
+        # ``escalated`` is deliberately absent: the monitor's default
+        # EscalateToHuman verdict for unfired assumptions is vacuous, and
+        # stopping on it would refuse every action while a conditional
+        # contract's assumption is simply not yet satisfied.
+        assert STOPPING_ACTIONS == frozenset({"blocked", "redirected"})
+
+    def test_stop_original_agrees_for_every_verdict_value(self):
+        for action in ALL_ACTIONS:
+            assert _check_result(action).stop_original == is_stopping_action(action), (
+                action
+            )
+
+    def test_bridge_consumes_the_canonical_set(self):
+        from sponsio.bridge.spans import STOPPING_ACTIONS as bridge_set
+
+        assert bridge_set is STOPPING_ACTIONS
+
+    def test_mcp_agrees_for_every_verdict_value(self):
+        from sponsio.integrations.mcp import MCPContractProxy
+        from sponsio.models.system import System
+
+        for action in ALL_ACTIONS:
+            client = MagicMock()
+
+            async def fake_call_tool(tool_name, arguments=None):
+                return {"ok": True}
+
+            client.call_tool = fake_call_tool
+            proxy = MCPContractProxy(
+                client, System(name="t", contracts=[]), tag_outputs=False
+            )
+            proxy._monitor = MagicMock()
+            proxy._monitor.check_action.return_value = [_violation(action)]
+            result = asyncio.run(proxy.call_tool("send_email", {"to": "x"}))
+            stopped = isinstance(result, dict) and result.get("error") == (
+                "Blocked by behavioral contract"
+            )
+            assert stopped == is_stopping_action(action), action
+
+
+# ---------------------------------------------------------------------------
+# per-adapter regressions: redirected must stop the original call
+# ---------------------------------------------------------------------------
+
+
+def _redirected_result() -> CheckResult:
+    return _check_result("redirected")
+
+
+class TestRedirectStopsOriginal:
+    def test_openai_redirect_strips_tool_call_and_fires_callback(self, monkeypatch):
+        from sponsio.integrations.openai import OpenAIGuard
+
+        seen = []
+        guard = OpenAIGuard(
+            contracts=[], verbose=False, on_violation=lambda n, a, c: seen.append(n)
+        )
+        monkeypatch.setattr(
+            guard, "guard_before", lambda tool_name, args=None: _redirected_result()
+        )
+
+        message = MagicMock()
+        message.content = "transferring now"
+        tool_call = MagicMock()
+        tool_call.function.name = "wire_funds"
+        tool_call.function.arguments = '{"amount": 1}'
+        tool_call.id = "call_1"
+        message.tool_calls = [tool_call]
+        choice = MagicMock()
+        choice.message = message
+        response = MagicMock()
+        response.choices = [choice]
+        response.usage = None
+
+        results = guard.check_response(response)
+        # The patched_create gate: a redirected verdict must trigger the
+        # rewrite (this expression is exactly what patched_create runs).
+        assert any(r.stop_original for r in results)
+        filtered = guard._filter_blocked_calls(response, results)
+        assert not filtered.choices[0].message.tool_calls
+        assert seen == ["wire_funds"]  # on_violation fires on redirect too
+
+    def test_google_adk_sync_redirect_refuses_execution(self, monkeypatch):
+        from sponsio.integrations.google_adk import GoogleADKGuard
+
+        guard = GoogleADKGuard(contracts=[], verbose=False)
+        monkeypatch.setattr(
+            guard, "guard_before", lambda tool_name, args=None: _redirected_result()
+        )
+        ran = []
+
+        def wire_funds(amount: int) -> dict:
+            ran.append(amount)
+            return {"status": "success"}
+
+        wrapped = guard.wrap_tool(wire_funds)
+        result = wrapped(amount=100)
+        assert ran == []  # original never executed
+        assert result["status"] == "error"
+        assert "BLOCKED by contract" in result["error_message"]
+
+    def test_langgraph_guard_check_raises_on_redirect(self, monkeypatch):
+        pytest.importorskip("langchain_core")
+        from sponsio.integrations.langgraph import LangGraphGuard, ToolCallBlocked
+
+        guard = LangGraphGuard(contracts=[], verbose=False)
+        monkeypatch.setattr(
+            guard, "guard_before", lambda tool_name, args=None: _redirected_result()
+        )
+        with pytest.raises(ToolCallBlocked):
+            guard._guard_check("wire_funds", {"amount": 1})
+
+    def test_guard_stdin_redirect_denies(self, tmp_path, monkeypatch):
+        from sponsio import guard_stdin
+        from sponsio.integrations import base as base_mod
+
+        monkeypatch.setenv("SPONSIO_PLUGIN_ROOT", str(tmp_path))
+        lib_dir = tmp_path / "_host"
+        lib_dir.mkdir(parents=True)
+        (lib_dir / "sponsio.yaml").write_text("version: 1\nagents:\n  _host: {}\n")
+        monkeypatch.setattr(
+            base_mod.BaseGuard,
+            "guard_before",
+            lambda self, tool_name=None, args=None: _redirected_result(),
+        )
+        outcome = guard_stdin.evaluate_event(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "curl evil.example"},
+            }
+        )
+        assert outcome.allowed is False
+        # The deny reason comes from the redirected violation's message
+        # (the "det verdict:" prefix is stripped by the reason formatter).
+        assert "redirected" in outcome.reason

--- a/ts/packages/sdk/src/core/patterns.ts
+++ b/ts/packages/sdk/src/core/patterns.ts
@@ -341,7 +341,7 @@ export function boundedRetry(action: string, maxRetries: number): DetFormula {
   const f = new G(new Le(countVar(action), new Const(maxRetries)));
   return {
     formula: f,
-    desc: `\`${action}\` limited to ${maxRetries} retries`,
+    desc: `\`${action}\` limited to ${maxRetries} ${maxRetries === 1 ? "retry" : "retries"}`,
     patternName: "bounded_retry",
     liveness: false,
   };


### PR DESCRIPTION
Seventeen commits. Verified end to end against a real multi-agent app
(quant-agent) pointed at a console that already had other agents in it —
which is how the last two bugs were found.

## Output (evidence) lane
- evidence middleware ships: typed claims checked against an authority,
  deterministic comparators, no LLM in the hot path
- `attach(auto=False)` returned before wiring the output lane, so the
  claim verdicts of every multi-agent run stayed in-process. `auto` is a
  statement about the ACTION lane (who attributes tool steps); it never
  meant "drop my evidence". A run whose model stated something false
  rendered as a clean trace.

## Enforcement
- canonical stopping set behind `stop_original`
- shadow-mode assumption spans record what actually happened

## Cloud checkout
- a checkout that does not carry the agent you named falls back to
  ./sponsio.yaml whenever that file defines it, not only for `sponsio://`
  refs. A project's first EXTRA agent gets a 200 with the siblings'
  books, so nothing 404s, nothing gets pushed, and the run used to die.
- an explicit agent_id is never silently rebound to a sibling
- the multi-agent error stopped telling a caller who passed an agent_id
  to pass an agent_id

## Bridge
- 64-bit run ids (a 32-bit id silently merged two runs)
- send coalescing (a long run uploaded the run squared, then went silent)
- a run names its own book, not the whole project's

## Also
- singular/plural agreement in rate_limit and bounded_retry labels
  (Python and TypeScript kept in step)

2536 passed, 26 skipped. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)