### PR TITLE
fix(ts): the npm install line pointed at 0.1.0, and a typo exited 0

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -81,7 +81,7 @@ Add this to your agent entry point:
 
 Without an LLM key, `init` still ships a name-heuristic starter plus capability packs (shell / filesystem / credentials / …) with deterministic rules — no LLM calls. Run `sponsio packs` for the full list with rule counts.
 
-For TypeScript, install `@sponsio/sdk` and run `npx sponsio init .`. Same yaml output, same `Sponsio({ config: "sponsio.yaml" })` API.
+For TypeScript, `npm install -D @sponsio/sdk@alpha` and run `npx sponsio init .`. Same yaml output, and the same shape of API: `new Sponsio({ config: "sponsio.yaml", agentId: "my_agent" })`.
 
 ## 4. Run and observe
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@ Sponsio はエージェントがツールを呼ぶ前に、その呼び出しを
 **または CLI を自分で実行:**
 
 ```bash
-pip install --pre sponsio        # または: npm install -D @sponsio/sdk
+pip install --pre sponsio        # または: npm install -D @sponsio/sdk@alpha
 sponsio init .             # 対話型ウィザード: フレームワーク・IDE ホスト・observe vs enforce を検出
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Two ways in: paste a prompt into your coding agent, or run the CLI yourself.
 **Or run the CLI yourself**:
 
 ```bash
