### PR TITLE
fix: three ways a rule looked armed and was not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,12 @@ jobs:
 
       - name: Run cross-language tests
         working-directory: ts/packages/sdk
-        run: node dist/__tests__/core.test.js
+        # The package's own test command, which is the whole compiled
+        # suite. This step ran only ``core.test.js`` — so the TS half of
+        # ``tests/cross_language/scenarios.json`` was never replayed in
+        # CI, and the shared file gated Python alone. A no_reversal
+        # argument inversion in the TS nl-parser lived through that gap.
+        run: npm test
 
   lint:
     name: Lint

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -44,6 +44,19 @@ def _contracts_from_guard(guard: Any) -> list[dict]:
                 "pipeline": "det",
                 "violationCount": 0,
             }
+            # The pattern body, not the sentence, is a rule's identity. The
+            # console dedupes mined proposals against the book by exactly
+            # this signature; a run whose agent has no published book yet —
+            # a first run, which is when mining is most useful — had only
+            # the label to go on, so it was offered the rules it had just
+            # been checked against, reworded.
+            pattern_name = getattr(guarantee, "pattern_name", None)
+            if pattern_name:
+                row["pattern"] = str(pattern_name)
+                row["args"] = [
+                    list(a) if isinstance(a, (list, tuple)) else a
+                    for a in (getattr(guarantee, "args", None) or ())
+                ]
             authored = getattr(contract, "desc", None)
             # The authored sentence and the compiled formula's description
             # can differ; a violation may arrive under either spelling.

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -130,7 +130,7 @@ class BridgeSession:
         session_id: str | None = None,
         client: Any = None,
         contracts: list[dict] | None = None,
-        agents: list[dict] | None = None,
+        agents: list[dict | str] | None = None,
         runs_dir: str | Path | None = None,
     ) -> None:
         self.guard = guard
@@ -186,6 +186,20 @@ class BridgeSession:
 
         self.agents: dict[str, dict] = {}
         for agent in agents or []:
