### PR TITLE
fix(docs): the docs home page's own call to action was a 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,12 @@ jobs:
       - name: Check linting
         run: ruff check sponsio/ tests/ scripts/
 
+      - name: Check documentation links
+        # Two files were renamed and ten references were not, including
+        # the one on the docs home page that is its primary call to
+        # action. Nothing in the build noticed.
+        run: python scripts/check_doc_links.py
+
       - name: Check README/QUICKSTART command sync
         run: |
           # Canonical user-journey commands that must appear in user-facing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,7 +370,7 @@ path. We'll acknowledge within 72 hours and coordinate disclosure.
 
 ## What belongs in this repo (and what doesn't)
 
-**Ship with open source:** user-facing guides, contract and architecture reference, and design notes (e.g. [`docs/cost-based-thresholds.md`](docs/cost-based-thresholds.md)).
+**Ship with open source:** user-facing guides, contract and architecture reference, and design notes (e.g. [`docs/concepts/assume-enforce-semantics.md`](docs/concepts/assume-enforce-semantics.md)).
 
 **Keep out of the public tree** (or redact before publishing):
 

--- a/docs/concepts/assume-enforce-semantics.md
+++ b/docs/concepts/assume-enforce-semantics.md
@@ -151,4 +151,4 @@ The runtime never blocks an agent action for failing to satisfy an assumption; i
 
 ---
 
-**Related:** [Contracts](contracts.md) · [Architecture](architecture.md) · [Formal methods](formal-methods.md) · [Pattern catalog](../reference/patterns.md)
+**Related:** [Pattern catalog](../reference/patterns.md) · [Architecture](architecture.md) · [Formal methods](formal-methods.md) · [Pattern catalog](../reference/patterns.md)

--- a/docs/concepts/formal-methods.md
+++ b/docs/concepts/formal-methods.md
@@ -66,8 +66,8 @@ Formal methods do not magic away every failure mode:
 - Pnueli, *The temporal logic of programs* (1977). Original LTL paper, very readable.
 - Baier & Katoen, *Principles of Model Checking* (2008). Chapters 5–7 cover LTL → automata in depth.
 - [Architecture](architecture.md). How Sponsio's grounding, monitor, and verifier components fit together.
-- [Contracts](contracts.md). The actual atom vocabulary and contract DSL syntax.
+- [Pattern catalog](../reference/patterns.md). The actual atom vocabulary and contract DSL syntax.
 
 ---
 
-**Related:** [Quickstart](../getting-started/quickstart.md) · [Contracts](contracts.md) · [CLI reference](../reference/cli.md) · [Integrations](../integrations/index.md) · [Architecture](architecture.md) · [OWASP coverage](owasp-coverage.md)
+**Related:** [Write your first contract](../getting-started/first-contract.md) · [Pattern catalog](../reference/patterns.md) · [CLI reference](../reference/cli.md) · [Integrations](../integrations/index.md) · [Architecture](architecture.md) · [OWASP coverage](owasp-coverage.md)

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -137,6 +137,6 @@ Deterministic formulas are evaluated in microseconds. A violation routes through
 ## Next
 
 - [Architecture](architecture.md): LTL semantics, grounding internals, why the atom vocabulary is the observation boundary.
-- [Deterministic contracts](contracts.md): the pattern library and how each pattern compiles to LTL.
+- [Deterministic contracts](../reference/patterns.md): the pattern library and how each pattern compiles to LTL.
 - [Write your first contract](../getting-started/first-contract.md): hands-on walkthrough.
 - [Integrations](../integrations/index.md): wire it into your framework (LangGraph, Claude Agent SDK, OpenAI, CrewAI, Google ADK, Vercel AI, MCP, or custom).

