### PR TITLE
fix(core): an enforcing run never starts with a rule missing

### DIFF
--- a/sponsio/config.py
+++ b/sponsio/config.py
@@ -1619,7 +1619,26 @@ def _compile_structured(entry: ConstraintEntry) -> Any:
             coerced_args.append(int(a))
         else:
             coerced_args.append(a)
-    compiled = fn(*coerced_args)
+    try:
+        compiled = fn(*coerced_args)
+    except TypeError as e:
+        # Wrong arity in the YAML: the raw TypeError names the factory's
+        # missing parameter but nothing about the contract the user wrote,
+        # so the traceback lands them in config.py with no way back to the
+        # offending block. Say which contract, what it passed, and what the
+        # pattern actually takes.
+        import inspect
+
+        try:
+            sig = f"{entry.pattern}{inspect.signature(fn)}"
+        except (TypeError, ValueError):  # pragma: no cover — builtins only
+            sig = entry.pattern
+        label = f" ({entry.desc})" if entry.desc else ""
+        raise ConfigError(
+            f"Pattern '{entry.pattern}'{label} was given "
+            f"{len(coerced_args)} argument(s): {coerced_args!r}. "
+            f"It takes: {sig}. ({e})"
+        ) from e
     # ``desc:`` from the YAML overrides the pattern factory's default
     # desc. useful when one contract has multiple structured clauses
     # that should share a clearer per-clause label, or when the
@@ -1770,8 +1789,15 @@ def _resolve_strict_compile(mode: str | None) -> bool:
 
     1. ``SPONSIO_STRICT_COMPILE`` env (``1`` / ``true`` / ``yes`` → strict;
        ``0`` / ``false`` / ``no`` → non-strict).  User has the final say.
-    2. ``defaults.mode`` from yaml: ``enforce`` → strict, anything else
+    2. The run's effective mode: ``enforce`` → strict, anything else
        (``observe`` / unset) → non-strict.
+
+    ``mode`` must be the *effective* mode, resolved the same way the
+    runtime resolves it — the ctor argument and ``SPONSIO_MODE``
+    included. Reading one yaml field instead meant a project that said
+    enforce anywhere else (``Sponsio(mode="enforce")``, a bare top-level
+    ``mode:``, ``runtime.mode``) loaded non-strict and dropped a broken
+    rule with only a warning, while believing it was enforcing.
 
     The intent: enforce mode defaults to strict because a silently-skipped
     contract becomes a security gap in production; observe mode defaults
