### PR TITLE
fix(cli): the CI gate exits 1, and the report stops calling no-record zero

### DIFF
--- a/sponsio/cli/commands/check.py
+++ b/sponsio/cli/commands/check.py
@@ -275,3 +275,11 @@ def check(trace_path, contracts, config_path, agent_id, as_json):
                 click.style(f"  \u2717 {fails}/{total} contract(s) VIOLATED", fg="red")
             )
         click.echo()
+
+    # Non-zero on a violation, so a CI job wired the way the docs describe
+    # actually fails. `docs/reference/cli.md` says every command exits 0 on
+    # success and 1 on failure, and lists a violation as failure — this
+    # command printed "✗ 1/1 contract(s) VIOLATED" and exited 0, so the
+    # gate was green no matter what the trace contained.
+    if passed < total:
+        sys.exit(1)

--- a/sponsio/integrations/base.py
+++ b/sponsio/integrations/base.py
@@ -852,6 +852,21 @@ class BaseGuard:
         contracts_list = list(self._system._contracts)
         if init_banner:
             print_banner(contracts_list)
+            # QUICKSTART reads as a continuous rollout — observe, review
+            # the report, flip to enforce — and nothing said the durable
+            # record stops at the flip. `sponsio report`, `replay` and
+            # `export-sessions` all go quiet at the moment an operator
+            # most wants them, and the report used to call that zero
+            # blocks rather than no record.
+            if self._mode != "observe" and self._session_log_dir is None:
+                import sys as _sys
+
+                print(
+                    "  note: enforce mode keeps no session log by default, so "
+                    "`sponsio report` / `replay` / `export-sessions` will have "
+                    "nothing to read.\n        pass session_log_dir= to keep one.",
+                    file=_sys.stderr,
+                )
 
         self._terminal_reporter: TerminalReporter | None = None
         if self._verbose:

--- a/sponsio/reporting/renderer.py
+++ b/sponsio/reporting/renderer.py
@@ -94,7 +94,19 @@ def render_markdown(report: Report) -> str:
     lines.append(f"**Sessions:** {report.total_sessions}")
     lines.append(f"**Events evaluated:** {report.total_events}")
     lines.append(f"**Violations caught:** {report.violations}")
-    lines.append(f"**Actually blocked (enforce mode):** {report.blocked}")
+    # An enforce run writes no session log by default (BaseGuard skips the
+    # JSONL logger outside observe, to avoid surprise writes to $HOME), so
+    # a zero here means "not recorded", not "did not happen" — and this
+    # line said the second. A run that blocked four calls reported
+    # "Actually blocked (enforce mode): 0".
+    if report.blocked:
+        lines.append(f"**Actually blocked (enforce mode):** {report.blocked}")
+    else:
+        lines.append(
+            "**Actually blocked (enforce mode):** not recorded — enforce runs "
+            "are not logged by default; pass `session_log_dir=` to Sponsio() "
+            "to keep them"
+        )
     lines.append(f"**Would-have-blocked (observe mode):** {report.observed}")
     lines.append(f"**Sto retries:** {report.retrying}")
     lines.append(f"**Pass rate:** {report.pass_rate * 100:.1f}%")