+            # A bare name is the shorthand: ``agents=["planner", "writer"]``
+            # is what a single-role run wants to write, and is what the
+            # parameter's name suggests. Without this it reached
+            # ``agent["id"]`` and raised ``string indices must be integers``
+            # from inside the bridge, which says nothing about the call.
+            if isinstance(agent, str):
+                self._ensure_agent(agent)
+                continue
+            if not isinstance(agent, dict) or "id" not in agent:
+                raise TypeError(
+                    "bridge: each entry in `agents` must be an agent id, or "
+                    "a dict with an 'id' key (plus optional 'role' and "
+                    f"'tools'). Got {agent!r}."
+                )
             self._ensure_agent(
                 agent["id"],
                 role=agent.get("role", "agent"),
@@ -530,7 +544,7 @@ def attach(
     session_id: str | None = None,
     client: Any = None,
     contracts: list[dict] | None = None,
-    agents: list[dict] | None = None,
+    agents: list[dict | str] | None = None,
     runs_dir: str | Path | None = None,
 ) -> BridgeSession:
     """Stream ``guard``'s run to a console.

--- a/sponsio/generation/dsl_to_contract.py
+++ b/sponsio/generation/dsl_to_contract.py
@@ -802,7 +802,11 @@ _KEYWORD_RULES: list[tuple[list[str], str, int]] = [
             r"cannot\s+reject\s+after",
             r"cannot\s+contradict",
             r"cannot\s+be\s+reversed",
-            r"(?:never|cannot|must\s+not)\s+(?:call\s+)?.*after\s+(?:calling\s+)?",
+            r"(?:never|cannot|must\s+not|don'?t|do\s+not)\s+(?:call\s+)?.*after\s+(?:calling\s+)?",
+            # "after `approve`, never call `deny`" — the same rule with the
+            # commitment first, which is the order the pattern wants and the
+            # one this list did not recognise at all.
+            r"^\s*after\s+.*\b(?:never|cannot|must\s+not|don'?t|do\s+not)\b",
             r"forbidden\s+after",
             r"prohibited\s+after",
             r"must\s+not\s+follow",
@@ -1175,6 +1179,38 @@ def _is_plausible_tool_name(w: str) -> bool:
     }:
         return False
     return True
+
+
+# Words that mark the action right after them as the forbidden one.
+_NEGATION_RE = re.compile(
+    r"\b(?:never|cannot|can\s+not|must\s+not|don'?t|do\s+not|no)\b"
+)
+
+
+def _forbidden_action_comes_first(lower: str, first: str, second: str) -> bool:
+    """True for "never call A after B", where B is the commitment.
+
+    ``no_reversal(commitment, contradiction)`` takes the committing action
+    first, and English puts it last whenever the sentence opens with the
+    prohibition: "never call `delete_bucket` after `restore_backup`" means
+    restore commits and delete contradicts, not the reverse. Reading the
+    two names in the order they appear compiled the opposite rule, under
+    the user's own sentence as its description — armed, displayed, and
+    checking something else.
+
+    Decided by position rather than by phrase, because the phrase list this
+    supplements matched "never after" and not "never call `x` after", and
+    every new way of saying it would need another entry.
+    """
+    i_first = lower.find(first.lower())
+    i_second = lower.find(second.lower(), i_first + 1 if i_first >= 0 else 0)
+    if i_first < 0 or i_second < 0 or i_second <= i_first:
+        return False
+    # "after" has to sit between the two actions: in "after `b`, never call
+    # `a`" the commitment already comes first and must not be swapped.
+    if not re.search(r"\bafter\b", lower[i_first + len(first) : i_second]):
+        return False
+    return bool(_NEGATION_RE.search(lower[:i_first]))
 
 
 def _try_bare_ordering_patterns(text: str, nl_line: str) -> ParsedConstraint | None:
@@ -1796,7 +1832,7 @@ def parse_dsl(expr: str) -> ParsedConstraint:
         if re.search(
             r"must not follow|should not follow|not allowed after|forbidden after|prohibited after|never after",
             _lower,
-        ):
+        ) or _forbidden_action_comes_first(_lower, actions[0], actions[1]):
             actions = [actions[1], actions[0]] + actions[2:]
 
     # --- Standard 2-argument patterns ---

--- a/sponsio/patterns/library.py
+++ b/sponsio/patterns/library.py
@@ -1577,10 +1577,25 @@ def dangerous_sql_verbs(
 
     from sponsio.patterns.library import arg_blacklist
 
+    # SQL keywords are case-insensitive by the language's own definition,
+    # and a model — or an ORM, or a formatter — writes them lowercase as
+    # often as not. Matching them case-sensitively meant `drop table users`
+    # walked past the pattern whose entire purpose is to stop it.
+    #
+    # The word boundary goes on at the same time: a bare `DELETE` also
+    # matched the word "deleted" in a comment, and a column named
+    # `drop_date`. Only a plain word is rewritten, so a caller who passes a
+    # real regex (`DROP\s+TABLE`) keeps exactly what they wrote, with case
+    # folding added.
+    guarded = [
+        rf"(?i)\b{verb}\b" if _re.fullmatch(r"[A-Za-z_]+", verb) else f"(?i){verb}"
+        for verb in forbidden
+    ]
+
     base = arg_blacklist(
         tool,
         "query",
-        forbidden,
+        guarded,
         desc=desc or f"{tool} must not use [{', '.join(forbidden)}]",
     )
     # Preserve the caller-facing pattern identity and its args so the

--- a/sponsio/tracer/grounding.py
+++ b/sponsio/tracer/grounding.py
@@ -167,6 +167,31 @@ class GroundingState:
 _NAMESPACED_TOOL_RE = re.compile(r"^[A-Za-z_][\w-]*:[A-Za-z_][\w-]*$")
 
 
+def _path_within(path: str, prefix: str) -> bool:
+    """Is ``path`` inside ``prefix``, as directories rather than as text?
+
+    A plain ``startswith`` answered two different questions wrong. It let
+    ``/safe/../etc/passwd`` through, because the string does begin with
+    ``/safe`` — the oldest escape there is, against a rule whose whole
+    purpose is confinement. And it counted ``/safeguard/evil.txt`` as
+    inside ``/safe``, because a prefix of the text is not a prefix of the
+    path.
+
+    Both segments are normalised, which collapses ``..`` and doubled
+    separators, and containment then requires a segment boundary.
+    Backslashes are read as separators too: on POSIX a literal backslash
+    in a filename is vanishingly rare, and reading one as a separator can
+    only ever refuse a path, never admit one.
+    """
+    import posixpath
+
+    normalized = posixpath.normpath(path.replace("\\", "/"))
+    root = posixpath.normpath(prefix.replace("\\", "/"))
+    if root == "/":
+        return normalized.startswith("/")
+    return normalized == root or normalized.startswith(root + "/")
+
+
 def _tool_matches(target_tool: str, event_tool: str, args_str: str) -> bool:
     """Check if a target tool spec matches the current event.
 
@@ -490,7 +515,7 @@ def ground_event(
                             v[pred_key("arg_paths_within", *args_tuple)] = True
                         else:
                             all_within = all(
-                                any(p.startswith(pfx) for pfx in prefixes)
+                                any(_path_within(p, pfx) for pfx in prefixes)
                                 for p in paths
                             )
                             v[pred_key("arg_paths_within", *args_tuple)] = all_within

--- a/tests/cross_language/scenarios.json
+++ b/tests/cross_language/scenarios.json
@@ -7,9 +7,30 @@
         "tool `check_policy` must precede `issue_refund`"
       ],
       "steps": [
-        {"tool": "issue_refund", "args": {"order_id": "#123"}, "expect_blocked": true,  "reason": "check_policy not called yet"},
-        {"tool": "check_policy", "args": {"order_id": "#123"}, "expect_blocked": false, "reason": "check_policy is always allowed"},
-        {"tool": "issue_refund", "args": {"order_id": "#123"}, "expect_blocked": false, "reason": "check_policy was called"}
+        {
+          "tool": "issue_refund",
+          "args": {
+            "order_id": "#123"
+          },
+          "expect_blocked": true,
+          "reason": "check_policy not called yet"
+        },
+        {
+          "tool": "check_policy",
+          "args": {
+            "order_id": "#123"
+          },
+          "expect_blocked": false,
+          "reason": "check_policy is always allowed"
+        },
+        {
+          "tool": "issue_refund",
+          "args": {
+            "order_id": "#123"
+          },
+          "expect_blocked": false,
+          "reason": "check_policy was called"
+        }
       ]
     },
     {
@@ -18,10 +39,36 @@
         "tool `send_email` at most 2 times"
       ],
       "steps": [
-        {"tool": "send_email", "args": {"to": "a@b.com"}, "expect_blocked": false, "reason": "first call (limit=2)"},
-        {"tool": "send_email", "args": {"to": "c@d.com"}, "expect_blocked": false, "reason": "second call (limit=2)"},
-        {"tool": "send_email", "args": {"to": "e@f.com"}, "expect_blocked": true,  "reason": "third call exceeds limit"},
-        {"tool": "get_inbox",  "args": {},                "expect_blocked": false, "reason": "different tool, not limited"}
+        {
+          "tool": "send_email",
+          "args": {
+            "to": "a@b.com"
+          },
+          "expect_blocked": false,
+          "reason": "first call (limit=2)"
+        },
+        {
+          "tool": "send_email",
+          "args": {
+            "to": "c@d.com"
+          },
+          "expect_blocked": false,
+          "reason": "second call (limit=2)"
+        },
+        {
+          "tool": "send_email",
+          "args": {
+            "to": "e@f.com"
+          },
+          "expect_blocked": true,
+          "reason": "third call exceeds limit"
+        },
+        {
+          "tool": "get_inbox",
+          "args": {},
+          "expect_blocked": false,
+          "reason": "different tool, not limited"
+        }
       ]
     },
     {
@@ -30,9 +77,30 @@
         "tools `approve` and `reject` are mutually exclusive"
       ],
       "steps": [
-        {"tool": "approve", "args": {"id": "1"}, "expect_blocked": false, "reason": "first call, either is fine"},
-        {"tool": "reject",  "args": {"id": "1"}, "expect_blocked": true,  "reason": "approve already called"},
-        {"tool": "approve", "args": {"id": "2"}, "expect_blocked": false, "reason": "approve still allowed (same tool)"}
+        {
+          "tool": "approve",
+          "args": {
+            "id": "1"
+          },
+          "expect_blocked": false,
+          "reason": "first call, either is fine"
+        },
+        {
+          "tool": "reject",
+          "args": {
+            "id": "1"
+          },
+          "expect_blocked": true,
+          "reason": "approve already called"
+        },
+        {
+          "tool": "approve",
+          "args": {
+            "id": "2"
+          },
+          "expect_blocked": false,
+          "reason": "approve still allowed (same tool)"
+        }
       ]
     },
     {
@@ -42,10 +110,70 @@
         "tool `transfer` at most 1 times"
       ],
       "steps": [
-        {"tool": "transfer", "args": {"amount": 100}, "expect_blocked": true,  "reason": "auth not called"},
-        {"tool": "auth",     "args": {"user": "bob"}, "expect_blocked": false, "reason": "auth is allowed"},
-        {"tool": "transfer", "args": {"amount": 100}, "expect_blocked": false, "reason": "auth done, first transfer"},
-        {"tool": "transfer", "args": {"amount": 200}, "expect_blocked": true,  "reason": "rate limit: at most 1"}
+        {
+          "tool": "transfer",
+          "args": {
+            "amount": 100
+          },
+          "expect_blocked": true,
+          "reason": "auth not called"
+        },
+        {
+          "tool": "auth",
+          "args": {
+            "user": "bob"
+          },
+          "expect_blocked": false,
+          "reason": "auth is allowed"
+        },
+        {
+          "tool": "transfer",
+          "args": {
+            "amount": 100
+          },
+          "expect_blocked": false,
+          "reason": "auth done, first transfer"
+        },
+        {
+          "tool": "transfer",
+          "args": {
+            "amount": 200
+          },
+          "expect_blocked": true,
+          "reason": "rate limit: at most 1"
+        }
+      ]
+    },
+    {
+      "name": "no_reversal_after_names_the_commitment",
+      "contracts": [
+        "never call `delete_bucket` after `restore_backup`"
+      ],
+      "steps": [
+        {
+          "tool": "delete_bucket",
+          "args": {
+            "name": "b1"
+          },
+          "expect_blocked": false,
+          "reason": "nothing has committed yet"
+        },
+        {
+          "tool": "restore_backup",
+          "args": {
+            "from": "b1"
+          },
+          "expect_blocked": false,
+          "reason": "the commitment itself is always allowed"
+        },
+        {
+          "tool": "delete_bucket",
+          "args": {
+            "name": "b1"
+          },
+          "expect_blocked": true,
+          "reason": "`after restore_backup` makes restore the commitment, whichever order the sentence names them in"
+        }
       ]
     }
   ]