--- a/docs/concepts/owasp-coverage.md
+++ b/docs/concepts/owasp-coverage.md
@@ -261,5 +261,5 @@ Four mechanisms apply across all ten risks.
 - [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
 - [Agentic AI Threats and Mitigations (T01-T17)](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
 - Pattern catalog: [Patterns](../reference/patterns.md)
-- Contract DSL: [Contracts](contracts.md)
+- Contract DSL: [Pattern catalog](../reference/patterns.md)
 - Contract bundles: [Contract library](../reference/contract-lib.md)

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -96,6 +96,6 @@ Replays a packaged unsafe-agent trajectory locally, no API key, no framework SDK
 
 ## Next
 
-- [Quickstart](quickstart.md): block an unsafe tool call in 60 seconds.
+- [Write your first contract](first-contract.md): block an unsafe tool call in 60 seconds.
 - [First contract](first-contract.md): write a custom contract against your own agent.
 - [Integrations](../integrations/index.md): plug Sponsio into your framework.

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -103,7 +103,7 @@ Yes. The eval script is `ODCV-Bench/eval_sponsio.py`; scenarios and replay tooli
 
 ## Reading order
 
-- **New here?** → [README](../../README.md) for the pitch, then [Quickstart](../getting-started/quickstart.md).
+- **New here?** → [README](../../README.md) for the pitch, then [Write your first contract](../getting-started/first-contract.md).
 - **Writing your first contract?** → [First contract](../getting-started/first-contract.md).
 - **Adopting in an existing repo?** → [Onboarding](onboarding.md).
 - **Shipping to production?** → [Observe vs. enforce](observe-vs-enforce.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ pip install --pre sponsio
 sponsio init .
 ```
 
-Then go to the [Quickstart](getting-started/quickstart.md).
+Then go to the [Write your first contract](getting-started/first-contract.md).
 
 ## Sections
 

--- a/docs/reference/benchmark-libraries.md
+++ b/docs/reference/benchmark-libraries.md
@@ -72,4 +72,4 @@ Each contract carries an `applicability` tag. Treat it as a hint about how much 
 
 - Sponsio's pattern factories: [`sponsio/patterns/library.py`](../../sponsio/patterns/library.py) (`arg_blacklist`, `must_precede`, `rate_limit`, `loop_detection`, `arg_length_limit`, etc.).
 - Capability packs auto-loaded by onboard: [`docs/reference/contract-lib.md`](contract-lib.md).
-- The `sponsio scan` CLI: [`sponsio/cli.py`](../../sponsio/cli.py).
+- The `sponsio scan` CLI: [`sponsio/cli/`](../../sponsio/cli/__init__.py).

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -157,4 +157,4 @@ Sponsio's evaluation harnesses for all three benchmarks (the `eval_sponsio.py` /
 
 ---
 
-**Related:** [README §Benchmarks](../../README.md#benchmarks--performance) · [Quickstart](../getting-started/quickstart.md) · [Patterns](patterns.md) · [Architecture](../concepts/architecture.md) · [OSS scope](oss-scope.md)
+**Related:** [README §Benchmarks](../../README.md#benchmarks--performance) · [Write your first contract](../getting-started/first-contract.md) · [Patterns](patterns.md) · [Architecture](../concepts/architecture.md) · [OSS scope](oss-scope.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -82,7 +82,7 @@ sponsio init . --apply "framework=langgraph;ides=claude-code:full;mode=observe" 
 sponsio init . --plan "framework=crewai;ides=cursor:skill"                  # dry-run preview
 ```
 
-See [getting-started/quickstart.md](../getting-started/quickstart.md) for the typical interactive flow.
+See [getting-started/first-contract.md](../getting-started/first-contract.md) for the typical interactive flow.
 
 ## sponsio onboard
 

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Every relative link in the docs points at a file that exists.
+
+Two files were renamed and ten references were not, including the one on
+`docs/index.md` that is the docs home page's primary call to action. A
+reader following the site's own front door got a 404, and nothing in the
+build noticed.
+
+Only relative links to files inside the repo are checked. External URLs,
+anchors, and mailto: are out of scope — this catches renames, which is
+the failure that actually happened.
+
+    python scripts/check_doc_links.py          # repo docs + top-level md
+    python scripts/check_doc_links.py docs/    # a subtree
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# [text](target) — captures the target, minus any #anchor or ?query.
+LINK = re.compile(r"\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+
+SKIP_PREFIXES = ("http://", "https://", "mailto:", "#", "tel:")
+
+
+def strip_code(text: str) -> str:
+    """Blank out fenced and inline code, keeping line numbers intact.
+
+    `registry[tool](**args)` inside a python block is not a link, and
+    reading it as one puts noise in front of the real breakage.
+    """
+    out, fenced = [], False
+    for line in text.split("\n"):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            out.append("")
+            continue
+        out.append("" if fenced else re.sub(r"`[^`]*`", "", line))
+    return "\n".join(out)
+
+
+def targets(text: str):
+    text = strip_code(text)
+    for match in LINK.finditer(text):
+        target = match.group(1)
+        if target.startswith(SKIP_PREFIXES):
+            continue
+        # Strip an anchor; a link to a section of a real file is fine.
+        target = target.split("#", 1)[0].split("?", 1)[0]
+        if target:
+            yield target, text[: match.start()].count("\n") + 1
+
+
+def check(roots: list[Path]) -> list[tuple[Path, int, str]]:
+    broken: list[tuple[Path, int, str]] = []
+    for root in roots:
+        files = [root] if root.is_file() else sorted(root.rglob("*.md"))
+        for path in files:
+            if "node_modules" in path.parts:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for target, line in targets(text):
+                if not (path.parent / target).resolve().exists():
+                    broken.append((path, line, target))
+    return broken
+
+
+def main(argv: list[str]) -> int:
+    repo = Path(__file__).resolve().parent.parent
+    if len(argv) > 1:
+        roots = [Path(a) for a in argv[1:]]
+    else:
+        roots = [repo / "docs"] + sorted(repo.glob("*.md"))
+    roots = [r for r in roots if r.exists()]
+
+    broken = check(roots)
+    if not broken:
+        checked = sum(
+            1 for r in roots for _ in ([r] if r.is_file() else r.rglob("*.md"))
+        )
+        print(f"all relative doc links resolve ({checked} file(s) checked)")
+        return 0
+
+    print(f"{len(broken)} broken relative link(s):", file=sys.stderr)
+    for path, line, target in broken:
+        rel = path.relative_to(repo) if repo in path.parents else path
+        print(f"  {rel}:{line} -> {target}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
`docs/index.md` line 17 says "Then go to the [Quickstart](getting-started/quickstart.md)". That file does not exist — it was renamed to `first-contract.md`. Nine other references to it and to `concepts/contracts.md` are equally dead, from `install.md`, `faq.md`, `overview.md`, `formal-methods.md`, `assume-enforce-semantics.md`, `owasp-coverage.md`, `benchmarks.md` and `cli.md`.

All ten now point where the content actually lives. Two more surfaced while checking: `sponsio/cli.py` became a package, and CONTRIBUTING illustrated "docs we ship with open source" with a file that has never existed.

## The check

`scripts/check_doc_links.py` resolves every relative markdown link in the repo and runs in CI's lint job. Nothing in the build noticed ten dead links, one of them on the front door.

It skips fenced and inline code — `registry[tool](**args)` in a python block parses as a link and buried the two real failures under two false ones on the first run. Verified by breaking a link deliberately: exit 1 with the file, line and target; restored, exit 0 over 45 files.

## Note on scope

This started from a fresh-eyes report that also flagged `pip install sponsio` (without `--pre`) in QUICKSTART and install.md. **That one is already correct on main** — both say `--pre`, and install.md explains why it is required. The report was generated against a working tree pinned to an older commit. The broken links are real on main and are what this PR fixes.

## Verified

`2505 passed, 37 skipped`; the three failures are the known local-venv artifact (`sponsio_cloud` importable) and run clean in a fresh venv. `ruff check` / `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)