@@ -1837,7 +1863,9 @@ def _synthesize_tool_policy_contract(
     return {"guarantee": formula, "desc": desc}
 
 
-def config_to_guard_kwargs(config: SponsoConfig, agent_id: str) -> dict[str, Any]:
+def config_to_guard_kwargs(
+    config: SponsoConfig, agent_id: str, mode: str | None = None
+) -> dict[str, Any]:
     """Extract BaseGuard constructor kwargs for a specific agent.
 
     Returns a dict with a ``contracts`` kwarg shaped like the Python
@@ -1848,6 +1876,11 @@ def config_to_guard_kwargs(config: SponsoConfig, agent_id: str) -> dict[str, Any
     Args:
         config: Parsed SponsoConfig.
         agent_id: Which agent's contracts to extract.
+        mode: The already-resolved effective mode, when the caller knows
+            it. It decides whether a contract that fails to compile is a
+            hard error or a skipped-with-warning. Callers who only have
+            the yaml (doctor, ``sponsio explain``) leave it None and the
+            yaml's own mode fields answer.
 
     Returns:
         Dict with keys: agent_id, contracts, plus defaults.
@@ -1871,7 +1904,12 @@ def config_to_guard_kwargs(config: SponsoConfig, agent_id: str) -> dict[str, Any
         else None
     )
 
-    strict = _resolve_strict_compile(config.defaults.get("mode"))
+    strict = _resolve_strict_compile(
+        mode
+        or config.runtime.mode
+        or config.defaults.get("mode")
+        or config.top_level_mode
+    )
 
     contract_dicts: list[dict] = []
     skipped: list[tuple[str, str]] = []
@@ -1913,15 +1951,27 @@ def config_to_guard_kwargs(config: SponsoConfig, agent_id: str) -> dict[str, Any
                 entry["mode"] = ce.mode
             contract_dicts.append(entry)
         except ConfigError as exc:
-            # In strict mode (enforce default, or SPONSIO_STRICT_COMPILE=1)
-            # any compile failure aborts loading. silently shipping a
-            # broken enforcement rule in production is worse than the
-            # crash.  In non-strict mode (observe default) skip the bad
-            # contract and surface a single batched warning so the rest of
-            # the yaml stays usable while reviewing.
-            if strict:
-                raise
+            # In strict mode (enforce, or SPONSIO_STRICT_COMPILE=1) any
+            # compile failure aborts loading. silently shipping a broken
+            # enforcement rule in production is worse than the crash.  In
+            # non-strict mode (observe) skip the bad contract and surface
+            # a single batched warning so the rest of the yaml stays
+            # usable while reviewing.
+            #
+            # A contract carrying its own ``mode: enforce`` raises either
+            # way: per-contract mode outranks the run's mode at check
+            # time, so this one rule was written to block regardless of
+            # how the run is configured. Dropping it quietly would be the
+            # same security gap strict mode exists to prevent.
             label = ce.desc or _short_constraint_label(ce.guarantee)
+            if strict or (ce.mode or "").strip().lower() == "enforce":
+                # Re-raise carrying the contract's own label. The compiler
+                # only ever sees one constraint entry, so without this the
+                # message describes the broken formula and never says which
+                # of the agent's contracts it belongs to.
+                raise ConfigError(
+                    f"Agent {agent_id!r}, contract {label!r}: {exc}"
+                ) from exc
             skipped.append((label, str(exc)))
 
     if skipped:
@@ -1930,9 +1980,10 @@ def config_to_guard_kwargs(config: SponsoConfig, agent_id: str) -> dict[str, Any
         bullet = "\n  - ".join(f"{label}: {err}" for label, err in skipped)
         warnings.warn(
             f"sponsio: skipped {len(skipped)} contract(s) for agent "
-            f"{agent_id!r} (observe mode, non-strict compile). "
-            f"Set SPONSIO_STRICT_COMPILE=1 or `defaults.mode: enforce` "
-            f"to escalate to ConfigError.\n  - " + bullet,
+            f"{agent_id!r} — they did not compile, and this run is in "
+            f"observe mode, where one bad rule does not take the rest "
+            f"down with it. THESE RULES ARE NOT ARMED. Fix them, or set "
+            f"SPONSIO_STRICT_COMPILE=1 to make this a hard error.\n  - " + bullet,
             UserWarning,
             stacklevel=2,
         )

--- a/sponsio/core.py
+++ b/sponsio/core.py
@@ -610,7 +610,13 @@ def Sponsio(  # noqa: N802 (branded factory function)
 
         from sponsio.config import config_to_guard_kwargs
 
-        cfg_kwargs = config_to_guard_kwargs(parsed, agent_id)
+        # ``mode`` is fully resolved by here (ctor arg > SPONSIO_MODE >
+        # yaml). Hand it over: the compiler decides from it whether a
+        # contract that fails to compile is fatal or merely skipped, and
+        # a run that enforces must never start with a rule missing.
+        cfg_kwargs = config_to_guard_kwargs(
+            parsed, agent_id, mode=mode or os.environ.get("SPONSIO_MODE")
+        )
         cfg_kwargs["verbose"] = verbose
         cfg_kwargs["verbosity"] = verbosity
         if dashboard_url is not None:

--- a/sponsio/doctor.py
+++ b/sponsio/doctor.py
@@ -184,11 +184,12 @@ def check_llm_credentials() -> CheckResult:
 def _config_mode() -> tuple[str, str] | None:
     """The mode a config in the cwd would actually produce, and its source.
 
-    Resolved the way ``sponsio.core`` resolves it — ``runtime.mode`` first,
-    then ``defaults.mode`` — rather than by reimplementing part of it here.
-    A partial copy is how this check ended up reporting "observe" with a
-    green tick for a config whose ``runtime.mode: enforce`` was blocking
-    calls at runtime, which is the most dangerous direction to be wrong in.
+    Resolved the way ``sponsio.core`` resolves it — ``runtime.mode``, then
+    ``defaults.mode``, then a bare top-level ``mode:`` — rather than by
+    reimplementing part of it here. A partial copy is how this check ended
+    up reporting "observe" with a green tick for a config that was blocking
+    calls at runtime, which is the most dangerous direction to be wrong in;
+    it happened twice, once per source left out.
     """
     for name in ("sponsio.yaml", "sponsio.yml"):
         candidate = Path.cwd() / name
@@ -205,6 +206,8 @@ def _config_mode() -> tuple[str, str] | None:
         default_mode = parsed.defaults.get("mode")
         if isinstance(default_mode, str):
             return default_mode, "defaults.mode"
+        if parsed.top_level_mode:
+            return parsed.top_level_mode, "mode"
         return None
     return None
 
@@ -403,6 +406,45 @@ def check_sponsio_yaml(path: Path) -> CheckResult:
             "fail",
             f"{yaml_path.name}: {e}",
         )
+
+    # ``load_config`` validates the schema; it does not compile the
+    # contracts. A rulebook with a well-formed block whose pattern args
+    # are wrong parses cleanly here and then either aborts the run
+    # (enforce) or is silently dropped from it (observe) — the doctor is
+    # exactly who should have said so first. Compile every agent, since
+    # each agent's block compiles independently.
+    #
+    # Always compile strictly, whatever the project's mode: strictness
+    # decides what the *runtime* does with a broken rule, and doctor
+    # wants to find it either way. The project's mode then grades it —
+    # an enforcing run will not start at all, an observing run will run
+    # without that rule.
+    try:
+        from sponsio.config import config_to_guard_kwargs
+    except Exception as e:  # pragma: no cover
+        return CheckResult("Config file", "fail", f"compiler import: {e}")
+
+    enforcing = (
+        cfg.runtime.mode
+        or cfg.defaults.get("mode")
+        or cfg.top_level_mode
+        or os.environ.get("SPONSIO_MODE")
+        or ""
+    ).strip().lower() == "enforce"
+    for agent_id in cfg.agents:
+        try:
+            config_to_guard_kwargs(cfg, agent_id, mode="enforce")
+        except Exception as e:
+            consequence = (
+                "this run will not start"
+                if enforcing
+                else "this rule will not be armed"
+            )
+            return CheckResult(
+                "Config file",
+                "fail" if enforcing else "warn",
+                f"{yaml_path.name}: a contract does not compile, {consequence} — {e}",
+            )
 
     # Detect unresolved ``${VAR}`` refs by inspecting the raw bytes —
     # the loader has already done expansion at this point so reaching

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -442,3 +442,120 @@ agents:
     assert len(kw["contracts"]) == 1
     skip_warns = [w for w in caught if "skipped" in str(w.message)]
     assert skip_warns == []
+
+
+# ---------------------------------------------------------------------------
+# Strictness follows the *effective* mode, not one yaml field
+# ---------------------------------------------------------------------------
+
+
+def _bad_regex_yaml_at(placement: str) -> str:
+    """The same two contracts, with ``enforce`` written in one of the
+    three places a yaml can say it."""
+    header = {
+        "defaults": "defaults:\n  mode: enforce",
+        "runtime": "runtime:\n  mode: enforce",
+        "top_level": "mode: enforce",
+        "none": "",
+    }[placement]
+    return f"""
+version: "1"
+{header}
+agents:
+  bot:
+    contracts:
+      - G:
+          ltl: "G(!(arg_field_has('Bash', 'command', 'rm\\\\s+.*\\\\.env')))"
+      - G:
+          ltl: "{_BAD_REGEX_LTL}"
+"""
+
+
+@pytest.mark.parametrize("placement", ["defaults", "runtime", "top_level"])
+def test_enforce_is_strict_wherever_the_yaml_says_it(tmp_path, monkeypatch, placement):
+    """A yaml that says enforce anywhere loads strictly.
+
+    Only ``defaults.mode`` used to be consulted, so a project written
+    with ``runtime.mode`` or a bare top-level ``mode:`` — both of which
+    the runtime honors — dropped a broken rule with a warning while
+    enforcing everything else. That is a rule the operator believes is
+    armed and is not.
+    """
+    monkeypatch.delenv("SPONSIO_STRICT_COMPILE", raising=False)
+
+    f = tmp_path / "sponsio.yaml"
+    f.write_text(_bad_regex_yaml_at(placement))
+    cfg = load_config(str(f))
+
+    with pytest.raises(ConfigError, match="Invalid regex"):
+        config_to_guard_kwargs(cfg, "bot")
+
+
+def test_mode_argument_makes_a_silent_yaml_strict(tmp_path, monkeypatch):
+    """``Sponsio(mode="enforce")`` over a yaml that names no mode is
+    still an enforcing run, so it compiles strictly."""
+    monkeypatch.delenv("SPONSIO_STRICT_COMPILE", raising=False)
+
+    f = tmp_path / "sponsio.yaml"
+    f.write_text(_bad_regex_yaml_at("none"))
+    cfg = load_config(str(f))
+
+    # Without the caller's mode, the yaml alone says nothing → observe.
+    with pytest.warns(UserWarning, match="skipped 1 contract"):
+        config_to_guard_kwargs(cfg, "bot")
+
+    with pytest.raises(ConfigError, match="Invalid regex"):
+        config_to_guard_kwargs(cfg, "bot", mode="enforce")
+
+
+def test_a_rule_that_enforces_on_its_own_never_gets_skipped(tmp_path, monkeypatch):
+    """Per-contract ``mode: enforce`` outranks the run's mode at check
+    time, so a broken one aborts the load even in an observe run."""
+    monkeypatch.delenv("SPONSIO_STRICT_COMPILE", raising=False)
+
+    y = f"""
+version: "1"
+defaults:
+  mode: observe
+agents:
+  bot:
+    contracts:
+      - G:
+          ltl: "{_BAD_REGEX_LTL}"
+        mode: enforce
+"""
+    f = tmp_path / "sponsio.yaml"
+    f.write_text(y)
+    cfg = load_config(str(f))
+
+    with pytest.raises(ConfigError, match="Invalid regex"):
+        config_to_guard_kwargs(cfg, "bot")
+
+
+def test_wrong_arity_names_the_contract_and_the_signature(tmp_path):
+    """A pattern given the wrong number of args used to raise a bare
+    TypeError from inside the compiler, naming neither the contract the
+    user wrote nor what the pattern takes."""
+    y = """
+version: "1"
+defaults:
+  mode: enforce
+agents:
+  bot:
+    contracts:
+      - G:
+          pattern: arg_blacklist
+          args: [lookup_customer, [ssn]]
+        desc: Lookups must never carry an SSN.
+"""
+    f = tmp_path / "sponsio.yaml"
+    f.write_text(y)
+    cfg = load_config(str(f))
+
+    with pytest.raises(ConfigError) as exc:
+        config_to_guard_kwargs(cfg, "bot")
+
+    msg = str(exc.value)
+    assert "Lookups must never carry an SSN." in msg  # which contract
+    assert "arg_blacklist(tool" in msg  # what it takes
+    assert "'lookup_customer'" in msg  # what was passed

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -135,6 +135,32 @@ class TestCheckMode:
         r = check_mode()
         assert r.status == "fail"
 
+    @pytest.mark.parametrize(
+        "yaml_body",
+        [
+            "runtime:\n  mode: enforce\n",
+            "defaults:\n  mode: enforce\n",
+            "mode: enforce\n",
+        ],
+    )
+    def test_a_yaml_that_enforces_is_reported_as_enforcing(
+        self, tmp_path, monkeypatch, yaml_body
+    ):
+        """All three yaml spellings of enforce reach the runtime, so all
+        three must reach this report. Saying "observe — safe default" over
+        a config that blocks is the one direction that gets someone hurt.
+        """
+        monkeypatch.delenv("SPONSIO_MODE", raising=False)
+        (tmp_path / "sponsio.yaml").write_text(
+            'version: "1"\n' + yaml_body + "agents:\n  bot:\n    contracts:\n"
+            '      - G: "tool `x` at most 0 times"\n'
+        )
+        monkeypatch.chdir(tmp_path)
+        r = check_mode()
+        assert r.status == "warn"
+        assert "enforce" in r.detail
+        assert "BLOCK" in r.detail
+
 
 class TestCheckProjectScan:
     def test_missing_path_is_skip(self, tmp_path):
@@ -257,6 +283,39 @@ class TestCheckSponsioYaml:
         r = check_sponsio_yaml(tmp_path)
         assert r.status == "fail"
         assert "sponsio.yaml" in r.detail
+
+    _UNCOMPILABLE = (
+        "agents:\n"
+        "  bot:\n"
+        "    contracts:\n"
+        "      - G:\n"
+        "          pattern: arg_blacklist\n"
+        "          args: [lookup_customer, [ssn]]\n"
+        "        desc: Lookups must never carry an SSN.\n"
+    )
+
+    def test_uncompilable_contract_fails_an_enforcing_project(self, tmp_path):
+        """Schema-valid but uncompilable is the failure doctor exists to
+        catch: this yaml loads fine and then aborts the moment
+        ``Sponsio(config=...)`` touches it."""
+        (tmp_path / "sponsio.yaml").write_text(
+            "version: 1\nmode: enforce\n" + self._UNCOMPILABLE
+        )
+        r = check_sponsio_yaml(tmp_path)
+        assert r.status == "fail"
+        assert "arg_blacklist" in r.detail
+        assert "will not start" in r.detail
+
+    def test_uncompilable_contract_warns_an_observing_project(self, tmp_path):
+        """Observe keeps running without the rule rather than aborting,
+        so it is a warning — but the operator still has a rule they
+        believe is armed and is not."""
+        (tmp_path / "sponsio.yaml").write_text(
+            "version: 1\nmode: observe\n" + self._UNCOMPILABLE
+        )
+        r = check_sponsio_yaml(tmp_path)
+        assert r.status == "warn"
+        assert "not be armed" in r.detail
 
     def test_unset_env_var_is_warned(self, tmp_path, monkeypatch):
         """The loader silently expands missing ``${VAR}`` to ``""``


### PR DESCRIPTION
Found by running a new agent app end-to-end against the console with a hand-written rulebook — a first-user path, not a unit test.

## The rule that wasn't there

A contract that fails to compile is skipped-with-warning in observe and fatal in enforce. That policy is right. The question it asked was not: strictness read `defaults.mode` and nothing else. A project that said enforce in any of the four other places the runtime honors — `Sponsio(mode="enforce")`, `SPONSIO_MODE`, `runtime.mode`, a bare top-level `mode:` — loaded non-strict, dropped the broken rule, printed one `UserWarning`, and enforced the rest.

```
mode='enforce'     -> loaded, 5 contracts, 1 warning(s)     # 6 were written
```

Strictness now follows the effective mode, resolved the way the runtime resolves it. A contract carrying its own `mode: enforce` raises either way — per-contract mode outranks the run's mode at check time, so that rule was written to block however the run is configured.

## Three quieter ones, same family

**Wrong arity was a bare TypeError.** 20 frames into `config.py`, naming the factory's missing parameter and nothing about the contract:

```
TypeError: arg_blacklist() missing 1 required positional argument: 'patterns'
```

Now:

```
ConfigError: Agent 'billing-desk', contract 'Customer lookups must never carry an SSN
or a full card number.': Pattern 'arg_blacklist' was given 2 argument(s):
['lookup_customer', ['ssn', 'full_card']]. It takes: arg_blacklist(tool: 'str',
param: 'str', patterns: 'list[str]', desc: 'str' = '')
```

Every strict re-raise carries the agent and contract label now, the bad-regex path included.

**`doctor` green-ticked a config that cannot load.** It validated the schema and never compiled the contracts, so the yaml above got `✓ Config file  sponsio.yaml: 1 agent(s)` and then raised the moment `Sponsio(config=...)` touched it. It compiles now — strictly whatever the mode, since a rule that will be dropped is precisely what doctor should find — and grades by the project's mode: `fail` if the run will not start, `warn` if the rule will merely be missing.

**`doctor` reported a blocking project as shadow.** `Runtime mode` read `runtime.mode` and `defaults.mode` but not a bare top-level `mode:`:

```
✓ Runtime mode      observe (shadow — safe default)     # the guard was in enforce
```

`_config_mode`'s own docstring warns about this partial copy; one source was still left out.

## Verified

`2471 passed, 32 skipped`. Three pre-existing failures in `test_oss_sto_gate.py` / `test_config_sections.py` reproduce on unmodified `main` in this venv (it has `sponsio_cloud` importable, which is what those tests assert against); CI does not. `ruff check` / `ruff format --check` clean.

New tests: strictness for all three yaml spellings of enforce and for the `mode=` argument; a per-contract `mode: enforce` in an observe run; the arity message naming contract + signature; doctor failing an enforcing project and warning an observing one; doctor's mode line for all three spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)