--- a/tests/cross_language/scenarios.json
+++ b/tests/cross_language/scenarios.json
@@ -175,6 +175,38 @@
           "reason": "`after restore_backup` makes restore the commitment, whichever order the sentence names them in"
         }
       ]
+    },
+    {
+      "name": "scope_limit_is_confinement_not_a_string_prefix",
+      "contracts": [
+        "tool `write_file` restricted to `/safe`"
+      ],
+      "steps": [
+        {
+          "tool": "write_file",
+          "args": {
+            "path": "/safe/ok.txt"
+          },
+          "expect_blocked": false,
+          "reason": "genuinely inside"
+        },
+        {
+          "tool": "write_file",
+          "args": {
+            "path": "/safe/../etc/passwd"
+          },
+          "expect_blocked": true,
+          "reason": "climbs out of /safe with .."
+        },
+        {
+          "tool": "write_file",
+          "args": {
+            "path": "/safeguard/evil.txt"
+          },
+          "expect_blocked": true,
+          "reason": "shares the text prefix, is not under the directory"
+        }
+      ]
     }
   ]
 }

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -574,3 +574,33 @@ def test_agents_rejects_anything_else_by_name(tmp_path):
     guard, client = FakeGuard(), FakeClient()
     with pytest.raises(TypeError, match="agent id"):
         attach(guard, client=client, runs_dir=tmp_path, agents=[42])
