### PR TITLE
fix(bridge): a run records which rulebook version it enforced

### DIFF
--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -97,10 +97,15 @@ def _say_of(response: Any) -> str:
 def _own_book(stamp: str, agent: str) -> str | None:
     """This agent's ``agent@vN`` out of a checkout stamp.
 
-    A whole-project pull is stamped "<project> a@v3 b@v1 ... sha:..."; a
+    A whole-project pull is stamped "<project> [a@v3 b@v1 ...] sha:..."; a
     single-agent pull "<project>@vN" with no agent prefix at all.
+
+    The list is bracketed, so the last entry arrives as ``b@v1]`` — which
+    parses as a version of None and reads in the console as a book nobody
+    published. It only ever bit the agent that sorted last, which is why
+    it survived: in a four-agent project the other three were fine.
     """
-    tokens = [t for t in stamp.split() if "@v" in t]
+    tokens = [t.strip("[](),") for t in stamp.split() if "@v" in t]
     for token in tokens:
         if token.startswith(f"{agent}@v"):
             return token
@@ -156,6 +161,7 @@ class BridgeSession:
         # clock. 64 bits from the system CSPRNG puts a collision out of reach.
         self.session_id = session_id or ("run-" + secrets.token_hex(8))
         self.mode = getattr(guard, "mode", None) or "observe"
+        self.rulebook_stamp = getattr(guard, "rulebook_stamp", None)
         self.root_agent = getattr(guard, "agent_id", "agent")
         self.started_at = int(time.time() * 1000)
         self.steps: list[dict] = []
@@ -436,7 +442,18 @@ class BridgeSession:
         # Which book this run enforced, when the config came from the cloud.
         # Absent for a local file, and absent is honest: a fabricated version
         # would make a replay claim to reproduce something it cannot.
-        stamp = os.environ.get("SPONSIO_RULEBOOK_STAMP", "").strip()
+        # Two ways a run knows which book it enforced:
+        # `config="sponsio://project"` sets the env var while resolving,
+        # and a checkout written to a file carries the stamp as its first
+        # line, which the loader keeps. Only the first was read, so an app
+        # that pulls the yaml itself — the shape the console's own wiring
+        # instructions produce — recorded no book at all. Every real run
+        # read `book=None` while replays, stamped server-side, showed a
+        # version.
+        stamp = (
+            os.environ.get("SPONSIO_RULEBOOK_STAMP", "").strip()
+            or str(self.rulebook_stamp or "").strip()
+        )
         if stamp:
             # The checkout stamp names every agent in the project
             # ("default a@v3 b@v1 ... sha:..."); a run is ONE agent's, so

--- a/sponsio/config.py
+++ b/sponsio/config.py
@@ -338,6 +338,12 @@ class SponsoConfig:
     runtime: RuntimeSection = field(default_factory=RuntimeSection)
     tool_policy: ToolPolicySection = field(default_factory=ToolPolicySection)
     top_level_mode: str | None = None