--- a/tests/test_cli_check_exit.py
+++ b/tests/test_cli_check_exit.py
@@ -1,0 +1,112 @@
+"""`sponsio check` is a CI gate, so its exit code has to mean something.
+
+`docs/reference/cli.md` states that every command exits 0 on success and
+1 on failure, and lists a contract violation as failure. This command
+printed "✗ 1/1 contract(s) VIOLATED" and exited 0, so a job wired the way
+the docs describe was green whatever the trace contained.
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from sponsio.cli import check
+
+
+def _trace(tmp_path, tools):
+    """An OTLP file with one span per tool, in order."""
+    spans = [
+        {
+            "traceId": "0" * 32,
+            "spanId": f"{i:016x}",
+            "name": name,
+            "startTimeUnixNano": str(1_000_000_000 * (i + 1)),
+            "endTimeUnixNano": str(1_000_000_000 * (i + 1) + 1000),
+            "attributes": [{"key": "tool.name", "value": {"stringValue": name}}],
+        }
+        for i, name in enumerate(tools)
+    ]
+    path = tmp_path / "trace.json"
+    path.write_text(
+        json.dumps(
+            {
+                "resourceSpans": [
+                    {
+                        "resource": {
+                            "attributes": [
+                                {
+                                    "key": "service.name",
+                                    "value": {"stringValue": "bot"},
+                                }
+                            ]
+                        },
+                        "scopeSpans": [{"scope": {"name": "t"}, "spans": spans}],
+                    }
+                ]
+            }
+        )
+    )
+    return str(path)
+
+
+def _config(tmp_path):
+    path = tmp_path / "sponsio.yaml"
+    path.write_text(
+        'version: "1"\nagents:\n  bot:\n    contracts:\n'
+        '      - G: "tool `check_policy` must precede `issue_refund`"\n'
+    )
+    return str(path)
+
+
+def test_a_violation_exits_nonzero(tmp_path):
+    """`issue_refund` before `check_policy` breaks the ordering."""
+    result = CliRunner().invoke(
+        check,
+        [
+            "--trace",
+            _trace(tmp_path, ["issue_refund", "check_policy"]),
+            "--config",
+            _config(tmp_path),
+            "--agent",
+            "bot",
+        ],
+    )
+    assert "VIOLATED" in result.output
+    assert result.exit_code == 1
+
+
+def test_a_clean_trace_exits_zero(tmp_path):
+    result = CliRunner().invoke(
+        check,
+        [
+            "--trace",
+            _trace(tmp_path, ["check_policy", "issue_refund"]),
+            "--config",
+            _config(tmp_path),
+            "--agent",
+            "bot",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_the_report_does_not_call_no_record_zero():
+    """An enforce run keeps no session log by default, so a zero here
+    means "not recorded", not "did not happen". A run that blocked four
+    calls reported "Actually blocked (enforce mode): 0"."""
+    from sponsio.reporting.aggregator import Report
+    from sponsio.reporting.renderer import render_markdown
+
+    out = render_markdown(Report())
+    assert "not recorded" in out
+    assert "**Actually blocked (enforce mode):** 0" not in out
+
+
+def test_a_real_block_count_is_still_shown():
+    from sponsio.reporting.aggregator import Report
+    from sponsio.reporting.renderer import render_markdown
+
+    out = render_markdown(Report(blocked=4))
+    assert "**Actually blocked (enforce mode):** 4" in out


### PR DESCRIPTION
Two claims from the fresh-eyes report, both verified against main before fixing.

## `sponsio check` exited 0 on a violation

```
✗ tool `check` must precede `ship` — VIOLATED
✗ 1/1 contract(s) VIOLATED
exit=0
```

The function had no `sys.exit` at all. `docs/reference/cli.md` says every command exits 0 on success and 1 on failure and lists a contract violation as failure, so a CI job wired the way the docs describe was green whatever the trace contained. (`sponsio validate` exits 1 correctly, so this was inconsistent, not policy.)

## The report called "not recorded" zero

An enforce run that blocked four calls:

```
**Actually blocked (enforce mode):** 0
```

Enforce keeps no session log by default. That is deliberate — `BaseGuard` skips the JSONL logger outside observe to avoid surprise writes to `$HOME`, and `session_log_dir=` overrides it. So the zero means *not recorded*, and the line said *did not happen*. It now names the reason and the way out; a real count still prints as a count.

The guard also says so at the moment it matters: constructing in enforce without a `session_log_dir` prints one line to stderr. QUICKSTART reads as a continuous rollout — observe, review the report, flip to enforce — and nothing said the durable record stops at the flip, which is exactly when `report`, `replay` and `export-sessions` go quiet.

## Verified

`2509 passed, 37 skipped`; the three failures are the known local-venv artifact (`sponsio_cloud` importable) and run clean in a fresh venv. `ruff check` / `format --check` clean.

Four new tests: a violating trace exits 1, a clean trace exits 0, an empty report says "not recorded", and a real block count still renders as the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)