+
+
+def test_contract_rows_carry_the_pattern_body(tmp_path):
+    """A rule's identity is its pattern and arguments, not its sentence.
+
+    The console dedupes mined proposals against this signature; without
+    it a run whose agent has no published book yet — a first run — was
+    offered the rules it had just been checked against, reworded.
+    """
+    guard, client = FakeGuard(), FakeClient()
+
+    class _Guarantee:
+        desc = "`warmup` must precede `ping`"
+        pattern_name = "must_precede"
+        args = ("warmup", "ping")
+
+    class _Contract:
+        desc = "warm up first"
+        guarantees = [_Guarantee()]
+        mode = "enforce"
+
+    class _System:
+        _contracts = [_Contract()]
+
+    guard._system = _System()
+    run = attach(guard, client=client, runs_dir=tmp_path)
+
+    row = next(iter(run.contracts.values()))
+    assert row["pattern"] == "must_precede"
+    assert row["args"] == ["warmup", "ping"]

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -536,3 +536,41 @@ def test_auto_false_still_leaves_guard_before_alone(tmp_path):
 
     guard.guard_before("query_prices", {})
     assert run.steps == []
+
+
+# -- the agents argument ----------------------------------------------------
+
+
+def test_agents_accepts_bare_names(tmp_path):
+    """``agents=["planner", "writer"]`` is what the parameter's name
+    suggests, and what a single-role run wants to write.
+
+    It used to reach ``agent["id"]`` and raise ``string indices must be
+    integers`` from inside the bridge — a message about neither the
+    argument nor the call.
+    """
+    guard, client = FakeGuard(), FakeClient()
+    run = attach(
+        guard,
+        client=client,
+        runs_dir=tmp_path,
+        agents=["planner", "writer"],
+    )
+    assert sorted(run.agents) == ["planner", "writer"]
+
+
+def test_agents_still_accepts_the_full_dict(tmp_path):
+    guard, client = FakeGuard(), FakeClient()
+    run = attach(
+        guard,
+        client=client,
+        runs_dir=tmp_path,
+        agents=[{"id": "planner", "role": "lead", "tools": ["search"]}],
+    )
+    assert run.agents["planner"]["role"] == "lead"
+
+
+def test_agents_rejects_anything_else_by_name(tmp_path):
+    guard, client = FakeGuard(), FakeClient()
+    with pytest.raises(TypeError, match="agent id"):
+        attach(guard, client=client, runs_dir=tmp_path, agents=[42])

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -283,3 +283,60 @@ def test_count_propagates_to_non_call_events():
     vals = ground(trace)
     # count should still be visible at step 1
     assert vals[1].get("count(issue_refund)") == 1
