### PR TITLE
chore(release): 0.2.0a13

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@ Sponsio はエージェントがツールを呼ぶ前に、その呼び出しを
 
 > **エージェント契約** とは、エージェントのすべてのアクションでチェックされるランタイムルールであり、[形式手法に裏打ちされています](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a12 alpha リリース。** `pip install --pre sponsio`。ホストされたコンソールに初めてドキュメントができました。1 行で実行を [app.sponsio.dev](https://app.sponsio.dev) に送れます。push、レビュー、pull の流れで、ルールブックは人が有効化する場所に置かれます。パターンカタログの例はすべてそのまま貼り付けて使えるようになり、テストがそれを保ちます。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a12)を参照。
+> **v0.2.0a13 alpha リリース。** `pip install --pre sponsio`。読み込めなかったバンドルが読み込めるようになりました。`include: sponsio:incident/openclaw` はエラーになり、37 本のルールが 1 本も有効になりませんでした。カタログに載っている 5 つのパターンが設定ローダーの参照するレジストリから漏れていて、`pattern: no_pii` は失敗する一方で同じルールを英文で書くとコンパイルできる状態でした。インストール バッジに `--pre` が抜けていて、最後の安定版 0.1.1 を指していました。ここより遥かに古いものです。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a13)を参照。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sponsio checks an agent's tool calls before they run. A rule can look at what al
 
 > An **agent contract** is a runtime rule that is checked at every agent action, [backed by formal methods](docs/concepts/formal-methods.md).
 
-> **v0.2.0a12 alpha is out.** `pip install --pre sponsio`. The hosted console is documented for the first time: one line sends a run to [app.sponsio.dev](https://app.sponsio.dev), and push, review, pull keeps the rulebook somewhere a person arms it. Every example in the pattern catalog is now one you can paste, with a test that keeps it that way. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a12).
+> **v0.2.0a13 alpha is out.** `pip install --pre sponsio`. Bundles that could not load now load: `include: sponsio:incident/openclaw` raised instead of arming its 37 rules, and five patterns the catalog documents were missing from the registry the config loader reads, so `pattern: no_pii` failed while the same rule in English compiled. The install badge left out `--pre`, so it pointed at the last stable release, 0.1.1, which is much older. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a13).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ Sponsio 在 Agent 调用工具之前先检查这次调用。一条规则可以�
 
 > **Agent 合约**是一条运行时规则，在每一次 Agent 操作时检查，[由形式化方法支撑](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a12 alpha 已发布。** `pip install --pre sponsio`。托管控制台第一次有了文档:一行代码把运行送上 [app.sponsio.dev](https://app.sponsio.dev),push、人工审核、pull 这条链保证规则由人来上膛。模式目录里每一条示例现在都能直接复制粘贴,并有测试守着。见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a12)。
+> **v0.2.0a13 alpha 已发布。** `pip install --pre sponsio`。原本加载不了的合约包现在能加载了:`include: sponsio:incident/openclaw` 以前直接报错,那 37 条规则一条都上不了膛;另有五个目录里登记过的模式不在配置加载器读的注册表里,导致 `pattern: no_pii` 报错、而同一条规则写成英文句子却能编译。安装徽章漏了 `--pre`,指向的是最后一个稳定版 0.1.1,比这里老得多。见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a13)。
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sponsio"
-version = "0.2.0a12"
+version = "0.2.0a13"
 description = "Runtime contract enforcement for LLM agent systems"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump plus the three README banners.

Everything in it is on main and verified. The install badge fix matters most right now: `pip install sponsio` resolves to 0.1.1, so anyone who copied the badge got a much older release.

`2778 passed, 15 skipped`. Links resolve across 46 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)