### PR TITLE
fix(nl): TypeScript refuses to enforce a book it could not parse

### DIFF
--- a/sponsio/generation/dsl_to_contract.py
+++ b/sponsio/generation/dsl_to_contract.py
@@ -573,7 +573,7 @@ _KEYWORD_RULES: list[tuple[list[str], str, int]] = [
     (
         [
             r"arg(?:ument)?s?\s+(?:must\s+)?not\s+contain",
-            r"(?:command|input|param)\s+must\s+not\s+contain",
+            r"(?:command|input|param|query|body|text|content|url|path)\s+must\s+not\s+contain",
             r"blacklist",
             r"must\s+not\s+contain\s+(?:.*(?:rm\s*-rf|sudo|DROP|eval))",
             r"forbid.*(?:in\s+(?:arguments?|params?|input))",
@@ -1711,9 +1711,28 @@ def parse_dsl(expr: str) -> ParsedConstraint:
                 "arg_blacklist",
                 "arg_blacklist needs at least 1 tool name",
             )
-        # If 2 actions, second might be a field name; if 1, use "command" default
+        # The field is named by the cue word in the sentence, not by the
+        # second backticked name — in "tool `bash` command must not contain
+        # `rm -rf`" the second name is the BANNED SHAPE, and taking it as
+        # the field produced
+        #   arg_field_has('bash', 'rm -rf', 'rm -rf')
+        # a rule asking whether an argument *named* `rm -rf` contains
+        # `rm -rf`. No such argument exists, so it never fired: parsed,
+        # armed, displayed, and unable to catch the thing it names.
         tool = actions[0]
-        param = actions[1] if len(actions) >= 2 else "command"
+        cue = re.search(
+            r"\b(command|query|input|params?|body|path|url|text|args?|content)\b",
+            text,
+            re.IGNORECASE,
+        )
+        if cue:
+            param = cue.group(1).lower()
+        elif len(actions) >= 2 and actions[1] not in forbidden:
+            # A second name that is not itself one of the banned shapes is
+            # the caller naming the field explicitly.
+            param = actions[1]
+        else:
+            param = "command"
         if not forbidden:
             return _build_error(
                 nl_line,

--- a/tests/cross_language/scenarios.json
+++ b/tests/cross_language/scenarios.json
@@ -207,6 +207,70 @@
           "reason": "shares the text prefix, is not under the directory"
         }
       ]
+    },
+    {
+      "name": "arg_blacklist_in_both_runtimes",
+      "contracts": [
+        "tool `bash` command must not contain `rm -rf`"
+      ],
+      "steps": [
+        {
+          "tool": "bash",
+          "args": {
+            "command": "ls -la"
+          },
+          "expect_blocked": false,
+          "reason": "harmless"
+        },
+        {
+          "tool": "bash",
+          "args": {
+            "command": "rm -rf /tmp/x"
+          },
+          "expect_blocked": true,
+          "reason": "the banned shape"
+        }
+      ]
+    },
+    {
+      "name": "requires_permission_in_both_runtimes",
+      "contracts": [
+        "tool `refund` requires permission `manager`"
+      ],
+      "steps": [
+        {
+          "tool": "refund",
+          "args": {
+            "amount": 10
+          },
+          "expect_blocked": true,
+          "reason": "no permission held"
+        }
+      ]
+    },
+    {
+      "name": "segregation_of_duty_in_both_runtimes",
+      "contracts": [
+        "`approve` and `audit` must be performed by different agents"
+      ],
+      "steps": [
+        {
+          "tool": "approve",
+          "args": {
+            "id": 1
+          },
+          "expect_blocked": false,
+          "reason": "first of the pair"
+        },
+        {
+          "tool": "audit",
+          "args": {
+            "id": 1
+          },
+          "expect_blocked": true,
+          "reason": "same agent doing both"
+        }
+      ]
     }
   ]
 }

--- a/ts/packages/sdk/src/core/nl-parser.ts
+++ b/ts/packages/sdk/src/core/nl-parser.ts
@@ -23,6 +23,8 @@ import {
   noPii,
   noKeywords,
   scopeLimit,
+  requiresPermission,
+  segregationOfDuty,
 } from "./patterns.js";
 import { Atom } from "./formula.js";
 
@@ -114,6 +116,41 @@ const KEYWORD_RULES: KeywordRule[] = [
     ],
     patternName: "scope_limit",
     minArgs: 1,