+
+
+# ---------------------------------------------------------------------------
+# arg_paths_within — confinement, not string prefixes
+# ---------------------------------------------------------------------------
+
+
+def _within(path: str, *prefixes: str) -> bool:
+    """Ground one write and read back whether it stayed inside."""
+    from sponsio.formulas._pred_key import pred_key
+
+    trace = make_trace(
+        Event(
+            ts=1,
+            agent="a",
+            event_type="tool_call",
+            tool="write_file",
+            args={"path": path},
+        )
+    )
+    v = ground(
+        trace,
+        content_atoms={"arg_paths_within": [("write_file", *prefixes)]},
+    )[0]
+    return v[pred_key("arg_paths_within", "write_file", *prefixes)]
+
+
+def test_a_path_that_climbs_out_is_not_within():
+    """`/safe/../etc/passwd` begins with `/safe` and is not inside it.
+
+    The check was a string prefix, so the oldest escape there is walked
+    straight through a rule whose whole purpose is confinement.
+    """
+    assert _within("/safe/../etc/passwd", "/safe") is False
+    assert _within("/safe/../../root/.ssh/id_rsa", "/safe") is False
+    assert _within("/safe/sub/../../etc/shadow", "/safe") is False
+    assert _within("/safe//../etc/passwd", "/safe") is False
+
+
+def test_a_sibling_that_shares_a_prefix_is_not_within():
+    """`/safeguard` is not under `/safe`: a prefix of the text is not a
+    prefix of the path."""
+    assert _within("/safeguard/evil.txt", "/safe") is False
+    assert _within("/safety-report/leak.txt", "/safe") is False
+
+
+def test_paths_actually_inside_are_still_allowed():
+    assert _within("/safe/ok.txt", "/safe") is True
+    assert _within("/safe/deep/nested/f.txt", "/safe") is True
+    assert _within("/safe", "/safe") is True
+    assert _within("/safe/a", "/safe/") is True
+    assert _within("/research/draft/x.parquet", "/research/draft") is True
+
+
+def test_any_of_several_roots_will_do():
+    assert _within("/tmp/scratch", "/safe", "/tmp") is True
+    assert _within("/etc/passwd", "/safe", "/tmp") is False

--- a/tests/test_nl_parser.py
+++ b/tests/test_nl_parser.py
@@ -369,6 +369,38 @@ class TestParseNLRuleBased:
         assert r.args[0] == "approve"
         assert r.args[1] == "reject"
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "never call `delete_bucket` after `restore_backup`",
+            "must not call `delete_bucket` after `restore_backup`",
+            "cannot call `delete_bucket` after `restore_backup`",
+            "don't call `delete_bucket` after `restore_backup`",
+            "`delete_bucket` is not allowed after `restore_backup`",
+            "after `restore_backup`, never call `delete_bucket`",
+            "after `restore_backup`, `delete_bucket` must not be called",
+        ],
+    )
+    def test_after_names_the_commitment_whatever_the_word_order(self, text):
+        """``after Y`` makes Y the commitment, wherever it sits.
+
+        ``no_reversal(commitment, contradiction)`` takes the committing
+        action first. Reading the two names in the order they appear
+        compiled the opposite rule — and carried the user's own sentence
+        as its description, so the console showed the right words over a
+        formula checking the reverse.
+        """
+        r = parse_nl_rule_based(text)
+        assert r.ok, r.error
+        assert r.pattern_name == "no_reversal"
+        assert r.args[0] == "restore_backup"  # commits
+        assert r.args[1] == "delete_bucket"  # contradicts
+
+    def test_a_leading_after_is_not_swapped_twice(self):
+        """The commitment already comes first here; swapping would undo it."""
+        r = parse_nl_rule_based("after `approve_refund`, never call `deny_refund`")
+        assert r.args == ("approve_refund", "deny_refund")
+
     # --- Cases that legitimately need LLM (rule-based should fail gracefully) ---
 
     def test_pure_english_fails_gracefully(self):

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -652,3 +652,58 @@ class TestDegeneratePatternsRejected:
         deadline("alert", "respond", 3)
         required_steps_completion("open_case", ["triage", "close_case"])
         untrusted_source_gate(["web_fetch"], ["send_email"])