+    # The checkout this file came from, e.g.
+    # "default [quant@v46 support@v1] sha:4f8379ad9c1e". `sponsio pull` and
+    # the cloud checkout write it as the file's first line; a hand-written
+    # yaml has none. It is what answers "which rules was this run checked
+    # against", which nothing else in the payload can.
+    rulebook_stamp: str | None = None
     """A bare top-level ``mode:``. Documented in
     docs/reference/config-yaml.md as the global default, so a file written
     exactly as documented has to work; it is the lowest-precedence yaml
@@ -1449,10 +1455,18 @@ def load_config(path: str | Path) -> SponsoConfig:
         raise FileNotFoundError(f"Config file not found: {path}")
 
     try:
-        with open(path) as f:
-            raw = yaml.safe_load(f)
+        text = path.read_text()
+        raw = yaml.safe_load(text)
     except yaml.YAMLError as e:
         raise ConfigError(f"Invalid YAML: {e}")
+
+    # The checkout stamp is a comment, so the YAML parse drops it. Read it
+    # off the raw text before it is gone: it is the only record of which
+    # rulebook version the run is about to enforce.
+    stamp = None
+    first = text.lstrip().split("\n", 1)[0].strip() if text.strip() else ""
+    if first.startswith("#") and "rulebook:" in first:
+        stamp = first.split("rulebook:", 1)[1].strip() or None
 
     if not isinstance(raw, dict):
         raise ConfigError("Config must be a YAML mapping (dict)")
@@ -1471,6 +1485,7 @@ def load_config(path: str | Path) -> SponsoConfig:
         runtime=_parse_runtime_section(raw.get("runtime")),
         tool_policy=_parse_tool_policy_section(raw.get("tool_policy")),
         top_level_mode=_parse_top_level_mode(raw.get("mode")),
+        rulebook_stamp=stamp,
     )
 
     # Parse tools section

--- a/sponsio/core.py
+++ b/sponsio/core.py
@@ -619,6 +619,11 @@ def Sponsio(  # noqa: N802 (branded factory function)
         )
         cfg_kwargs["verbose"] = verbose
         cfg_kwargs["verbosity"] = verbosity
+        # Carry the checkout stamp through to the guard so a run can say
+        # which rulebook version it enforced. Set after construction
+        # rather than as a kwarg: every adapter's __init__ would otherwise
+        # have to learn about it, and none of them use it.
+        _stamp = getattr(parsed, "rulebook_stamp", None)
         if dashboard_url is not None:
             cfg_kwargs["dashboard_url"] = dashboard_url
         if otel_exporter is not None:
@@ -634,7 +639,10 @@ def Sponsio(  # noqa: N802 (branded factory function)
         cfg_kwargs["tool_policy"] = parsed.tool_policy
         cfg_kwargs.update(kwargs)
 
-        return guard_cls(**cfg_kwargs)
+        guard = guard_cls(**cfg_kwargs)
+        if _stamp:
+            guard.rulebook_stamp = _stamp
+        return guard
 
     # Inline mode
     # Forward the parsed/typed policy so BaseGuard can synthesize the

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -604,3 +604,50 @@ def test_contract_rows_carry_the_pattern_body(tmp_path):
     row = next(iter(run.contracts.values()))
     assert row["pattern"] == "must_precede"
     assert row["args"] == ["warmup", "ping"]
+
+
+def test_a_run_records_the_book_it_enforced(tmp_path):
+    """`config="sponsio://project"` sets an env var while resolving, but a
+    checkout written to a file carries the stamp as its first line — the
+    shape the console's own wiring instructions produce.
+
+    Only the env var was read, so those runs recorded no book at all and
+    the console could not say which rules were in force. Replays, stamped
+    server-side, showed a version; real runs showed none.
+    """
+    guard, client = FakeGuard(), FakeClient()
+    guard.rulebook_stamp = "default [other@v3 quant@v46] sha:abc123"
+    guard.agent_id = "quant"
+
+    run = attach(guard, client=client, runs_dir=tmp_path)
+    vm = run.view_model()
+
+    # The checkout names every agent; a run is one agent's.
+    assert vm["rulebook"] == "quant@v46"
+    assert vm["rulebookRef"] == "default [other@v3 quant@v46] sha:abc123"
+    assert vm["session"]["rulebookVersion"] == 46
+
+
+def test_no_stamp_stays_absent(tmp_path):
+    """A hand-written yaml has no checkout. Absent is honest — a
+    fabricated version would make a replay claim to reproduce something
+    it cannot."""
+    guard, client = FakeGuard(), FakeClient()
+    run = attach(guard, client=client, runs_dir=tmp_path)
+    vm = run.view_model()
+    assert "rulebook" not in vm or not vm["rulebook"]
+
+
+def test_the_last_agent_in_the_bracketed_list_keeps_its_version(tmp_path):
+    """The checkout list is bracketed, so its last entry arrives as
+    `b@v1]` and parsed as a version of None — a book nobody published.
+
+    It only bit the agent that sorted last, which is why it survived: in
+    a four-agent project the other three were fine.
+    """
+    guard, client = FakeGuard(agent_id="zulu"), FakeClient()
+    guard.rulebook_stamp = "default [alpha@v3 zulu@v9] sha:abc123"
+    run = attach(guard, client=client, runs_dir=tmp_path)
+    vm = run.view_model()
+    assert vm["rulebook"] == "zulu@v9"
+    assert vm["session"]["rulebookVersion"] == 9


### PR DESCRIPTION
Every ingested run showed `book=None` in the console, so the one question an audit trail exists for — *which rules were in force when this ran* — had no answer. Replays showed a version, because the server assigns theirs. Real runs showed none.

## The mechanism was already here

Complete, down to reducing the whole checkout to this agent's own book and setting `session.rulebookVersion`. It read exactly one source: the env var `resolve_config_ref` sets while resolving `config="sponsio://project"`.

An app that pulls the rulebook itself and hands `Sponsio()` the resulting file never goes through that path. That is the shape the console's own wiring instructions produce, and it is what quant-agent does.

So the feature worked on one entry path and was invisible on the other:

```
config="sponsio://alpha"        ->  book records correctly
config="sponsio.cloud.yaml"     ->  book=None
```

The stamp is the checkout's first line — `# rulebook: default [quant@v46 ...] sha:...` — which the YAML parse drops as a comment. `load_config` keeps it now, `Sponsio()` hands it to the guard, and the bridge reads it when the env var is unset.

Verified against the real quant-agent config:

```
vm.rulebook             = 'quant@v46'
vm.rulebookRef          = 'default [e2e-night@v1 orchestrator@v2 quant@v46 ...]'
session.rulebookVersion = 46
```

A hand-written yaml still records nothing, which is honest — a fabricated version would make a replay claim to reproduce something it cannot.

## Writing the test found a second one

The checkout list is bracketed, so `_own_book` returned the last entry as `zulu@v9]`, whose version parses as `None` — a book nobody published. It only ever bit the agent that sorted last, which is why a four-agent project looked fine.

## Verified

`2499 passed, 34 skipped`; the three failures in `test_oss_sto_gate.py` / `test_config_sections.py` are the known local-venv artifact (`sponsio_cloud` importable) and were `0 failed` in a clean venv during the 0.2.0a10 release check. `ruff check` / `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)