+  },
+  // Argument blacklist — a shape that must never be sent. Phrasings
+  // copied from the Python parser so one rulebook reads the same in both.
+  {
+    patterns: [
+      /arg(?:ument)?s?\s+(?:must\s+)?not\s+contain/,
+      /(?:command|input|param|query|body)\s+must\s+not\s+contain/,
+      /blacklist/,
+      /ban\s+(?:patterns?|commands?)\s+in/,
+    ],
+    patternName: "arg_blacklist",
+    minArgs: 2,
+  },
+  // Requires permission
+  {
+    patterns: [
+      /requires?\s+(?:\w+\s+)?permission/,
+      /needs?\s+permission/,
+      /must\s+have\s+permission/,
+      /requires?\s+admin\b/,
+    ],
+    patternName: "requires_permission",
+    minArgs: 2,
+  },
+  // Segregation of duty
+  {
+    patterns: [
+      /segregation of dut/,
+      /separation of dut/,
+      /different agent/,
+      /must be (?:done|performed) by different/,
+      /same agent.*cannot.*both/,
+    ],
+    patternName: "segregation_of_duty",
+    minArgs: 2,
   },
   // Must precede (last — most general, requires backtick context)
   {
@@ -268,6 +305,21 @@ export function parseNl(text: string): DetFormula | null {
         return idempotent(tools[0]);
       case "mutual_exclusion":
         return mutualExclusion(tools[0], tools[1]);
+      case "arg_blacklist": {
+        // "tool `bash` command must not contain `rm -rf`" — the first
+        // backticked name is the tool, the rest are the banned shapes.
+        // The field comes from the cue word when there is one, since a
+        // blacklist on the wrong field silently checks nothing.
+        const field =
+          (text.match(/\b(command|query|input|param|body|path|url|text)\b/) || [])[1] ??
+          "*";
+        if (tools.length < 2) continue;
+        return argBlacklist(tools[0], field, tools.slice(1));
+      }
+      case "requires_permission":
+        return requiresPermission(tools[0], tools[1]);
+      case "segregation_of_duty":
+        return segregationOfDuty(tools[0], tools[1]);
       case "scope_limit": {
         // The roots are the path-shaped arguments; the tool is whatever
         // else was named. "restrict file access to `/workspace`" names no

--- a/ts/packages/sdk/src/index.ts
+++ b/ts/packages/sdk/src/index.ts
@@ -281,17 +281,40 @@ export class Sponsio {
     this.mode = resolveMode(options.mode, yamlMode);
 
     // ── Parse NL strings into det formulas ───────────────────────────
+    // A contract that does not parse is a rule that is not there. In
+    // observe mode that is a warning, because the point of observe is to
+    // keep running and surface what would fire. In enforce it is fatal:
+    // the alternative is an agent that reports success while enforcing a
+    // book with holes in it, and the operator has no way to know which
+    // holes. Python raises here; TypeScript logged one line and ran on.
+    const unparsed: string[] = [];
     for (const c of sources) {
       if (typeof c === "string") {
         const parsed = parseNl(c);
         if (parsed) {
           this._contracts.push(parsed);
         } else {
-          console.warn(`[sponsio] Could not parse: "${c}"`);
+          unparsed.push(c);
         }
       } else {
         this._contracts.push(c);
       }
+    }
+    if (unparsed.length > 0) {
+      const listed = unparsed.map((c) => `  - ${c}`).join("\n");
+      if (this.mode === "enforce") {
+        throw new Error(
+          `sponsio: ${unparsed.length} contract(s) could not be parsed, and ` +
+            `this guard is in enforce mode. THESE RULES ARE NOT ARMED. Fix ` +
+            `them, or write them as structured \`pattern:\` blocks in a ` +
+            `sponsio.yaml, which covers every pattern the library has.\n` +
+            listed,
+        );
+      }
+      console.warn(
+        `[sponsio] ${unparsed.length} contract(s) could not be parsed and ` +
+          `are NOT armed (observe mode, so the run continues):\n${listed}`,
+      );
     }
 
     // ── Sto pipeline is not part of this build ──────────────────────


### PR DESCRIPTION
## The half that mattered

A contract that does not parse is a rule that is not there. Python raises. TypeScript logged one line and ran on:

```
[sponsio] Could not parse: "tool `run_sql` query must not contain `DROP`"
  DROP TABLE users  -> 放行
```

So a TS agent enforced a book with holes in it and reported success, and the operator had no way to know which holes. Enforce mode throws now, naming every contract it could not read. Observe still runs — that is what observe is for — but says the rules are **NOT armed** rather than "could not parse".

## The half I overstated, corrected

I reported this as "TS covers 9 of 40 patterns". That was wrong in the way that matters: **TypeScript fully supports the structured `pattern:` form**, which is how real rulebooks are written and what the console hands you. All three of `dangerous_sql_verbs`, `ctx_required`, `scope_limit` load and enforce correctly from a yaml, lowercase SQL and path traversal included.

The gap is only in NL strings. Measured over fifteen realistic sentences: Python 13/15, TypeScript 11/15. The three TS-only misses — `arg_blacklist`, `requires_permission`, `segregation_of_duty` — now parse, using Python's own phrasings so one rulebook reads the same in either runtime. TypeScript is now 13/15, level with Python; the two both miss (`tool_allowlist`, `bounded_retry`) are a Python gap too.

## A fourth rule that looked armed and was not

The scenario added for `arg_blacklist` found it. Python parsed

```
tool `bash` command must not contain `rm -rf`
```

into `arg_field_has('bash', 'rm -rf', 'rm -rf')` — it took the **banned shape as the field name**, so the rule asked whether an argument *named* `rm -rf` contains `rm -rf`. No such argument exists. Parsed, armed, displayed, and unable to catch the thing it names.

The field is read from the sentence's cue word now, which is what the new TypeScript path already did. `query` was also missing from the cue list, so `` tool `run_sql` query must not contain `DROP` `` did not parse at all.

## Verified

- `2502 passed, 37 skipped`. The three failures in `test_oss_sto_gate.py` / `test_config_sections.py` are the known local-venv artifact (`sponsio_cloud` importable); a clean venv during the 0.2.0a10 release verification ran `2522 passed, 0 failed`.
- TS `npm test` 20/20. Cross-language scenarios: Python 18 passed, TS **25 passed, 0 failed**.
- `ruff check` / `format --check` clean.
- Three scenarios added to `tests/cross_language/scenarios.json`, so neither runtime can drift back alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)