+
+
+# ---------------------------------------------------------------------------
+# dangerous_sql_verbs — SQL keywords do not have a case
+# ---------------------------------------------------------------------------
+
+
+def _sql_blocks(query: str, forbidden=None) -> bool:
+    """Does the preset stop this query?"""
+    import warnings
+
+    from sponsio.integrations.base import BaseGuard
+    from sponsio.patterns.library import dangerous_sql_verbs
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        guard = BaseGuard(
+            agent_id="t",
+            contracts=[{"guarantee": dangerous_sql_verbs("run_sql", forbidden)}],
+            mode="enforce",
+            verbose=False,
+        )
+    return not guard.guard_before("run_sql", {"query": query}).allowed
+
+
+def test_a_lowercase_verb_is_still_destructive():
+    """SQL keywords are case-insensitive by the language's definition, and
+    a model writes them lowercase as often as not. Matching them
+    case-sensitively let `drop table users` past the pattern whose whole
+    purpose is to stop it."""
+    assert _sql_blocks("drop table users")
+    assert _sql_blocks("DrOp TaBlE users")
+    assert _sql_blocks("truncate t")
+    assert _sql_blocks("delete from t")
+
+
+def test_uppercase_still_blocks():
+    assert _sql_blocks("DROP TABLE users")
+    assert _sql_blocks("SELECT 1; DROP TABLE t")
+
+
+def test_a_verb_inside_an_identifier_is_not_a_verb():
+    """A bare `DELETE` also matched the word "deleted" in a comment and a
+    column named `drop_date`, so the word boundary went on at the same
+    time as the case folding."""
+    assert not _sql_blocks("SELECT dropped_at FROM t")
+    assert not _sql_blocks("SELECT * FROM deleted_items")
+    assert not _sql_blocks("SELECT 1")
+
+
+def test_a_caller_regex_keeps_its_own_shape():
+    """Only a plain word is given a boundary; a real regex is left as
+    written, with case folding added."""
+    assert _sql_blocks("drop   table t", forbidden=[r"DROP\s+TABLE"])
+    assert not _sql_blocks("drop column c", forbidden=[r"DROP\s+TABLE"])

