### PR TITLE
fix(nl): arg_blacklist names the field the sentence names

### DIFF
--- a/sponsio/generation/dsl_to_contract.py
+++ b/sponsio/generation/dsl_to_contract.py
@@ -573,6 +573,11 @@ _KEYWORD_RULES: list[tuple[list[str], str, int]] = [
     (
         [
             r"arg(?:ument)?s?\s+(?:must\s+)?not\s+contain",
+            # "arg `command` must not contain ..." — the form
+            # `sponsio patterns` advertises, where the field is
+            # quoted between the marker and the verb.
+            r"\b(?:arg|argument|field|param(?:eter)?)s?\s+[`\"']"
+            r"[^`\"']+[`\"']\s+(?:must\s+)?not\s+contain",
             r"(?:command|input|param|query|body|text|content|url|path)\s+must\s+not\s+contain",
             r"blacklist",
             r"must\s+not\s+contain\s+(?:.*(?:rm\s*-rf|sudo|DROP|eval))",
@@ -1720,16 +1725,31 @@ def parse_dsl(expr: str) -> ParsedConstraint:
         # `rm -rf`. No such argument exists, so it never fired: parsed,
         # armed, displayed, and unable to catch the thing it names.
         tool = actions[0]
-        cue = re.search(
-            r"\b(command|query|input|params?|body|path|url|text|args?|content)\b",
+        # Three ways a sentence names the field, in the order they win.
+        #
+        # 1. Marked explicitly — "tool `bash` arg `command` must not ...",
+        #    which is the form `sponsio patterns` advertises. `arg` here
+        #    is a MARKER meaning "the field is next", never the field
+        #    itself; reading it as one produced arg_field_has(bash, 'arg')
+        #    and a rule that watches an argument nobody sends.
+        # 2. A cue word naming a real field — "... command must not ...".
+        # 3. A second backticked name that is not itself one of the banned
+        #    shapes: the caller naming the field without a marker.
+        marked = re.search(
+            r"\b(?:arg|argument|field|param(?:eter)?)s?\s+[`\"']([^`\"']+)[`\"']",
             text,
             re.IGNORECASE,
         )
-        if cue:
+        cue = re.search(
+            r"\b(command|query|input|body|path|url|text|content|param|parameter)\b",
+            text,
+            re.IGNORECASE,
+        )
+        if marked:
+            param = marked.group(1).strip()
+        elif cue:
             param = cue.group(1).lower()
         elif len(actions) >= 2 and actions[1] not in forbidden:
-            # A second name that is not itself one of the banned shapes is
-            # the caller naming the field explicitly.
             param = actions[1]
         else:
             param = "command"

--- a/tests/test_nl_parser.py
+++ b/tests/test_nl_parser.py
@@ -471,3 +471,61 @@ class TestPatternCoverageViaNL:
         assert result.pattern_name == expected_pattern, (
             f"Expected {expected_pattern}, got {result.pattern_name} for: {nl!r}"
         )
+
+
+class TestArgBlacklistNamesTheRightField:
+    """Every phrasing the docs and the CLI catalog advertise.
+
+    A blacklist aimed at the wrong field is a rule that parses, arms,
+    prints ACTIVE, and can never fire — the worst shape a bug can take
+    in a product whose job is to stop things. Two of these forms shipped
+    broken in different releases, in opposite directions, so they are
+    pinned together.
+    """
+
+    @pytest.mark.parametrize(
+        "text,tool,field",
+        [
+            # `sponsio patterns` prints this one.
+            ("tool `bash` arg `command` must not contain `rm -rf`", "bash", "command"),
+            # docs/reference/patterns.md prints this one.
+            ("tool `bash` command must not contain `rm -rf`", "bash", "command"),
+            ("`run_sql` query must not contain `DROP`", "run_sql", "query"),
+            ("tool `api` argument `url` must not contain `http://`", "api", "url"),
+            ("tool `db` field `sql` must not contain `DROP`", "db", "sql"),
+        ],
+    )
+    def test_the_field_is_the_one_the_sentence_names(self, text, tool, field):
+        r = parse_nl_rule_based(text)
+        assert r.ok, r.error
+        assert r.pattern_name == "arg_blacklist"
+        assert r.args[0] == tool
+        assert r.args[1] == field
+
+    def test_the_marker_word_is_never_the_field(self):
+        """`arg` in "arg `command`" says the field is next; it is not the
+        field. Reading it as one built arg_field_has(bash, 'arg', ...) —
+        a rule watching an argument nobody sends."""
+        r = parse_nl_rule_based("tool `bash` arg `command` must not contain `rm -rf`")
+        assert r.args[1] != "arg"
+
+    def test_it_actually_blocks(self):
+        import warnings
+
+        import sponsio
+
+        for text in (
+            "tool `bash` arg `command` must not contain `rm -rf`",
+            "tool `bash` command must not contain `rm -rf`",
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                guard = sponsio.Sponsio(
+                    agent_id="t",
+                    contracts=[text],
+                    mode="enforce",
+                    verbose=False,
+                    init_banner=False,
+                )
+            assert not guard.guard_before("bash", {"command": "rm -rf /"}).allowed, text
+            assert guard.guard_before("bash", {"command": "ls -la"}).allowed, text


### PR DESCRIPTION
Found by a fresh-eyes agent given only the docs and told to record every place it got stuck. It found this in ~25 minutes.

Both phrasings the product itself advertises produced a rule that can never fire — in opposite directions, in different releases.

`sponsio patterns` prints:

```
tool `bash` arg `command` must not contain `rm -rf`
```

0.2.0a11 compiles that to `arg_field_has('bash', 'arg', 'rm -rf')` — a rule watching an argument named `arg`, which nothing sends. It parses ✓, arms `ACTIVE`, and `bash(command="rm -rf /")` goes straight through.

**That one is my regression.** The cue-word list I added in a11 included `args?`, and the marker word `arg` sits earlier in the sentence than the field it marks. Before a11 this form was correct.

`docs/reference/patterns.md` prints:

```
tool `bash` command must not contain `rm -rf`
```

which a11 fixed and a10 got wrong the other way, taking the banned shape as the field name.

So each release had exactly one of the two right, and the one that shipped broken was whichever a user happened to copy.

## The fix

Three ways a sentence names the field, in the order they win:

1. **Marked** — `arg \`command\``, `argument \`url\``, `field \`sql\``. The marker says *the field is next*; it is never the field.
2. **A cue word** naming a real field — `command`, `query`, `body`, `path`, …
3. **A second backticked name** that is not one of the banned shapes.

The classifier also learns the marked form, which it did not recognise at all — `` tool `api` argument `url` must not contain `http://` `` failed to parse.

## Verified

Five phrasings pinned, and the tests assert the rule **actually blocks** `rm -rf /` and **actually admits** `ls -la` — not merely that it parses. Parsing was never the problem.

`2512 passed, 37 skipped`; the three failures in `test_oss_sto_gate.py` / `test_config_sections.py` are the known local-venv artifact (`sponsio_cloud` importable) and run clean in a fresh venv. `ruff check` / `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)