### PR TITLE
fix(docs): QUICKSTART had the mode precedence backwards

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -114,7 +114,18 @@ runtime:
   mode: enforce
 ```
 
-Precedence: explicit ctor arg > env var > yaml > default.
+Precedence for `mode`: `SPONSIO_MODE` > ctor arg > yaml > `observe`.
+
+**The env var beats your code, on purpose.** Whoever runs the deployment
+has to be able to flip enforcement without waiting for a release, so
+`SPONSIO_MODE=observe` turns off blocking even where the source says
+`mode="enforce"`, and the reverse holds too. If a rule is not behaving the
+way the code reads, check the environment first: `sponsio doctor` prints
+the mode actually in force.
+
+Every other knob goes the other way. `dashboard`, for instance, is
+`ctor arg > SPONSIO_DASHBOARD > yaml`, because it is set in code at deploy
+time rather than flipped by an operator mid-incident.
 
 ## Troubleshooting
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -23,7 +23,7 @@ Sponsio works with any agent framework in Python and TypeScript. Each integratio
 | MCP | `from sponsio.mcp import MCPContractProxy` | `proxy.call_tool()` | 3 |
 | No framework | `sponsio.Sponsio(contracts=[...])` | `guard.guard_before()` / `guard_after()` | 3 |
 
-### TypeScript (via Pyodide, same engine, no server)
+### TypeScript (native, same engine, no server)
 
 | Framework | Import | Integration |
 |---|---|---|

--- a/tests/test_langgraph_real_graph.py
+++ b/tests/test_langgraph_real_graph.py
@@ -1,0 +1,96 @@
+"""The LangGraph path, through a compiled graph.
+
+`test_langgraph_integration.py` drives the guard directly. Nothing built a
+`StateGraph`, compiled it, and invoked it, so the one thing a LangGraph
+user actually does was never exercised: `guard.wrap(tools)` returns a
+`ToolNode`, and a ToolNode outside a graph raises on a missing runtime
+config before any contract is consulted.
+
+Skipped when langgraph is absent, so the suite still runs on a bare
+install.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, TypedDict
+
+import pytest
+
+pytest.importorskip("langgraph")
+
+from langchain_core.messages import AIMessage  # noqa: E402
+from langchain_core.tools import tool  # noqa: E402
+from langgraph.graph import END, START, StateGraph  # noqa: E402
+from langgraph.graph.message import add_messages  # noqa: E402
+
+from sponsio import contract  # noqa: E402
+from sponsio.langgraph import Sponsio  # noqa: E402
+
+
+@tool
+def check_policy(order_id: str) -> str:
+    """Check the refund policy for an order."""
+    return "policy ok"
+
+
+@tool
+def issue_refund(order_id: str, amount: float) -> str:
+    """Issue a refund for an order."""
+    return f"refunded {amount}"
+
+
+class _State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+def _app(mode: str):
+    guard = Sponsio(
+        agent_id="my_bot",
+        mode=mode,
+        verbose=False,
+        contracts=[
+            contract("policy gate before refund")
+            .assume("called `issue_refund`")
+            .guarantees("must call `check_policy` before `issue_refund`")
+        ],
+    )
+    graph = StateGraph(_State)
+    graph.add_node("tools", guard.wrap([check_policy, issue_refund]))
+    graph.add_edge(START, "tools")
+    graph.add_edge("tools", END)
+    return graph.compile()
+
+
+def _call(app, name: str, args: dict, idx: int) -> str:
+    message = AIMessage(
+        content="", tool_calls=[{"name": name, "args": args, "id": f"c{idx}"}]
+    )
+    return str(app.invoke({"messages": [message]})["messages"][-1].content)
+
+
+def test_a_compiled_graph_blocks_then_allows(monkeypatch) -> None:
+    """The order the contract names, through the real node."""
+    monkeypatch.setenv("SPONSIO_MODE", "enforce")
+    app = _app("enforce")
+    refund = {"order_id": "A1", "amount": 9.99}
+
+    first = _call(app, "issue_refund", refund, 0)
+    assert "ToolCallBlocked" in first or "BLOCKED" in first, first
+
+    assert "policy ok" in _call(app, "check_policy", {"order_id": "A1"}, 1)
+
+    after = _call(app, "issue_refund", refund, 2)
+    assert "refunded" in after, after
+
+
+def test_observe_mode_runs_the_tool(monkeypatch) -> None:
+    """Observe records and does not stop. A mode that quietly enforced
+    would make every first rollout a production incident.
+
+    `SPONSIO_MODE` outranks the ctor arg by design, and conftest sets it to
+    `enforce` for the suite, so this test has to clear it. See
+    tests/test_mode_precedence.py."""
+    monkeypatch.delenv("SPONSIO_MODE", raising=False)
+    app = _app("observe")
+    out = _call(app, "issue_refund", {"order_id": "A1", "amount": 9.99}, 0)
+    assert "refunded" in out, out

--- a/tests/test_mode_precedence.py
+++ b/tests/test_mode_precedence.py
@@ -1,0 +1,70 @@
+"""Where the mode comes from, pinned.
+
+QUICKSTART said "explicit ctor arg > env var", which is backwards. The
+real order is `SPONSIO_MODE` > ctor arg > yaml > observe, and the
+asymmetry is deliberate: whoever runs the deployment has to be able to
+flip enforcement without waiting for a release.
+
+Backwards in that direction is the dangerous one. It tells a reader their
+code wins, so a team with `SPONSIO_MODE=enforce` in the container reads
+`mode="observe"` in the source and believes they are shadowing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import sponsio
+from sponsio import contract
+
+RULE = [
+    contract("gate")
+    .assume("called `issue_refund`")
+    .guarantees("must call `check_policy` before `issue_refund`")
+]
+
+
+def _blocked(**kwargs) -> bool:
+    guard = sponsio.Sponsio(agent_id="b", verbose=False, contracts=RULE, **kwargs)
+    return guard.guard_before("issue_refund", {}).stop_original
+
+
+@pytest.mark.parametrize(
+    "env,ctor,expect_stop",
+    [
+        ("enforce", "observe", True),
+        ("observe", "enforce", False),
+        (None, "enforce", True),
+        (None, "observe", False),
+    ],
+)
+def test_the_env_var_outranks_the_ctor_arg(monkeypatch, env, ctor, expect_stop) -> None:
+    if env is None:
+        monkeypatch.delenv("SPONSIO_MODE", raising=False)
+    else:
+        monkeypatch.setenv("SPONSIO_MODE", env)
+    assert _blocked(mode=ctor) is expect_stop
+
+
+def test_dashboard_goes_the_other_way(monkeypatch) -> None:
+    """The asymmetry is the point, so the other side needs a test too:
+    `dashboard` is a deploy-time choice made in code, not an operator's
+    mid-incident flip, and its ctor arg wins."""
+    monkeypatch.setenv("SPONSIO_DASHBOARD", "http://127.0.0.1:9999")
+    guard = sponsio.Sponsio(
+        agent_id="b", verbose=False, contracts=RULE, dashboard=False
+    )
+    assert getattr(guard, "_dashboard_url", None) is None
+
+
+def test_quickstart_states_the_real_order() -> None:
+    """The doc and the loader have already drifted once."""
+    from pathlib import Path
+
+    text = (Path(__file__).resolve().parents[1] / "QUICKSTART.md").read_text()
+    assert "`SPONSIO_MODE` > ctor arg > yaml" in text, (
+        "QUICKSTART no longer states the mode precedence the loader implements"
+    )
+    assert "explicit ctor arg > env var" not in text, (
+        "QUICKSTART is back to claiming the ctor arg outranks the env var"
+    )


### PR DESCRIPTION
## The precedence was inverted

QUICKSTART said `explicit ctor arg > env var > yaml > default`. The loader does the opposite for `mode`, and its docstring says why:

```
mode:       SPONSIO_MODE env  >  ctor arg  >  yaml  >  "observe"
dashboard:  ctor arg  >  SPONSIO_DASHBOARD env  >  yaml  >  None
```

The asymmetry is deliberate: whoever runs the deployment has to flip enforcement without waiting for a release. `dashboard` is set in code at deploy time and goes the other way.

**Backwards in this direction is the dangerous one.** It tells a reader their code wins, so a team with `SPONSIO_MODE=enforce` in the container reads `mode="observe"` in the source and believes they are shadowing while every violation blocks.

Measured:

```
SPONSIO_MODE=enforce, Sponsio(mode="observe")  ->  mode=enforce, blocked=True
```

Both claims added to QUICKSTART were run first: `SPONSIO_MODE=observe` turns off a source-level `enforce`, and `sponsio doctor` prints the mode in force.

`tests/test_mode_precedence.py` pins all four combinations, the dashboard asymmetry, and the sentence itself, because the doc and the loader have already drifted once.

## How it surfaced

`tests/test_langgraph_real_graph.py`, new here. `test_langgraph_integration.py` drives the guard directly; nothing had built a `StateGraph`, compiled it and invoked it, so the one thing a LangGraph user does was never exercised.

It passes: first `issue_refund` raises `ToolCallBlocked`, `check_policy` runs, the second `issue_refund` returns. Its **observe** case failed, and the reason was the precedence: conftest sets `SPONSIO_MODE=enforce` for the suite and the ctor arg could not override it.

## Also

`docs/integrations/index.md` called the TypeScript SDK "via Pyodide". It has no Pyodide dependency, its engine is `ts/packages/sdk/src/core/`, and CI names that job "Test (TypeScript — native)". A TS reader was being told they would run a Python runtime in WASM.

## Checks

2786 passed, 15 skipped, with every framework extra installed. Links resolve across 46 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)