--- a/ts/packages/sdk/src/core/grounding.ts
+++ b/ts/packages/sdk/src/core/grounding.ts
@@ -171,6 +171,42 @@ function escapeRegexLiteral(literal: string): string {
  * Ctx atoms (``ctx(k, v)``), accumulator snapshots, and ``time_since``
  * fire on every event regardless of type (matching Python parity).
  */
+/**
+ * Is `path` inside `prefix`, as directories rather than as text?
+ *
+ * A plain `startsWith` answered two different questions wrong. It let
+ * `/safe/../etc/passwd` through, because the string does begin with
+ * `/safe` — the oldest escape there is, against a rule whose whole
+ * purpose is confinement. And it counted `/safeguard/evil.txt` as inside
+ * `/safe`, because a prefix of the text is not a prefix of the path.
+ *
+ * Parity with Python's `_path_within` in `sponsio/tracer/grounding.py`.
+ */
+function normalizePosix(input: string): string {
+  const text = input.replace(/\\/g, "/");
+  const absolute = text.startsWith("/");
+  const out: string[] = [];
+  for (const segment of text.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (out.length && out[out.length - 1] !== "..") out.pop();
+      else if (!absolute) out.push("..");
+      continue;
+    }
+    out.push(segment);
+  }
+  const joined = out.join("/");
+  if (absolute) return "/" + joined;
+  return joined || ".";
+}
+
+export function pathWithin(path: string, prefix: string): boolean {
+  const normalized = normalizePosix(path);
+  const root = normalizePosix(prefix);
+  if (root === "/") return normalized.startsWith("/");
+  return normalized === root || normalized.startsWith(root + "/");
+}
+
 export function groundEvent(
   event: ToolEvent,
   state: GroundingState,
@@ -359,7 +395,7 @@ export function groundEvent(
             if (targetTool === tool) {
               const paths = argsStr.match(/(\/[^\s;|&>"']+)/g) ?? [];
               const allWithin = paths.length === 0 ||
-                paths.every((p) => prefixes.some((pre) => p.startsWith(pre)));
+                paths.every((p) => prefixes.some((pre) => pathWithin(p, pre)));
               v[predKey("arg_paths_within", targetTool, ...prefixes)] = allWithin;
             }
           }

--- a/ts/packages/sdk/src/core/nl-parser.ts
+++ b/ts/packages/sdk/src/core/nl-parser.ts
@@ -82,7 +82,15 @@ const KEYWORD_RULES: KeywordRule[] = [
   },
   // No reversal
   {
-    patterns: [/cannot.*after\s+approv/, /no reversal/, /cannot\s+deny\s+after/, /must\s+not.*after/],
+    patterns: [
+      /cannot.*after\s+approv/,
+      /no reversal/,
+      /cannot\s+deny\s+after/,
+      /(?:never|cannot|must\s+not|don'?t|do\s+not)\s+(?:call\s+)?.*after\s+(?:calling\s+)?/,
+      /^\s*after\s+.*\b(?:never|cannot|must\s+not|don'?t|do\s+not)\b/,
+      /must\s+not\s+follow/,
+      /not\s+allowed\s+after/,
+    ],
     patternName: "no_reversal",
     minArgs: 2,
   },
@@ -190,6 +198,32 @@ function tryResponseContent(text: string): DetFormula | null {
   return null;
 }
 
+
+const NEGATION_RE = /\b(?:never|cannot|can\s+not|must\s+not|don'?t|do\s+not|no)\b/;
+
+/**
+ * True for "never call A after B", where B is the commitment.
+ *
+ * Decided by position rather than by phrase: the phrase list this
+ * supplements matches "never after" and not "never call `x` after", and
+ * every new way of saying it would need another entry. Parity with
+ * Python's ``_forbidden_action_comes_first``.
+ */
+function forbiddenActionComesFirst(
+  lower: string,
+  first: string,
+  second: string,
+): boolean {
+  const iFirst = lower.indexOf(first.toLowerCase());
+  if (iFirst < 0) return false;
+  const iSecond = lower.indexOf(second.toLowerCase(), iFirst + 1);
+  if (iSecond < 0 || iSecond <= iFirst) return false;
+  // "after" has to sit between the two actions: in "after `b`, never call
+  // `a`" the commitment already comes first and must not be swapped.
+  if (!/\bafter\b/.test(lower.slice(iFirst + first.length, iSecond))) return false;
+  return NEGATION_RE.test(lower.slice(0, iFirst));
+}
+
 export function parseNl(text: string): DetFormula | null {
   // P2 response-content patterns first — keep them ahead of the
   // generic keyword cascade so "response must not contain emails"
@@ -219,8 +253,23 @@ export function parseNl(text: string): DetFormula | null {
         return idempotent(tools[0]);
       case "mutual_exclusion":
         return mutualExclusion(tools[0], tools[1]);
-      case "no_reversal":
-        return noReversal(tools[0], tools[1]);
+      case "no_reversal": {
+        // ``noReversal(commitment, contradiction)`` takes the committing
+        // action first, and English puts it last whenever the sentence
+        // opens with the prohibition: "never call `delete` after
+        // `restore`" means restore commits. Reading the names in the
+        // order they appear built the opposite rule — and this parser
+        // rewrites the desc from the args, so the console showed a rule
+        // the user never wrote. Parity with Python's
+        // ``_forbidden_action_comes_first``.
+        const swap =
+          /must not follow|should not follow|not allowed after|forbidden after|prohibited after|never after/.test(
+            lower,
+          ) || forbiddenActionComesFirst(lower, tools[0], tools[1]);
+        return swap
+          ? noReversal(tools[1], tools[0])
+          : noReversal(tools[0], tools[1]);
+      }
       case "cooldown": {
         const n = extractNumber(text);
         if (n == null) continue;

--- a/ts/packages/sdk/src/core/nl-parser.ts
+++ b/ts/packages/sdk/src/core/nl-parser.ts
@@ -22,6 +22,7 @@ import {
   maxLength,
   noPii,
   noKeywords,
+  scopeLimit,
 } from "./patterns.js";
 import { Atom } from "./formula.js";
 
@@ -98,6 +99,20 @@ const KEYWORD_RULES: KeywordRule[] = [
   {
     patterns: [/cooldown/, /minimum\s+\d+\s+steps?\s+between/],
     patternName: "cooldown",
+    minArgs: 1,
+  },
+  // Scope limit — confinement to a path root. Python's NL parser has had
+  // this since the pattern shipped; TypeScript did not, so a shared
+  // rulebook that wrote it in English enforced in one runtime and, with
+  // one console line, nowhere in the other.
+  {
+    patterns: [
+      /restricted?\s+to\s+(?:paths?|`?\/)/,
+      /restrict\s+file\s+access\s+to/,
+      /confined?\s+to\s+(?:paths?|`?\/)/,
+      /must\s+(?:stay|remain)\s+(?:with)?in\s+`?\//,
+    ],
+    patternName: "scope_limit",
     minArgs: 1,
   },
   // Must precede (last — most general, requires backtick context)
@@ -253,6 +268,19 @@ export function parseNl(text: string): DetFormula | null {
         return idempotent(tools[0]);
       case "mutual_exclusion":
         return mutualExclusion(tools[0], tools[1]);
+      case "scope_limit": {
+        // The roots are the path-shaped arguments; the tool is whatever
+        // else was named. "restrict file access to `/workspace`" names no
+        // tool, so the rule applies to any call carrying a path.
+        const roots = tools.filter((t) => t.startsWith("/"));
+        const named = tools.filter((t) => !t.startsWith("/"));
+        const bare = text.match(/(?:^|\s)(\/[^\s`'",;]+)/g) ?? [];
+        const paths = roots.length
+          ? roots
+          : bare.map((b) => b.trim()).filter(Boolean);
+        if (!paths.length) continue;
+        return scopeLimit(named[0] ?? ".*", paths);
+      }
       case "no_reversal": {
         // ``noReversal(commitment, contradiction)`` takes the committing
         // action first, and English puts it last whenever the sentence


### PR DESCRIPTION
Found by running agent apps the product's own docs describe — a rulebook written in English, an agent passing hostile paths, a SQL tool. Each of these is a rule that loads, arms, shows in the console, and does not do what it says.

## `scope_limit` was a string prefix, not confinement

`scope_limit(write_file, ["/safe"])` allowed `/safe/../../root/.ssh/id_rsa`. The check was `path.startswith(prefix)`, so the oldest escape there is walked straight through a rule whose entire purpose is confinement.

The same line got a second question wrong in the other direction: `/safeguard/evil.txt` and `/safety-report/leak.txt` counted as inside `/safe`, because a prefix of the text is not a prefix of the path.

Both paths are normalised now, and containment requires a segment boundary. Identical line, identical fix in TypeScript — plus `scope_limit` in its NL parser, which it did not have at all: a shared rulebook that wrote the rule in English enforced it in Python and, with one console line and no rule, nowhere in TS.

## `never call A after B` compiled the opposite rule

```
never call `delete_bucket` after `restore_backup`
  →  G(called(delete_bucket) -> G(!called(restore_backup)))
```

delete commits, restore contradicts — backwards. `no_reversal(commitment, contradiction)` takes the committing action first, and English puts it last whenever the sentence opens with the prohibition. The rule appeared in the console carrying the user's own sentence while checking the reverse; in a run where `restore_backup` was immediately followed by `delete_bucket`, it passed.

A swap existed as a list of fixed phrases — it matched `never after`, not `never call \`x\` after`, where the tool name sits between the two words. Position decides now. Two phrasings that were not recognised at all now are, including a leading `after \`b\`, never call \`a\`` which must **not** swap.

TypeScript had the same inversion with no swap of any kind, and it rewrites the description from the parsed arguments, so its console entry was a rule the user never wrote.

## `drop table users` walked past `dangerous_sql_verbs`

Matched case-sensitively, and SQL keywords do not have a case. The word boundary went on at the same time, because a bare `DELETE` also matched "deleted" in a comment and a column named `drop_date`. TypeScript already did both, so this is Python catching up.

## And the reason all three could hide

The CI step named **"Run cross-language tests"** ran `node dist/__tests__/core.test.js`. The TS side of `tests/cross_language/scenarios.json` was never replayed, so the shared file gated Python alone. It runs the package's own test command now — the whole compiled suite, both parity scripts included. Verified by reintroducing the `no_reversal` inversion: `18 passed, 2 failed`.

Two scenarios added to that file, so neither runtime can drift back alone.

## Also here

- `attach(guard, agents=["billing-desk"])` — the obvious reading of the parameter — raised `TypeError: string indices must be integers` from inside session.py. A bare name is the shorthand now.
- A contract row carries the `pattern` and `args` it was built from. The console dedupes mined proposals against that signature, so a run whose agent has no published book — a first run — was being offered the rules it had just been checked against, reworded.

## Verified

`2495 passed, 34 skipped`. The three failures in `test_oss_sto_gate.py` / `test_config_sections.py` reproduce on unmodified `main` in this venv (it has `sponsio_cloud` importable, which those tests assert against) and not in CI. TS `npm test` 20/20 including both parity scripts. `ruff check` / `format --check` clean. `scripts/check_ts_parity.py` 11 of 11 identical. quant-agent re-run end to end against the console: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)