### PR TITLE
release: 0.2.0a10 — three rules that looked armed and were not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,90 @@ broke.
 
 ---
 
+## [0.2.0a10]: 2026-09-02
+
+Found by running seven agent applications against the stack — a support
+desk, an ops bot, a load harness, one that passes hostile arguments, a
+TypeScript agent — rather than by adding tests to code already believed
+correct. Three of these are the same shape: a rule that loads, arms,
+shows in the console, and does not do what it says.
+
+### Fixed
+
+- **`scope_limit` was a string prefix, not confinement.** A rule reading
+  "writes stay under `/safe`" allowed `/safe/../../root/.ssh/id_rsa`,
+  because the check was `path.startswith(prefix)` — the oldest escape
+  there is, against a rule whose entire purpose is confinement. The same
+  line also counted `/safeguard/evil.txt` as inside `/safe`: a prefix of
+  the text is not a prefix of the path. Paths are normalised now and
+  containment requires a segment boundary. Identical fix in TypeScript,
+  which had the identical line.
+
+- **`never call A after B` compiled the opposite rule.**
+  `no_reversal(commitment, contradiction)` takes the committing action
+  first, and English puts it last whenever the sentence opens with the
+  prohibition. The contract appeared in the console carrying the user's
+  own sentence while checking the reverse, and passed on exactly the
+  sequence it was written to stop. Word order decides by position now,
+  not by a list of fixed phrases. TypeScript had the same inversion with
+  no swap at all.
+
+- **`drop table users` walked past `dangerous_sql_verbs`.** The preset
+  matched its verbs case-sensitively, and SQL keywords do not have a
+  case. Word boundaries went on at the same time, so `DELETE` no longer
+  matches the word "deleted" in a comment or a column named `drop_date`.
+
+- **An enforcing run could start with a rule missing.** Strict compile
+  read `defaults.mode` and nothing else, so a project that said enforce
+  in any of the four other places the runtime honors dropped the broken
+  contract, printed one `UserWarning`, and enforced the rest. Strictness
+  follows the effective mode now, and a contract carrying its own
+  `mode: enforce` raises either way.
+
+- **`sponsio doctor` green-ticked a config that cannot load**, because it
+  validated the schema and never compiled the contracts. It compiles them
+  now and grades by the project's mode. Its `Runtime mode` line also read
+  two of the three places a yaml can say `enforce`, so a blocking project
+  was reported as `observe (shadow — safe default)`.
+
+- **`sponsio doctor` failed on a minimal install.** `find_spec` on a
+  dotted name imports the parent package and raises when it is absent, so
+  the check whose only job is to report what is missing crashed on a
+  machine with no `google` — which is what `pip install sponsio` gives
+  you. Doctor opened with a red mark on a healthy install.
+
+- **A pattern given the wrong number of arguments** raised a bare
+  `TypeError` from inside the compiler, naming the factory's missing
+  parameter and nothing about the contract. Errors now name the agent,
+  the contract's own description, what it passed, and the signature.
+
+- **`attach(guard, agents=["name"])`** — the obvious reading of the
+  parameter — raised `string indices must be integers` from inside the
+  bridge. A bare name is the shorthand now.
+
+### Changed
+
+- A contract row sent to a console carries the `pattern` and `args` it
+  was built from, so a run whose agent has no published book is no longer
+  offered the rules it was just checked against.
+- `tool_allowlist` reads the same in both runtimes; TypeScript's NL
+  parser understands `scope_limit`, which it did not before.
+- CI runs the TypeScript half of `tests/cross_language/scenarios.json`.
+  The step was named "Run cross-language tests" and ran the unit tests,
+  so the shared file gated Python alone — which is how two of the
+  inversions above survived.
+
+### Removed
+
+- The SMT hooks. `base.py` accepted an `smt=` config and imported
+  `sponsio.integrations.smt_middleware`; `CloudClient.smt` imported
+  `sponsio.cloud.smt`. Neither module is in this build, so opting in
+  raised `ModuleNotFoundError` at construction while the public docstring
+  documented the feature. They return with the modules that make them
+  work.
+
+---
+
 ## [0.2.0a9]: 2026-09-02
 
 Follow-up to `0.2.0a8`, all of it found by running a real multi-agent app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sponsio"
-version = "0.2.0a9"
+version = "0.2.0a10"
 description = "Runtime contract enforcement for LLM agent systems"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sponsio/__init__.py
+++ b/sponsio/__init__.py
@@ -44,7 +44,7 @@ Direct guard import (advanced)::
 # shipped a wheel that introduced itself as a3 because only pyproject was
 # bumped. (Deriving this from importlib.metadata at import time costs a
 # metadata scan on every import; a two-line lockstep comment is cheaper.)
-__version__ = "0.2.0a9"
+__version__ = "0.2.0a10"
 
 # --- Main entry point ---
 from sponsio.core import Sponsio

--- a/sponsio/doctor.py
+++ b/sponsio/doctor.py
@@ -122,11 +122,18 @@ def check_optional_sdks() -> CheckResult:
     present = []
     missing = []
     for mod in watch:
-        if importlib.util.find_spec(mod) is not None:
-            # Prefer the user-facing name
-            present.append(mod.split(".")[0].replace("_", "-"))
-        else:
-            missing.append(mod.split(".")[0].replace("_", "-"))
+        # ``find_spec`` on a dotted name imports the PARENT package first,
+        # and raises when the parent is absent rather than returning None.
+        # So on a minimal install — no ``google`` at all, which is exactly
+        # what someone gets from ``pip install sponsio`` — the check whose
+        # only job is to report what is missing crashed instead, and
+        # doctor opened with a red ✗ on a healthy machine.
+        try:
+            found = importlib.util.find_spec(mod) is not None
+        except (ImportError, ValueError):
+            found = False
+        # Prefer the user-facing name
+        (present if found else missing).append(mod.split(".")[0].replace("_", "-"))
 
     present = sorted(set(present))
     missing = sorted(set(missing))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -746,5 +746,12 @@ class TestOptionalSdksOnAMinimalInstall:
 
         monkeypatch.setattr(importlib.util, "find_spec", raising)
         r = check_optional_sdks()
+
+        # The point is that it answers at all rather than raising.
         assert r.status in ("ok", "skip")
-        assert "google" in r.detail
+        # ...and that the absent one is not counted as present. The detail
+        # truncates the missing list, so read the half before the
+        # parenthetical rather than asserting on a display string whose
+        # contents depend on what else the test machine happens to have.
+        present_part = r.detail.split("(not installed:")[0]
+        assert "google" not in present_part

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -723,3 +723,28 @@ class TestCheckSkillInstalled:
         results, _code = run_doctor(tmp_path)
         names = [r.name for r in results]
         assert "Agent Skill" in names, names
+
+
+class TestOptionalSdksOnAMinimalInstall:
+    def test_a_dotted_name_whose_parent_is_absent_is_just_missing(self, monkeypatch):
+        """``find_spec`` on a dotted name imports the parent package first
+        and RAISES when it is absent, rather than returning None.
+
+        On a minimal install — no ``google`` at all, which is what
+        ``pip install sponsio`` gives you — the check whose only job is to
+        report what is missing crashed instead, and doctor opened with a
+        red ✗ on a healthy machine.
+        """
+        import importlib.util
+
+        real = importlib.util.find_spec
+
+        def raising(name, *a, **kw):
+            if name.startswith("google"):
+                raise ModuleNotFoundError("No module named 'google'")
+            return real(name, *a, **kw)
+
+        monkeypatch.setattr(importlib.util, "find_spec", raising)
+        r = check_optional_sdks()
+        assert r.status in ("ok", "skip")
+        assert "google" in r.detail


### PR DESCRIPTION
Version bump, changelog, and one fix found while verifying the release candidate.

## The release-blocker this round found

`sponsio doctor` **failed on a minimal install**:

```
✗ check_optional_sdks  uncaught: ModuleNotFoundError("No module named 'google'")
1 check(s) failed
```

`find_spec` on a dotted name imports the parent package first and raises when it is absent, so the check whose only job is to report what is missing crashed on a machine with no `google` — which is precisely what `pip install sponsio` gives you. It only shows on a pristine install, which is why no earlier run caught it: every dev venv here has `google-auth` pulled in by something.

Now: `• Optional SDKs  none installed (install langchain / openai / anthropic to use integrations)` and `All core checks passed`.

## What ships

Everything from #138–#141. The changelog entry has the full shape; the three that matter most are `scope_limit` being a string prefix rather than confinement, `never call A after B` compiling the opposite rule, and `drop table users` walking past `dangerous_sql_verbs`.

## Verified

In a **clean venv with no `sponsio_cloud`** (which is what made three tests look like failures in earlier runs):

- `2522 passed, 11 skipped` — zero failures
- `ruff check` / `ruff format --check` clean under CI's pinned 0.16.1
- TS `npm test` 20/20, including both parity scripts
- `python -m build` + `twine check` both dists PASSED

Then, from the **built wheel in a pristine venv**, every fix re-checked against the artifact a user actually installs:

```
ok   scope_limit 拦住 /safe/../etc/passwd
ok   scope_limit 拦住 /safe/../../root/.ssh/id_rsa
ok   scope_limit 拦住 /safeguard/evil.txt
ok   scope_limit 放行 /safe/ok.txt
ok   SQL 拦住 drop table users(小写)
ok   SQL 拦住 DROP TABLE users
ok   SQL 放行 SELECT dropped_at
ok   NL 语序:restore 是 commitment
ok   smt= 报 TypeError 而非 ModuleNotFoundError
ok   CheckResult 无 smt_* 字段
ok   sponsio.bridge 可导入
ok   enforce 下编译失败会硬报错
```

Plus an end-to-end run from that venv: ordering blocks then allows, `/safe/ok` allowed, `/safe/../etc/x` blocked.

The doctor regression test was checked against the bug it describes — reverting the fix fails it, restoring it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)