-pip install --pre sponsio   # or: npm install -D @sponsio/sdk
+pip install --pre sponsio   # or: npm install -D @sponsio/sdk@alpha
 sponsio init .              # asks what you use, then writes sponsio.yaml
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,7 +62,7 @@ Sponsio 在 Agent 调用工具之前先检查这次调用。一条规则可以�
 **或自行运行 CLI：**
 
 ```bash
-pip install --pre sponsio        # 或 npm install -D @sponsio/sdk
+pip install --pre sponsio        # 或 npm install -D @sponsio/sdk@alpha
 sponsio init .             # 交互式向导：检测框架、选择 IDE host、observe vs enforce
 ```
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -57,7 +57,7 @@ Python 3.10 and newer. Older versions are not tested.
 The TypeScript deterministic engine ships separately:
 
 ```bash
-npm install @sponsio/sdk
+npm install @sponsio/sdk@alpha
 ```
 
 See [TypeScript integrations](../integrations/index.md#typescript) for framework bindings. The Python and TS engines share the same LTL core. They produce identical block/allow decisions over the same trace.

--- a/docs/getting-started/onboard-prompt.md
+++ b/docs/getting-started/onboard-prompt.md
@@ -132,7 +132,7 @@ project.  Three steps.
 
 ══════════════ Step 0: install the Sponsio CLI ══════════════
 
-  command -v sponsio >/dev/null 2>&1 || npm install -D @sponsio/sdk
+  command -v sponsio >/dev/null 2>&1 || npm install -D @sponsio/sdk@alpha
 
 Quiet check first.  Re-running ``npm install`` against an already-
 present version is fine but noisy in IDE-agent transcripts.  The

--- a/tests/test_install_instructions.py
+++ b/tests/test_install_instructions.py
@@ -1,7 +1,11 @@
-"""`pip install sponsio` resolves to 0.1.1, a different and much older
-release, because 0.2.0a* is a pre-release. Every install instruction we
-ship therefore has to carry `--pre`, including the README badge, which is
-the first thing on the page and the easiest one to forget.
+"""Install lines have to name the pre-release, in both ecosystems.
+
+`pip install sponsio` resolves to 0.1.1 and `npm install @sponsio/sdk`
+resolves to 0.1.0: 0.2.0a* and 0.2.0-alpha.* are pre-releases, so both
+package managers skip them unless asked. Both stable versions are much
+older software. Every install instruction we ship therefore has to carry
+`--pre` or `@alpha`, including the README badge, which is the first thing
+on the page and the easiest one to forget.
 """
 
 from __future__ import annotations
@@ -50,3 +54,22 @@ def test_the_readme_badge_carries_pre() -> None:
         )
         assert badge, f"{name}: install badge missing"
         assert "--pre" in badge.group(1), f"{name}: badge says {badge.group(1)}"
+
+
+# npm's stable tag is 0.1.0; the alpha lives under the `alpha` dist-tag.
+NPM = re.compile(
+    r"(?:npm install|npm i|yarn add|pnpm add)[^\n`]*?@sponsio/sdk(@[a-z0-9.-]+)?"
+)
+
+
+@pytest.mark.parametrize("path", FILES, ids=lambda p: p.name)
+def test_npm_install_instructions_name_the_alpha(path: Path) -> None:
+    if path.name in EXPLAINS_THE_PLAIN_FORM or "release-notes" in path.parts:
+        pytest.skip("documents the plain form deliberately")
+    bad = [
+        ln
+        for ln in path.read_text().splitlines()
+        for m in NPM.finditer(ln)
+        if m.group(1) != "@alpha"
+    ]
+    assert not bad, f"{path.name}: npm install without @alpha:\n" + "\n".join(bad)

--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -63,7 +63,7 @@
   ],
   "scripts": {
     "build": "tsc && tsc -p tsconfig.cli.json && node -e \"require('fs').writeFileSync('dist/cli/package.json', '{\\\"type\\\":\\\"commonjs\\\"}\\n')\"",
-    "test": "node --test dist/__tests__/*.test.js",
+    "test": "node --test dist/",
     "test:cli": "node --test dist/cli/__tests__/*.test.js",
     "test:src": "npx tsx src/__tests__/core.test.ts",
     "test:parity": "npx tsx src/__tests__/parity.test.ts && npx tsx src/__tests__/parity.scenarios.test.ts"

--- a/ts/packages/sdk/src/cli/__tests__/unknown-command.test.ts
+++ b/ts/packages/sdk/src/cli/__tests__/unknown-command.test.ts
@@ -1,0 +1,62 @@
+// A mistyped command must fail loudly.
+//
+// `sponsio valdate` used to fall through to the scanner, which found no
+// files, printed `{"tools":[]}` and exited 0. The onboarding prompt tells
+// coding agents to run these commands, so an agent that typos one reads a
+// zero exit and moves on believing it worked.
+//
+// The scanner still has to accept what it is for: a path, a glob, a file.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const BIN = path.resolve(__dirname, "../../../bin/sponsio.cjs");
+
+function run(args: string[]): { code: number; out: string; err: string } {
+  try {
+    const out = execFileSync(process.execPath, [BIN, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, out, err: "" };
+  } catch (e) {
+    const x = e as { status?: number; stdout?: string; stderr?: string };
+    return { code: x.status ?? 1, out: x.stdout ?? "", err: x.stderr ?? "" };
+  }
+}
+
+test("a mistyped command exits non-zero and names itself", () => {
+  const r = run(["valdate"]);
+  assert.notEqual(r.code, 0, `expected failure, got:\n${r.out}`);
+  assert.match(r.err, /unknown command 'valdate'/);
+  assert.match(r.err, /--help/);
+});
+
+test("a real command still runs", () => {
+  const r = run(["patterns"]);
+  assert.equal(r.code, 0, r.err);
+  assert.match(r.out, /Sponsio patterns/);
+});
+
+test("a path is still a scan target, not a command", () => {
+  const r = run([path.resolve(__dirname, "..")]);
+  assert.equal(r.code, 0, r.err);
+  assert.match(r.out, /"tools"/);
+});
+
+test("a glob is still a scan target", () => {
+  const r = run(["src/**/*.ts"]);
+  assert.equal(r.code, 0, r.err);
+  assert.match(r.out, /"tools"/);
+});
+
+test("help lists the commands, not just scan flags", () => {
+  const r = run(["--help"]);
+  assert.equal(r.code, 0, r.err);
+  assert.match(r.out, /COMMANDS:/);
+  for (const cmd of ["init", "validate", "doctor", "report", "patterns"]) {
+    assert.ok(r.out.includes(cmd), `help does not mention ${cmd}`);
+  }
+});

--- a/ts/packages/sdk/src/cli/cli.ts
+++ b/ts/packages/sdk/src/cli/cli.ts
@@ -22,7 +22,7 @@
  * need ``--config`` a second time).  CLI flags always win over YAML.
  */
 
-import { promises as fs } from "fs";
+import { promises as fs, existsSync } from "fs";
 import { loadConfig, ConfigError, type SponsioConfig } from "./config";
 import { runOnboardCli } from "./onboard";
 import { runReportCli } from "./report";
@@ -69,6 +69,17 @@ const HELP =
     "",
     "ARGUMENTS:",
     '  <patterns...>       Files or glob patterns to scan (default: "src/**/*.{ts,tsx,js,jsx}")',
+    "",
+    "COMMANDS:",
+    "  init | onboard      Write a sponsio.yaml for this project",
+    "  scan | validate     Mine contracts from code; check a config parses",
+    "  mode | packs        Flip observe/enforce; list the shipped contract packs",
+    "  check | eval        Judge one trace; judge a directory of them",
+    "  report | replay     What would have been blocked; re-run a recorded session",
+    "  patterns | explain  The pattern catalog; why one contract exists",
+    "  doctor | skill      Environment check; install the agent skill",
+    "  prompt | export     Authoring prompts; export a config or sessions",
+    "  demo                Run a packaged scenario",
     "",
     "OPTIONS:",
     "  -o, --out <file>    Write output to <file> instead of stdout",
@@ -326,6 +337,32 @@ async function main() {
       process.exit(1);
     }
     return;
+  }
+
+  // Anything above returned. A first argument that is plainly meant as a
+  // command and matched none of them used to fall through to the scanner,
+  // which found no files, printed `{"tools":[]}` and exited 0. A typo
+  // therefore looked like a success — and the onboarding prompt tells
+  // coding agents to run these commands, so the agent reads the zero exit
+  // and moves on.
+  //
+  // A scan target is a path or a glob. A bare word that is neither, with
+  // no extension and no glob metacharacter and nothing on disk by that
+  // name, is a mistyped command.
+  const first = raw[0];
+  if (
+    first !== undefined &&
+    !first.startsWith("-") &&
+    !/[*?[\]{}]/.test(first) &&
+    !first.includes("/") &&
+    !first.includes(".") &&
+    !existsSync(first)
+  ) {
+    process.stderr.write(
+      `sponsio: unknown command '${first}'\n` +
+        `Run 'sponsio --help' for the list, or pass a path or glob to scan.\n`,
+    );
+    process.exit(2);
   }
 
   const args = parseArgs(raw);


### PR DESCRIPTION
First walk of the TypeScript path as a user.

The engine is fine. A rule loaded from yaml blocked `send_email` before `verify_address` and allowed it after. Everything wrong was on the way to a correct setup.

## `npm install -D @sponsio/sdk` installs 0.1.0

npm's `latest` is the old stable; the alpha is under the `alpha` tag. The pip problem one ecosystem over, and 0.1.0 is different software (`@sponsio/sdk/mcp` does not exist in it). Every install line says `@sponsio/sdk@alpha` now, and the install-instructions test grew an npm rule beside the pip one.

## QUICKSTART taught an API that throws

```
Sponsio({ config: "sponsio.yaml" })
→ TypeError: Class constructor Sponsio cannot be invoked without 'new'
```

On every published version. It reads `new Sponsio({ config, agentId })` now.

## A mistyped command exited 0

`sponsio valdate` fell through to the scanner, found no files, printed `{"tools":[]}` and exited 0. The onboarding prompt tells **coding agents** to run these commands, so an agent that typos one reads the zero exit and moves on.

A first argument with no glob character, no slash, no extension, and nothing on disk by that name is a mistyped command. It now says so on stderr and exits 2. Paths and globs still scan.

## `sponsio --help` never mentioned the commands

It described the scanner and its flags. The first thing anyone types hid `init`, `validate`, `doctor` and fifteen others.

## `npm test` never ran three test files

The script globbed `dist/__tests__/*.test.js`, missing `dist/cli/__tests__/`. `onboard.test` and `scan.test` had never run in CI. `node --test dist/` recurses: 20 tests became 45.

## Checks

Python 2814 passed, 19 skipped. TS 45 passed. The 9 cross-language parity scenarios pass on both sides. Links resolve across 46 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)