### PR TITLE
docs(cloud): document the console path, and stop calling a draft published

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -127,6 +127,7 @@ sponsio check --trace trace.json --config sponsio.yaml --agent agent
 ## Next
 
 - [First contract](docs/getting-started/first-contract.md): write your own rule.
+- [The hosted console](docs/getting-started/hosted-console.md): stream a run to app.sponsio.dev, and keep the rulebook where a human reviews it.
 - [Integrations](docs/integrations/index.md): plug into LangGraph, CrewAI, OpenAI Agents, and others.
 - [Config reference](docs/reference/config-yaml.md): full `sponsio.yaml` schema.
 - [CLI reference](docs/reference/cli.md): every command and flag.

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@ Sponsio は時間軸に沿って展開されるエージェントの手続きに
 
 > **エージェント契約** とは、エージェントのすべてのアクションでチェックされるランタイムルールであり、[形式手法に裏打ちされています](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a8 alpha リリース。** `pip install --pre sponsio`。出力レーンが登場しました。実行前に検査されるすべてのツール呼び出しに加えて、実行が主張する型付きクレームも決定的な比較器で権威ソースと照合されます——ホットパスに LLM はありません。プロジェクトに複数の agent がある場合にのみ現れる 2 つのバグも修正:2 番目の agent がそもそも起動できない問題と、マルチ agent 実行のクレーム判定がコンソールに届かない問題。[v0.2.0a8 リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a8)を参照。
+> **v0.2.0a11 alpha リリース。** `pip install --pre sponsio`。a8 以降の 3 リリースは、いずれも同じ不具合を修正しています。ルールが読み込まれ、ACTIVE と表示され、それでも一度も発火しない、という不具合です。パス検査が `/safe/../../root/.ssh` を通していました。`never call A after B` が逆のルールにコンパイルされていました。SQL 動詞リストが小文字を取りこぼしていました。さらに、実行はどのバージョンのルールブックを適用したかを記録するようになり、記録された実行を当時実際に有効だったルールで再生できます。[v0.2.0a11 リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a11)を参照。
 
 ---
 
@@ -67,6 +67,18 @@ sponsio init .             # 対話型ウィザード: フレームワーク・I
 ```
 
 ウィザードがフレームワークを自動検出し、対応するラップ スニペットを表示します。手動配線は [docs/integrations/](docs/integrations/index.md) を参照。[OpenClaw ユーザー](docs/integrations/openclaw.md)は ClawHavoc + CVE-2026-25253 のカバレッジを最初から利用できます。設定リファレンス、observe → enforce 切替、CI 配線は[完全ガイド](QUICKSTART.md)を参照。
+
+**実行を見る、ルールブックを共有する。** 強制はローカルで動き、アカウントは不要です。エージェントが何をしたかを見たい場合や、ルールブックを「人がレビューしてから有効になる」場所に置きたい場合は、[app.sponsio.dev](https://app.sponsio.dev) がホスト側です。1 行で実行が画面に出ます:
+
+```python
+import sponsio
+import sponsio.bridge
+
+guard = sponsio.Sponsio(config="sponsio.yaml", agent_id="mailer", mode="enforce")
+run = sponsio.bridge.attach(guard)
+```
+
+`sponsio push sponsio.yaml` がアップロードするのは下書きで、有効にはなりません。コンソールで人が公開し、その後 `sponsio pull` または `config="sponsio://default"` でレビュー済みのバージョンを取り戻します。送信はベストエフォートなので、コンソールが落ちてもエージェントは止まりません。[ホストされたコンソール](docs/getting-started/hosted-console.md)を参照。
 
 **自然言語から契約を下書きする。** `sponsio validate "<平易な文のルール>"` は、自然言語のルールを読み返せる契約に変換します。出力はあくまで下書きとして扱い、enforce する前に自分でレビューして調整してください。決定論的なのは契約がランタイムでどう*強制される*かであって、どう下書きされるかではありません。
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sponsio provides deterministic contracts for agent procedures over time, enforce
 
 > An **agent contract** is a runtime rule that is checked at every agent action, [backed by formal methods](docs/concepts/formal-methods.md).
 
-> **v0.2.0a8 alpha is out.** `pip install --pre sponsio`. The output lane ships: alongside every tool call checked before it executes, a run's typed claims are now checked against an authority by deterministic comparators — no LLM in the hot path. Also fixes two bugs that only appear once a project has more than one agent: the second agent could not run at all, and multi-agent runs lost their claim verdicts on the way to the console. See the [v0.2.0a8 release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a8).
+> **v0.2.0a11 alpha is out.** `pip install --pre sponsio`. Three releases since a8, all fixing the same failure: a rule that loaded, showed ACTIVE, and could never fire. A path check let `/safe/../../root/.ssh` through. `never call A after B` compiled into the opposite rule. A SQL verb list missed lowercase. A run now also records which rulebook version it enforced, so a recorded run can be replayed against the rules that were actually in force. See the [v0.2.0a11 release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a11).
 
 ---
 
@@ -66,6 +66,18 @@ sponsio init .             # interactive wizard: detects framework, IDE hosts, o
 ```
 
 The wizard auto-detects your framework and prints the right wrap snippet. For manual wiring, see [all supported integrations](docs/integrations/index.md). [OpenClaw users](docs/integrations/openclaw.md) get bundled ClawHavoc and CVE-2026-25253 coverage out of the box. For config reference, observe → enforce flip, and CI wiring, see the [full walkthrough](QUICKSTART.md).
+
+**Watching runs, and sharing a rulebook.** Enforcement is local and needs no account. If you want to see what your agent did, or keep the rulebook somewhere a person reviews it before it arms, [app.sponsio.dev](https://app.sponsio.dev) is the hosted side. One line puts a run on screen:
+
+```python
+import sponsio
+import sponsio.bridge
+
+guard = sponsio.Sponsio(config="sponsio.yaml", agent_id="mailer", mode="enforce")
+run = sponsio.bridge.attach(guard)
+```
+
+`sponsio push sponsio.yaml` uploads a rulebook as a draft. It does not arm. A person publishes it in the console, and `sponsio pull` or `config="sponsio://default"` brings the reviewed version back. Sending is best effort, so a console that is down never blocks the agent. See [the hosted console](docs/getting-started/hosted-console.md).
 
 **Drafting contracts from natural language.** `sponsio validate "<rule in plain English>"` turns a plain-English rule into a contract you can read back. Treat the output as a starting draft to review and adjust before you enforce. The determinism is in how contracts are *enforced* at runtime, not in how they're drafted.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ Sponsio 为 Agent 在时间维度上展开的过程提供确定性合约，强�
 
 > **Agent 合约**是一条运行时规则，在每一次 Agent 操作时检查，[由形式化方法支撑](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a8 alpha 已发布。** `pip install --pre sponsio`。输出通道上线：除了每次工具调用在执行前被检查之外,一次运行所声明的结构化断言现在也会由确定性比较器对照权威来源核验——热路径上没有 LLM。同时修复两个只在项目里有多个 agent 时才会出现的问题:第二个 agent 根本跑不起来,以及多 agent 运行的断言判定送不到控制台。见 [v0.2.0a8 发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a8)。
+> **v0.2.0a11 alpha 已发布。** `pip install --pre sponsio`。a8 之后的三个版本修的是同一种问题:规则加载了、显示 ACTIVE、但永远不会触发。路径检查放行了 `/safe/../../root/.ssh`。`never call A after B` 编译成了相反的规则。SQL 动词表漏掉了小写。另外,一次运行现在会记录它执行的是哪个版本的规则书,录下来的运行可以对着当时真正生效的规则重放。见 [v0.2.0a11 发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a11)。
 
 ---
 
@@ -67,6 +67,18 @@ sponsio init .             # 交互式向导：检测框架、选择 IDE host、
 ```
 
 向导会自动检测你的框架并打印对应的接入片段。手动接线见 [docs/integrations/](docs/integrations/index.md)。[OpenClaw 用户](docs/integrations/openclaw.md)开箱即享 ClawHavoc + CVE-2026-25253 覆盖。配置参考、observe → enforce 切换、CI 接线见[完整指引](QUICKSTART.md)。
+
+**看运行,和共享规则书。** 强制执行是本地的,不需要账号。如果你想看你的 agent 到底做了什么,或者想把规则书放在一个"有人审过才生效"的地方,[app.sponsio.dev](https://app.sponsio.dev) 就是托管的那一半。一行代码把一次运行送上屏幕:
+
+```python
+import sponsio
+import sponsio.bridge
+
+guard = sponsio.Sponsio(config="sponsio.yaml", agent_id="mailer", mode="enforce")
+run = sponsio.bridge.attach(guard)
+```
+
+`sponsio push sponsio.yaml` 上传的是草稿,不会生效。由人在控制台发布,之后 `sponsio pull` 或 `config="sponsio://default"` 把审过的版本取回来。发送是尽力而为的,控制台挂了也不会挡住 agent。见[托管控制台](docs/getting-started/hosted-console.md)。
 
 **用自然语言起草合约。** `sponsio validate "<一句话规则>"` 会把一条自然语言规则转成一份你能读回来的合约。把输出当作起点草稿，enforce 之前先自己 review、按需调整。确定性在于合约在运行时如何被*强制执行*，而不在于它如何被起草。
 

--- a/docs/getting-started/hosted-console.md
+++ b/docs/getting-started/hosted-console.md
@@ -1,6 +1,6 @@
 ---
 title: The hosted console
-description: Connect an agent to app.sponsio.dev — stream its runs, keep its rulebook in the cloud, and pull the reviewed version back.
+description: Connect an agent to app.sponsio.dev. Stream its runs, keep its rulebook in the cloud, and pull the reviewed version back.
 ---
 
 # The hosted console
@@ -36,7 +36,7 @@ sponsio doctor
 The **Cloud** row names the endpoint, the tenant, and every agent that
 has a rulebook. If it shows a URL you did not expect, a
 previous `sponsio login --url ...` is still stored and outranks the
-default — log in again with the right `--url`.
+default. Log in again with the right `--url`.
 
 Prefer environment variables in CI: `SPONSIO_API_KEY` and
 `SPONSIO_API_URL` are read the same way and need no credentials file.
@@ -135,7 +135,7 @@ List what the key can reach:
 sponsio projects                  # projects, and agents that have a book
 ```
 
-That list does not say which books are published — an agent with nothing
+That list does not say which books are published. An agent with nothing
 but drafts is in it. `sponsio pull --agent <name>` is what tells you which
 head an agent actually has.
 
@@ -147,7 +147,7 @@ sponsio pull --agent mailer -o sponsio.cloud.yaml
 
 `pull` returns the **published** version. A book that has never been
 published has no published head to hand out, so you get its latest draft
-instead — and the output says so:
+instead, and the output says so:
 
 ```
 wrote sponsio.cloud.yaml · 1 · DRAFT (nothing published yet; publish it to pin what pull returns)
@@ -187,7 +187,7 @@ sponsio pull               →  the reviewed version comes back
 
 The console's copilot mines proposals from your runs. A proposal is
 never a rule until someone arms it, and each one states how thin its own
-evidence is — read that number before arming.
+evidence is. Read that number before arming.
 
 ---
 

--- a/docs/getting-started/hosted-console.md
+++ b/docs/getting-started/hosted-console.md
@@ -1,0 +1,194 @@
+---
+title: The hosted console
+description: Connect an agent to app.sponsio.dev — stream its runs, keep its rulebook in the cloud, and pull the reviewed version back.
+---
+
+# The hosted console
+
+Everything else in these docs runs on your machine with no account. This
+page is the other half: streaming a run to [app.sponsio.dev](https://app.sponsio.dev)
+so you can see what crossed the boundary, and keeping the rulebook there
+so a human reviews a rule before it arms.
+
+Enforcement never depends on any of it. The console is where runs are
+read and rules are reviewed; if the network is down your agent is
+unaffected.
+
+---
+
+## 1. Sign in
+
+Create a key in the console under **Setup**, then:
+
+```bash
+sponsio login --key sk_sp_v1_...
+```
+
+It checks the key before saving it to `~/.sponsio/credentials` (mode
+0600) and prints the projects it can reach.
+
+Confirm what you are pointed at:
+
+```bash
+sponsio doctor
+```
+
+The **Cloud** row names the endpoint, the tenant, and every agent that
+has a rulebook. If it shows a URL you did not expect, a
+previous `sponsio login --url ...` is still stored and outranks the
+default — log in again with the right `--url`.
+
+Prefer environment variables in CI: `SPONSIO_API_KEY` and
+`SPONSIO_API_URL` are read the same way and need no credentials file.
+
+---
+
+## 2. Stream a run to the console
+
+**This is the step that puts your agent on screen, and it is one line.**
+Attaching a bridge to a guard projects each guarded call into a console
+step and sends it as the run progresses:
+
+```python
+import sponsio
+import sponsio.bridge          # note: a submodule, import it explicitly
+
+guard = sponsio.Sponsio(config="sponsio.yaml", agent_id="mailer",
+                        mode="enforce")
+run = sponsio.bridge.attach(guard)
+
+# ... your agent loop, unchanged ...
+
+run.finish()                   # flushes the final state
+```
+
+That is all. `attach` wraps `guard_before` so every checked call is
+recorded; `finish()` sends the last frame.
+
+Two rules this path is built to respect:
+
+- **Sending never blocks the agent.** Every upload is best-effort. If the
+  console is unreachable the run is unaffected and the failure is
+  reported at the end, not raised.
+- **Nothing is invented.** A field the run does not carry is left out
+  rather than guessed.
+
+### Naming a run
+
+`attach` generates an id. Pass your own when you want to find it again:
+
+```python
+run = sponsio.bridge.attach(guard, session_id="nightly-2026-09-03")
+```
+
+### Multi-agent runs
+
+For a single-agent loop the default `auto=True` records every guarded
+call for you. When several agents share one guard, turn it off and
+attribute each step yourself:
+
+```python
+run = sponsio.bridge.attach(guard, auto=False,
+                            agents=["planner", "writer"])
+...
+step = run.record(tool_name, args, agent="planner")
+```
+
+`agents=` takes bare names, or dicts (`{"id": ..., "role": ...,
+"tools": [...]}`) when you want roles on the graph.
+
+### What does not stream a run
+
+Two things look like they should and do not:
+
+- `Sponsio(..., dashboard=True)` targets a **local** dashboard on
+  127.0.0.1, not the cloud.
+- `sponsio export-sessions --to <url>` ships OTLP spans to the trace
+  store. Those are spans, not runs: they do not appear under **Sessions**
+  and they carry no contract verdicts.
+
+---
+
+## 3. Keep the rulebook in the cloud
+
+### Push
+
+```bash
+sponsio push sponsio.yaml         # the path is required
+```
+
+Each agent block becomes the next version of that agent's book.
+
+> **`push` uploads a draft. It does not publish.** The version sits
+> unarmed until a human publishes it, which is the point: an agent that
+> can publish its own enforcement rules is one nobody can be held
+> responsible for. `push` says so on its last line.
+
+### Publish
+
+Publishing is a human action, in the console: open **Rulebook**, review
+the version, and publish it. There is no `sponsio publish` command.
+
+List what the key can reach:
+
+```bash
+sponsio projects                  # projects, and agents that have a book
+```
+
+That list does not say which books are published — an agent with nothing
+but drafts is in it. `sponsio pull --agent <name>` is what tells you which
+head an agent actually has.
+
+### Pull
+
+```bash
+sponsio pull --agent mailer -o sponsio.cloud.yaml
+```
+
+`pull` returns the **published** version. A book that has never been
+published has no published head to hand out, so you get its latest draft
+instead — and the output says so:
+
+```
+wrote sponsio.cloud.yaml · 1 · DRAFT (nothing published yet; publish it to pin what pull returns)
+```
+
+Read that line. Without it you cannot tell whether the rules you just
+wrote into the file your guard loads were reviewed by anyone.
+
+Pin an exact version when you need to reproduce a run:
+
+```bash
+sponsio pull --agent mailer --version 46 -o sponsio.v46.yaml
+```
+
+### Or let the guard pull for itself
+
+```python
+guard = sponsio.Sponsio(config="sponsio://default", agent_id="mailer")
+```
+
+A `sponsio://<project>` ref resolves to a cloud checkout when a key is
+set and the service answers, the last cached copy when it does not, and
+a local yaml if you never pulled. Enforcement never waits on the network,
+and the run records which version it enforced.
+
+---
+
+## The loop
+
+```
+sponsio login              →  sign in once
+sponsio.bridge.attach()    →  runs appear under Sessions
+sponsio push sponsio.yaml  →  rulebook uploaded as a draft
+(console: Rulebook)        →  a human reviews and publishes
+sponsio pull               →  the reviewed version comes back
+```
+
+The console's copilot mines proposals from your runs. A proposal is
+never a rule until someone arms it, and each one states how thin its own
+evidence is — read that number before arming.
+
+---
+
+**Related:** [Install](install.md) · [Write your first contract](first-contract.md) · [CLI reference](../reference/cli.md) · [Config file](../reference/config-yaml.md)

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -97,5 +97,5 @@ Replays a packaged unsafe-agent trajectory locally, no API key, no framework SDK
 ## Next
 
 - [Write your first contract](first-contract.md): block an unsafe tool call in 60 seconds.
-- [First contract](first-contract.md): write a custom contract against your own agent.
+- [The hosted console](hosted-console.md): stream a run to app.sponsio.dev and keep the rulebook there.
 - [Integrations](../integrations/index.md): plug Sponsio into your framework.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Then go to the [Write your first contract](getting-started/first-contract.md).
 
 ## Sections
 
-- **[Getting started](getting-started/install.md)**: install, run your first guarded agent, write your first contract. Includes paste-ready [IDE-agent prompts](getting-started/onboard-prompt.md) for Claude Code / Cursor / Codex driven setup.
+- **[Getting started](getting-started/install.md)**: install, run your first guarded agent, write your first contract, and [connect to the hosted console](getting-started/hosted-console.md). Includes paste-ready [IDE-agent prompts](getting-started/onboard-prompt.md) for Claude Code / Cursor / Codex driven setup.
 - **[Concepts](concepts/overview.md)**: what contracts are, how the runtime evaluates them, the LTL (linear temporal logic) backbone, OWASP coverage.
 - **[Integrations](integrations/index.md)**: drop-in adapters for LangGraph, Claude Agent, OpenAI Agents, CrewAI, Vercel AI, MCP, and others.
 - **[Guides](guides/onboarding.md)**: task-oriented walkthroughs. Tuning, observe-vs-enforce, contract sources, reporting, FAQ.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -100,12 +100,19 @@ guard = sponsio.Sponsio(
 while not done:
     tool_name, args = llm_decide_next_action()
     result = guard.guard_before(tool_name, args)
-    if result.blocked:
+    if result.stop_original:      # not result.blocked: see note below
         llm_messages.append(f"Action blocked: {result.det_violations[0].message}")
         continue
     output = execute_tool(tool_name, args)
     guard.guard_after(tool_name, output)
 ```
+
+**Gate on `result.stop_original`, not `result.blocked`.** A `redirect_to_safe`
+violation leaves `blocked` False and `allowed` True, because the agent flow can
+continue down the safe path. A loop that gates on `blocked` falls through and
+runs the exact call the contract forbade. `stop_original` folds hard blocks and
+redirects together, so it fails closed. If you want the substitution itself, see
+[Redirect to safe](#redirect-to-safe-v02).
 
 ## Tool policy: default-deny + proactive filtering (v0.2)
 
@@ -161,7 +168,7 @@ while not done:
     legal_tools = [t for t in ALL_TOOLS if t.name in legal_names]
     tool_name, args = llm_decide_next_action(messages, tools=legal_tools)
     result = guard.guard_before(tool_name, args)
-    if result.blocked:
+    if result.stop_original:      # not result.blocked: see note below
         messages.append(f"Action blocked: {result.det_violations[0].message}")
         continue
     output = execute_tool(tool_name, args)

--- a/docs/reference/patterns.md
+++ b/docs/reference/patterns.md
@@ -68,11 +68,29 @@ In **observe mode**, no strategy runs. Violations are logged and surfaced in rep
 
 ## Catalog
 
-Run `sponsio patterns` on the CLI to browse this catalog interactively with NL examples.
+Run `sponsio patterns` on the CLI to browse this catalog interactively.
+
+**Every cell in the "How to write it" column is copy-pasteable and is checked
+by the test suite.** Two forms appear there, because not every pattern has a
+plain-English phrasing the parser accepts:
+
+- A quoted sentence goes straight into a `G:` or `A:` field, or into
+  `sponsio validate "..."`.
+- A `{pattern: ..., args: [...]}` mapping goes into the same field as a
+  structured entry. This form always works and is the only form for the
+  patterns whose arguments a sentence cannot carry.
+
+```yaml
+agents:
+  my_agent:
+    contracts:
+      - G: "tool `check_policy` must precede `issue_refund`"
+      - G: {pattern: token_budget, args: [50000]}
+```
 
 ### Safety
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
 | `must_precede(A, B)` | `"tool `check_policy` must precede `issue_refund`"` | A must have been called before B can execute |
 | `must_confirm(action)` | `"tool `delete_file` requires confirmation"` | A confirmation step must precede the action |
@@ -83,98 +101,98 @@ Run `sponsio patterns` on the CLI to browse this catalog interactively with NL e
 
 ### Compliance
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
-| `no_reversal(A, B)` | `"after `approve`, tool `reject` is forbidden"` | Once A is called, B is permanently forbidden |
+| `no_reversal(A, B)` | `"tool `reject` must not follow `approve`"` | Once A is called, B is permanently forbidden |
 | `segregation_of_duty(A, B)` | `"tools `review` and `approve` must be by different agents"` | Same agent cannot perform both actions |
 | `always_followed_by(A, B)` | `"every `refund` must be followed by `notify`"` | Whenever A happens, B must eventually happen |
 | `required_steps_completion(steps)` | `"`aml_check` must complete before `issue_loan`"` | All steps must have completed before a gate is passed |
 
 ### Operational
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
 | `rate_limit(action, N)` | `"tool `query_db` at most 5 times"` | Action can be called at most N times total |
 | `idempotent(action)` | `"tool `transfer` at most 1 times"` | Action can be called at most once (special case of rate_limit) |
 | `cooldown(action, N)` | `"tool `send_email` cooldown of 3 steps"` | At least N steps between consecutive calls |
 | `deadline(trigger, action, N)` | `"tool `respond` within 3 steps of `receive`"` | Action must happen within N steps of trigger |
 | `bounded_retry(action, N)` | `"tool `deploy` at most 3 retries"` | Action limited to N retries |
-| `loop_detection(action, N)` | `"tool `search` must not loop more than 5 times"` | Detects repeated calls with similar args |
+| `loop_detection(action, N)` | `{pattern: loop_detection, args: ['search', 5]}` | Detects repeated calls with similar args |
 
 ### Exclusion
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
 | `mutual_exclusion(A, B)` | `"tools `approve` and `reject` are mutually exclusive"` | At most one of A or B can ever be called |
-| `tool_allowlist(tools)` | `"agent may only call `search`, `summarize`"` | Only listed tools may be called |
+| `tool_allowlist(tools)` | `{pattern: tool_allowlist, args: [['search', 'summarize']]}` | Only listed tools may be called |
 
 ### Recovery
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
-| `redirect_to_safe(unsafe, safe)` | `"redirect `issue_refund` to `log_refund_request`"` | Substitute a forbidden tool with a pre-approved alternative. Bundled with the `RedirectToSafe` strategy: a violation surfaces as `action="redirected"` with `fallback_action=safe`, the trace records the substitute call. |
+| `redirect_to_safe(unsafe, safe)` | `{pattern: redirect_to_safe, args: ['issue_refund', 'log_refund_request']}` | Substitute a forbidden tool with a pre-approved alternative. Bundled with the `RedirectToSafe` strategy: a violation surfaces as `action="redirected"` with `fallback_action=safe`, the trace records the substitute call. |
 
 ### Argument and path checks
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
 | `arg_blacklist(tool, field, patterns)` | `"bash command must not contain `rm -rf`"` | An arg field must not match forbidden regex patterns |
 | `scope_limit(tool, paths)` | `"bash may only access files under `/workspace`"` | All file paths in tool args must be within allowed prefixes |
-| `arg_length_limit(tool, field, N)` | `"`sql.query` at most 500 chars"` | Argument length cap |
-| `arg_value_range(tool, field, lo, hi)` | `"`transfer.amount` between 0 and 10000"` | Numeric argument range |
+| `arg_length_limit(tool, field, N)` | `{pattern: arg_length_limit, args: ['sql', 'query', 500]}` | Argument length cap |
+| `arg_value_range(tool, field, lo, hi)` | `{pattern: arg_value_range, args: ['transfer', 'amount', 0, 10000]}` | Numeric argument range |
 | `data_intact(tool, field)` | `"`aml_report` must not be edited after `aml_check`"` | Payload field is immutable once written |
 
 ### Agentic security
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
-| `untrusted_source_gate(tool)` | `"content from untrusted sources requires review"` | Data from untrusted origin must pass a gate before use |
+| `untrusted_source_gate(tool)` | `{pattern: untrusted_source_gate, args: [['fetch_url'], ['send_email']]}` | Data from untrusted origin must pass a gate before use |
 | `confirm_after_source(tool)` | `"confirmation required after reading from `web_search`"` | A confirmation step must follow a source-read |
-| `dangerous_bash_commands()` | `"bash must not run `rm -rf /`, `:(){:|:&};:`..."` | Built-in bash command blacklist |
-| `dangerous_sql_verbs()` | `"sql must not issue `DROP`, `TRUNCATE`, `ALTER`"` | Built-in SQL verb blacklist |
+| `dangerous_bash_commands()` | `{pattern: dangerous_bash_commands}` | Built-in bash command blacklist |
+| `dangerous_sql_verbs()` | `{pattern: dangerous_sql_verbs, args: ['execute_sql']}` | Built-in SQL verb blacklist |
 | `irreversible_once(action)` | `"`post_tweet` at most once per session"` | Irreversible actions capped to a single call |
 
 ### Resource
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
-| `token_budget(N)` | `"total LLM tokens under 50000"` | Session-wide token cap |
-| `delegation_depth_limit(N)` | `"sub-agent delegation at most 3 levels"` | Bounds recursive agent delegation |
+| `token_budget(N)` | `{pattern: token_budget, args: [50000]}` | Session-wide token cap |
+| `delegation_depth_limit(N)` | `{pattern: delegation_depth_limit, args: [3]}` | Bounds recursive agent delegation |
 
 ### Approval and audit
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
-| `approval_active(action, role)` | `"`issue_refund` requires active approval from `manager`"` | A specific role must have approved the action recently |
+| `approval_active(action, role)` | `{pattern: approval_active, args: ['issue_refund', 'manager', 3600]}` | A specific role must have approved the action recently |
 | `approval_freshness(approval, action, max_steps)` | `"`approve_pr` valid for 10 steps before `merge_pr`"` | Approval must be within N steps of the gated action |
-| `audit_after(action, audit)` | `"every `delete_user` must log `audit_event`"` | Sensitive action must be followed by an audit-log step |
+| `audit_after(action, audit)` | `"`delete_user` must be audited"` | Sensitive action must be followed by an audit-log step |
 | `backup_before_destructive(backup, action)` | `"`snapshot_db` must precede `drop_table`"` | Backup must run before any destructive action |
 | `dry_run_before_commit(dry_run, commit)` | `"`plan` must precede `apply`"` | Plan / preview step required before commit |
 | `sanitized_before_sink(source, sanitizer, sink)` | `"`untrusted_input` must pass `sanitize` before `db_write`"` | Untrusted input must pass a sanitizer before reaching a sink |
 
 ### Identity and context
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
-| `ctx_required(tool, key, values)` | `"`publish` requires ctx[`msg_verified`]=`true`"` | A `ctx(k, v)` fact must be set before the tool runs |
-| `ctx_matches_required(tool, key, regex)` | `"`issue_refund` requires caller_id matching `^spiffe://prod/finance-`"` | A `ctx(k, v)` value must match a regex |
+| `ctx_required(tool, key, values)` | `{pattern: ctx_required, args: ['publish', 'msg_verified', ['true']]}` | A `ctx(k, v)` fact must be set before the tool runs |
+| `ctx_matches_required(tool, key, regex)` | `{pattern: ctx_matches_required, args: ['issue_refund', 'caller_id', '^spiffe://prod/finance-']}` | A `ctx(k, v)` value must match a regex |
 
 ### Argument allowlist and content
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
-| `arg_allowlist(tool, field, patterns)` | `"`http_post` url must match allowlist"` | Argument must match one of the allowed regex patterns |
-| `duplicate_call_limit(tool, args_pattern, N)` | `"`send_email` to same recipient at most 1 time"` | Cap on repeated calls with similar args |
-| `time_since(predicate_key, max_seconds)` | `"action within 60s of `user_request`"` | Bounded time window since a referenced predicate |
+| `arg_allowlist(tool, field, patterns)` | `"url must be one of `https://api.example.com`, `https://api.internal`"` | Argument must match one of the allowed regex patterns |
+| `duplicate_call_limit(tool, args_pattern, N)` | `"same `send_email` request `recipient` at most 1 time"` | Cap on repeated calls with similar args |
+| `time_since(predicate_key, max_seconds)` | `{pattern: time_since, args: ['user_request', 60]}` | Bounded time window since a referenced predicate |
 
 ### Output checks (deterministic)
 
 These are deterministic atoms that match against `llm_response` events via regex or exact string compare. They are distinct from stochastic atoms (judge-backed, like `tone` or `faithfulness`), which need an LLM judge at runtime and are not part of this OSS release.
 
-| Pattern | NL example | What it enforces |
+| Pattern | How to write it | What it enforces |
 |---|---|---|
 | `no_pii(fields)` | `"response must not contain PII"` | Regex-detect SSN, credit card, email, phone in response |
-| `no_keywords(words)` | `"response must not mention competitors"` | Response cannot contain any of the given strings |
+| `no_keywords(words)` | `{pattern: no_keywords, args: [['Acme', 'Globex']]}` | Response cannot contain any of the given strings |
 | `max_length(max_words, max_chars)` | `"response under 200 words"` | Response length cap |
 
 ---

--- a/sponsio/cli/commands/cloud.py
+++ b/sponsio/cli/commands/cloud.py
@@ -102,10 +102,24 @@ def pull(
     except CloudError as exc:
         raise click.ClickException(str(exc)) from exc
 
+    # Say which head this is, the way a ``sponsio://`` checkout does. A book
+    # that has never been published hands out its draft, and writing that
+    # into the file a guard loads without a word makes the review step —
+    # push uploads, a human publishes — invisible at exactly the point it
+    # matters. On stdout the notice goes to stderr so `pull > sponsio.yaml`
+    # still yields loadable yaml.
+    channel = getattr(pulled, "channel", None)
+    head = (
+        " · DRAFT (nothing published yet; publish it to pin what pull returns)"
+        if channel == "draft"
+        else (f" · {channel}" if channel and channel != "published" else "")
+    )
     if output:
         Path(output).write_text(pulled.yaml_text)
-        click.echo(f"wrote {output} · {pulled.versions or '?'}")
+        click.echo(f"wrote {output} · {pulled.versions or '?'}{head}")
     else:
+        if head:
+            click.echo(f"# {pulled.versions or '?'}{head}", err=True)
         click.echo(pulled.yaml_text, nl=False)
 
 
@@ -114,7 +128,12 @@ def pull(
 @click.option("--project", "project", help="Project to publish into (created if new)")
 @click.option("--url", "url", help="API base URL")
 def push(config_path: str, project: str | None, url: str | None) -> None:
-    """Publish a local sponsio.yaml as the next version of each agent's book."""
+    """Upload a local sponsio.yaml as the next version of each agent's book.
+
+    The version is a draft: it is not published and does not arm until a
+    human publishes it in the console. An agent that could publish its own
+    enforcement rules is one nobody can be held responsible for.
+    """
     from sponsio.cloud.client import CloudError
 
     client = _client(url=url)
@@ -131,13 +150,19 @@ def push(config_path: str, project: str | None, url: str | None) -> None:
         raise click.ClickException(str(exc)) from exc
 
     click.echo(f"pushed to project '{result.get('project')}'")
-    for name, book in (result.get("agents") or {}).items():
+    agents = result.get("agents") or {}
+    for name, book in agents.items():
         # Say plainly when nothing moved. An agent that re-pushes on every
         # start would otherwise look like it keeps changing the book.
         state = "unchanged" if book.get("unchanged") else "new version"
         click.echo(
             f"  {name}: v{book.get('version')} · {book.get('rules')} rules · {state}"
         )
+    # A push that says only "new version" reads as shipped. It is not: the
+    # version sits unarmed until a human publishes it, and nothing else in
+    # the CLI ever says so.
+    if any(not book.get("unchanged") for book in agents.values()):
+        click.echo("draft — publish it in the console to arm it")
 
 
 @cli.command()
@@ -171,4 +196,8 @@ def projects(url: str | None) -> None:
         click.echo(name)
     agents = identity.get("agents_with_rulebooks") or []
     if agents:
-        click.echo("\nagents with a published rulebook: " + ", ".join(agents))
+        # The field is agents_with_rulebook*s*, and a book with nothing but
+        # drafts is in it. Calling that "published" claims a human reviewed
+        # rules nobody has looked at; `sponsio pull --agent <name>` is what
+        # says which head an agent actually has.
+        click.echo("\nagents with a rulebook: " + ", ".join(agents))

--- a/sponsio/cli/commands/cloud.py
+++ b/sponsio/cli/commands/cloud.py
@@ -104,8 +104,8 @@ def pull(
 
     # Say which head this is, the way a ``sponsio://`` checkout does. A book
     # that has never been published hands out its draft, and writing that
-    # into the file a guard loads without a word makes the review step —
-    # push uploads, a human publishes — invisible at exactly the point it
+    # into the file a guard loads without a word hides the review step
+    # (push uploads, a human publishes) at exactly the point it
     # matters. On stdout the notice goes to stderr so `pull > sponsio.yaml`
     # still yields loadable yaml.
     channel = getattr(pulled, "channel", None)
@@ -162,7 +162,7 @@ def push(config_path: str, project: str | None, url: str | None) -> None:
     # version sits unarmed until a human publishes it, and nothing else in
     # the CLI ever says so.
     if any(not book.get("unchanged") for book in agents.values()):
-        click.echo("draft — publish it in the console to arm it")
+        click.echo("draft. publish it in the console to arm it")
 
 
 @cli.command()
@@ -189,7 +189,7 @@ def projects(url: str | None) -> None:
     names = identity.get("projects") or []
     if not names:
         click.echo(
-            "no projects yet — `sponsio push sponsio.yaml --project <name>` creates one"
+            "no projects yet. `sponsio push sponsio.yaml --project <name>` creates one"
         )
         return
     for name in names:

--- a/sponsio/doctor.py
+++ b/sponsio/doctor.py
@@ -808,10 +808,13 @@ def check_cloud() -> CheckResult:
     detail = f"{client.url} · {tenant}"
     if projects:
         detail += " · projects: " + ", ".join(projects)
+    # The field counts books, not published ones: an agent whose every
+    # version is an unreviewed draft is in it. Saying "published" here would
+    # green-tick rules nobody has looked at, and push creates a draft too.
     detail += (
-        " · rulebooks published for: " + ", ".join(agents)
+        " · rulebooks for: " + ", ".join(agents)
         if agents
-        else " · no rulebook published yet (a first push will create one)"
+        else " · no rulebook yet (a first push uploads one as a draft)"
     )
     return CheckResult("Cloud", "ok", detail)
 

--- a/sponsio/init_wizard.py
+++ b/sponsio/init_wizard.py
@@ -535,10 +535,10 @@ def print_next_steps(picks: "InitPicks", *, ts_project: bool = False) -> None:
             click.echo(f"        (it'll invoke the sponsio-{ide}:configure skill).")
     if skill_ides:
         click.echo()
-        click.echo(f"    {', '.join(skill_ides)} — Agent Skill installed.")
+        click.echo(f"    {', '.join(skill_ides)}: Agent Skill installed.")
         click.echo("      Ask the IDE's develop agent: \"set up Sponsio in this")
         click.echo('      project" / "tune contracts from policy.md" / "explain')
-        click.echo('      why C1 fired" — it has the playbook.')
+        click.echo('      why C1 fired". It has the playbook.')
 
     # Mode flip is already an explicit step in the wizard (axis 3,
     # observe vs enforce); echoing "flip when ready" here was just
@@ -771,7 +771,7 @@ def run_interactive(env: Environment) -> InitPicks:
     ide_levels: dict[str, str] = {}
     for h in SUPPORTED_HOSTS:
         if h not in env.ides_installed:
-            click.secho(f"{h} — not installed, skipping", dim=True)
+            click.secho(f"{h}: not installed, skipping", dim=True)
             continue
         level = _select(
             f"Sponsio level for {h}",

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -157,6 +157,43 @@ def test_pull_passes_agent_and_version_through(runner, patched):
     assert client.calls[-1] == ("pull", "alpha", "quant", 3)
 
 
+def test_pull_says_when_it_handed_out_a_draft(runner, patched, tmp_path):
+    """A book nobody published still pulls — as its draft. Writing that into
+    the file a guard loads without a word makes the review step invisible at
+    the point it matters."""
+    patched["install"](pulled=PulledRulebook(YAML, versions="1", channel="draft"))
+    out = tmp_path / "sponsio.yaml"
+
+    result = runner.invoke(cli, ["pull", "alpha", "-o", str(out)])
+
+    assert result.exit_code == 0, result.output
+    assert "DRAFT" in result.output
+
+
+def test_pull_is_quiet_about_the_published_head(runner, patched, tmp_path):
+    patched["install"](pulled=PulledRulebook(YAML, versions="3", channel="published"))
+    out = tmp_path / "sponsio.yaml"
+
+    result = runner.invoke(cli, ["pull", "alpha", "-o", str(out)])
+
+    assert "DRAFT" not in result.output and "published" not in result.output
+
+
+def test_pull_keeps_stdout_loadable(runner, patched):
+    """``sponsio pull > sponsio.yaml`` must yield yaml. The draft notice goes
+    to stderr or it corrupts the file it was meant to warn about."""
+    patched["install"](pulled=PulledRulebook(YAML, versions="1", channel="draft"))
+    try:
+        split = CliRunner(mix_stderr=False)  # click < 8.2
+    except TypeError:
+        split = CliRunner()  # 8.2 dropped the flag and splits by default
+    result = split.invoke(cli, ["pull", "alpha"])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == YAML
+    assert "DRAFT" in result.stderr
+
+
 # -- push ------------------------------------------------------------------
 
 
@@ -186,6 +223,20 @@ def test_push_says_plainly_when_nothing_moved(runner, patched, tmp_path):
     result = runner.invoke(cli, ["push", str(config)])
 
     assert "unchanged" in result.output
+    # Nothing was uploaded, so there is no draft awaiting a human.
+    assert "draft" not in result.output
+
+
+def test_push_says_the_new_version_is_a_draft(runner, patched, tmp_path):
+    """A bare "new version" reads as shipped. It is not: it sits unarmed
+    until a human publishes it, and nothing else in the CLI says so."""
+    patched["install"]()
+    config = tmp_path / "sponsio.yaml"
+    config.write_text(YAML)
+
+    result = runner.invoke(cli, ["push", str(config)])
+
+    assert "draft" in result.output and "publish" in result.output
 
 
 def test_push_without_a_key_is_refused(runner, patched, tmp_path):

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -158,7 +158,7 @@ def test_pull_passes_agent_and_version_through(runner, patched):
 
 
 def test_pull_says_when_it_handed_out_a_draft(runner, patched, tmp_path):
-    """A book nobody published still pulls — as its draft. Writing that into
+    """A book nobody published still pulls, as its draft. Writing that into
     the file a guard loads without a word makes the review step invisible at
     the point it matters."""
     patched["install"](pulled=PulledRulebook(YAML, versions="1", channel="draft"))

--- a/tests/test_patterns_doc_examples.py
+++ b/tests/test_patterns_doc_examples.py
@@ -1,0 +1,62 @@
+"""Every example in the pattern catalog must actually work.
+
+``docs/reference/patterns.md`` is linked from the README as the reference
+for the pattern library, so its table is where a new user copies their
+first rule from. For a long time 19 of the 44 cells did not parse: the
+column was called "NL example" and held sentences nobody had run. A user
+following the reference got ``ContractSyntaxError`` from the reference.
+
+This test reads the shipped file and puts every cell through the same
+front door a user would.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from sponsio.formulas.formula import Atom  # noqa: F401  (eval'd by examples)
+from sponsio.generation.dsl_to_contract import parse_contract
+from sponsio.patterns import library
+
+DOC = Path(__file__).resolve().parents[1] / "docs" / "reference" / "patterns.md"
+
+# | `pattern(sig)` | <cell> | prose |
+ROW = re.compile(r"^\|\s*`([a-z_0-9]+)\([^`]*\)`\s*\|\s*(.+?)\s*\|", re.M)
+STRUCTURED = re.compile(r"^\{pattern:\s*([a-z_0-9]+)(?:,\s*args:\s*(.+))?\}$")
+
+
+def _cells() -> list[tuple[str, str]]:
+    text = DOC.read_text(encoding="utf-8")
+    rows = [(pat, cell.strip("`")) for pat, cell in ROW.findall(text)]
+    assert len(rows) > 30, f"catalog table not found or shrank: {len(rows)} rows"
+    return rows
+
+
+@pytest.mark.parametrize("pattern,cell", _cells(), ids=lambda v: str(v)[:40])
+def test_catalog_example_is_usable(pattern: str, cell: str) -> None:
+    """A cell is usable in one of the three forms the docs promise."""
+    factory = getattr(library, pattern, None)
+    assert factory is not None, (
+        f"catalog names a pattern that does not exist: {pattern}"
+    )
+
+    structured = STRUCTURED.match(cell)
+    if structured:
+        # `{pattern: X, args: [...]}` goes into a yaml G:/A: field verbatim.
+        name, raw_args = structured.group(1), structured.group(2)
+        assert name == pattern, f"row {pattern} shows {name}"
+        args = ast.literal_eval(raw_args) if raw_args else []
+        getattr(library, name)(*args)
+        return
+
+    if cell.startswith(f"{pattern}("):
+        # A Python call, for patterns whose arguments are atoms.
+        eval(cell, {"__builtins__": {}, "Atom": Atom, pattern: factory})  # noqa: S307
+        return
+
+    # Otherwise a sentence, which must survive the parser a user would hit.
+    parse_contract(cell.strip('"'))


### PR DESCRIPTION
## Why

Nothing in the user-facing tree mentioned `app.sponsio.dev`, `sponsio login/push/pull`, `sponsio.bridge.attach`, or the `sponsio://` ref. Verified on `origin/main`: zero matches across `README.md`, `QUICKSTART.md`, `docs/`, `llms.txt`. A reader following the docs end to end never learned a run can reach the console at all — and that is one line of code.

## Docs

Adds `docs/getting-started/hosted-console.md`, linked from `docs/index.md`, `docs/getting-started/install.md`, and `QUICKSTART.md`. It covers sign-in, streaming a run with `sponsio.bridge.attach()`, push → human publish → pull, and `config="sponsio://<project>"`.

Every command and snippet in it was run against production before it was written down. That is also how the fixes below were found — the doc kept describing behaviour the CLI did not have.

Also fixes a duplicate in `install.md`'s Next list: two entries both pointed at `first-contract.md`.

## Fixes

`push` uploads a draft; a human arms it in the console. That split is the point of a hosted rulebook. Three places erased it:

**`pull` discarded `PulledRulebook.channel`.** A book that has never been published hands out its latest draft, and `pull` wrote that into the file a guard loads without a word. A `sponsio://` checkout has printed DRAFT since 9173096; `pull` now does too. When yaml goes to stdout the notice goes to stderr, so `sponsio pull > sponsio.yaml` still parses.

```
$ sponsio pull --agent docverify -o out.yaml       # never published
wrote out.yaml · 1 · DRAFT (nothing published yet; publish it to pin what pull returns)
$ sponsio pull --agent quant -o out.yaml           # published head
wrote out.yaml · 46
$ sponsio pull --agent quant --version 46 -o out.yaml
wrote out.yaml · 46 · pinned
```

**`push` read as shipped.** Its help said "Publish a local sponsio.yaml"; its output stopped at "new version". It now says what it did:

```
$ sponsio push sponsio.yaml
pushed to project 'default'
  docverify: v2 · 2 rules · new version
draft — publish it in the console to arm it
```

No line is added when everything was unchanged — nothing is waiting on a human.

**`projects` and `doctor` labelled drafts "published".** The server field is `agents_with_rulebooks`; an agent whose every version is an unreviewed draft is in it. Both now say "with a rulebook". Confirmed against production: `docverify` had two versions, `published: false` on both, and was listed as having a published rulebook.

## Verification

Against production `app.sponsio.dev` on a clean venv built from this branch: the DRAFT / published / pinned outputs above, `pull > file` still loading as yaml, the push draft line appearing only on a new version, and `projects` / `doctor` wording.

`2554 passed, 11 skipped`. `ruff check` and `ruff format --check` clean. `scripts/check_doc_links.py`: all relative links resolve across 46 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)