### PR TITLE
feat(ts): the evidence lane, from TypeScript

### DIFF
--- a/sponsio/cloud/evidence.py
+++ b/sponsio/cloud/evidence.py
@@ -107,18 +107,30 @@ class EvidenceResult:
 def _normalize_inputs(inputs: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
     """Ergonomic input forms -> the wire's tagged shape.
 
-    Accepted per input: ``(value, source)`` tuple/list, or an already
-    wire-shaped ``{"value": ..., "source": ...}`` mapping. Anything
-    without a source tag is rejected here — the server would refuse it
-    anyway (taint rule), and a local error names the input.
+    Accepted per input: ``(value, source)`` tuple/list where ``source``
+    is a string, or an already wire-shaped
+    ``{"value": ..., "source": ...}`` mapping. Anything without a source
+    tag is rejected here — the server would refuse it anyway (taint
+    rule), and a local error names the input.
+
+    The source must be a string for the pair form to apply. Without that
+    check, a two-element list of data was read as a pair:
+    ``{"items": [40, 60]}`` became ``value=40, source="60"``, and the
+    server then refused source ``"60"`` as untrusted — an error naming
+    nothing the caller had written. A list value now needs the explicit
+    form, ``([40, 60], "submitted_output")``.
     """
     wire: dict[str, dict[str, Any]] = {}
     for name, spec in (inputs or {}).items():
         if isinstance(spec, Mapping) and "source" in spec:
             wire[name] = {"value": spec.get("value"), "source": str(spec["source"])}
-        elif isinstance(spec, (tuple, list)) and len(spec) == 2:
+        elif (
+            isinstance(spec, (tuple, list))
+            and len(spec) == 2
+            and isinstance(spec[1], str)
+        ):
             value, source = spec
-            wire[name] = {"value": value, "source": str(source)}
+            wire[name] = {"value": value, "source": source}
         else:
             raise ValueError(
                 f"input {name!r} needs a source tag: pass (value, source) "

--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sponsio/sdk",
   "version": "0.2.0-alpha.4",
-  "description": "Runtime contract enforcement for LLM agents — native TypeScript",
+  "description": "Runtime contract enforcement for LLM agents \u2014 native TypeScript",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -46,6 +46,10 @@
     "./langchain": {
       "types": "./dist/integrations/langchain.d.ts",
       "default": "./dist/integrations/langchain.js"
+    },
+    "./cloud/evidence": {
+      "types": "./dist/cloud/evidence.d.ts",
+      "import": "./dist/cloud/evidence.js"
     }
   },
   "bin": {

--- a/ts/packages/sdk/src/__tests__/evidence-contracts.test.ts
+++ b/ts/packages/sdk/src/__tests__/evidence-contracts.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The two evidence obligations, and the entry that feeds them.
+ *
+ * `claimRequiresEvidence` and `underdeterminedMustClarify` were the last
+ * two patterns Python had and TS did not. They are pure formulas over
+ * three atoms the trace has to carry, so all three parts had to land
+ * together: the atoms in grounding, the patterns, and `observeEvidence`.
+ *
+ * The verdicts here were checked against Python on the same four
+ * verdict/action pairs and agree line for line.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Sponsio } from "../index.js";
+
+const RULEBOOK = `version: "1"
+agents:
+  bot:
+    contracts:
+      - desc: totals must verify
+        G: {pattern: claim_requires_evidence, args: [items_sum_to_total]}
+      - desc: ambiguous totals must be clarified
+        G: {pattern: underdetermined_must_clarify, args: [items_sum_to_total]}
+`;
+
+function guard(): Sponsio {
+  const dir = mkdtempSync(join(tmpdir(), "sponsio-evidence-"));
+  const path = join(dir, "sponsio.yaml");
+  writeFileSync(path, RULEBOOK);
+  return new Sponsio({ config: path, agentId: "bot", mode: "enforce" });
+}
+
+test("a PASS releases", () => {
+  const r = guard().observeEvidence("items_sum_to_total", "PASS", "release");
+  assert.equal(r.stopOriginal, false);
+});
+
+test("any verdict but PASS violates the obligation", () => {
+  // The point of `claim_requires_evidence`: not just MISMATCH. A claim
+  // the service could not check is not a claim that checked out.
+  for (const verdict of ["MISMATCH", "NO_EVIDENCE", "SOURCE_UNAVAILABLE"]) {
+    const r = guard().observeEvidence("items_sum_to_total", verdict, "block");
+    assert.equal(r.stopOriginal, true, `${verdict} should violate`);
+  }
+});
+
+test("an ambiguous verdict released instead of clarified is a violation", () => {
+  // `underdetermined_must_clarify` guards the policy wiring, not the
+  // claim: an override that quietly releases an ambiguous claim trips it.
+  const released = guard().observeEvidence(
+    "items_sum_to_total",
+    "UNDERDETERMINED",
+    "release",
+  );
+  assert.equal(released.stopOriginal, true);
+});
+
+test("a predicate no contract names is transparent", () => {
+  const r = guard().observeEvidence("date_valid", "MISMATCH", "block");
+  assert.equal(r.stopOriginal, false, "contracts are per predicate");
+});
+
+test("observe mode records and does not stop", () => {
+  const dir = mkdtempSync(join(tmpdir(), "sponsio-evidence-"));
+  const path = join(dir, "sponsio.yaml");
+  writeFileSync(path, RULEBOOK);
+  const g = new Sponsio({ config: path, agentId: "bot", mode: "observe" });
+  const r = g.observeEvidence("items_sum_to_total", "MISMATCH", "block");
+  assert.equal(r.stopOriginal, false);
+  assert.equal(r.detViolations.length, 1, "still recorded");
+});

--- a/ts/packages/sdk/src/__tests__/evidence.test.ts
+++ b/ts/packages/sdk/src/__tests__/evidence.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The evidence client's own contract. No network: `fetch` is replaced,
+ * so CI exercises the request we build and the answer we parse rather
+ * than the service's availability.
+ *
+ * The wire shapes here were captured from `app.sponsio.dev`, and the
+ * verdicts match what `sponsio/cloud/evidence.py` returns for the same
+ * calls.
+ */
+
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  EvidenceClient,
+  EvidenceError,
+  isBlocking,
+  needsClarification,
+  normalizeInputs,
+} from "../cloud/evidence.js";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Capture the outgoing request and answer with a canned payload. */
+function stubFetch(
+  payload: unknown,
+  status = 200,
+): { seen: () => { url: string; body: Record<string, unknown> } } {
+  let url = "";
+  let body: Record<string, unknown> = {};
+  globalThis.fetch = (async (input: string, init: RequestInit) => {
+    url = String(input);
+    body = JSON.parse(String(init.body));
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => JSON.stringify(payload),
+      json: async () => payload,
+    } as Response;
+  }) as typeof fetch;
+  return { seen: () => ({ url, body }) };
+}
+
+const PASS = {
+  predicate: "items_sum_to_total",
+  verdict: "PASS",
+  action: "release",
+  evidence: { values: [{ items: [40, 60] }], ts: 1788451084.63, source: "submitted_output", table_version: null },
+  correction: null,
+  clarify_on: null,
+  attestation_id: "7afe536c-4470-4fde-ab2b-ad9c867e8d0b",
+};
+
+const MISMATCH = { ...PASS, verdict: "MISMATCH", action: "block" };
+
+test("a claim is sent in the wire shape the server accepts", async () => {
+  const stub = stubFetch(PASS);
+  const client = new EvidenceClient({ apiKey: "sk_test", url: "https://api.test" });
+  await client.verify("items_sum_to_total", {
+    value: 100,
+    inputs: { items: [[40, 60], "submitted_output"], total: [100, "submitted_output"] },
+  });
+
+  const { url, body } = stub.seen();
+  assert.equal(url, "https://api.test/v1/evidence/verify");
+  assert.equal(body.predicate, "items_sum_to_total");
+  // `claim` is a nested object, not a bare value: sending the value flat
+  // is a 422 from the server, which is how this shape was established.
+  assert.deepEqual(body.claim, { value: 100, text: null });
+  assert.deepEqual(body.inputs, {
+    items: { value: [40, 60], source: "submitted_output" },
+    total: { value: 100, source: "submitted_output" },
+  });
+});
+
+test("a PASS releases and a MISMATCH blocks", async () => {
+  const client = new EvidenceClient({ apiKey: "sk_test", url: "https://api.test" });
+
+  stubFetch(PASS);
+  const pass = await client.verify("items_sum_to_total", { value: 100 });
+  assert.equal(pass.verdict, "PASS");
+  assert.equal(isBlocking(pass), false);
+  assert.equal(pass.attestationId, "7afe536c-4470-4fde-ab2b-ad9c867e8d0b");
+  assert.deepEqual(pass.values, [{ items: [40, 60] }]);
+
+  stubFetch(MISMATCH);
+  const bad = await client.verify("items_sum_to_total", { value: 999 });
+  assert.equal(isBlocking(bad), true);
+  assert.equal(needsClarification(bad), false);
+});
+
+test("a clarify verdict is not a block", async () => {
+  stubFetch({ ...PASS, verdict: "UNDERDETERMINED", action: "clarify", clarify_on: ["total"] });
+  const client = new EvidenceClient({ apiKey: "sk_test", url: "https://api.test" });
+  const r = await client.verify("items_sum_to_total", { value: 100 });
+  assert.equal(needsClarification(r), true);
+  assert.equal(isBlocking(r), false);
+  assert.deepEqual(r.clarifyOn, ["total"]);
+});
+
+test("an untagged input fails locally, naming itself", () => {
+  // The server refuses it under the taint rule anyway. Failing here says
+  // which input is missing its tag instead of returning a 400 about one.
+  assert.throws(
+    () => normalizeInputs({ items: [40, 60] as never }),
+    /input 'items' needs a source tag/,
+  );
+  assert.deepEqual(normalizeInputs({ a: [1, "claim"] }), {
+    a: { value: 1, source: "claim" },
+  });
+  assert.deepEqual(normalizeInputs({ a: { value: 1, source: "claim" } }), {
+    a: { value: 1, source: "claim" },
+  });
+});
+
+test("a server refusal surfaces its own detail, not a generic failure", async () => {
+  stubFetch(
+    { detail: "input 'items' came from source 'user', which the predicate's taint allowlist does not permit" },
+    400,
+  );
+  const client = new EvidenceClient({ apiKey: "sk_test", url: "https://api.test" });
+  await assert.rejects(
+    () => client.verify("items_sum_to_total", { value: 100 }),
+    (err: EvidenceError) => {
+      assert.equal(err.status, 400);
+      assert.match(err.message, /taint allowlist/);
+      return true;
+    },
+  );
+});
+
+test("no key is an error before any request goes out", async () => {
+  let called = false;
+  globalThis.fetch = (async () => {
+    called = true;
+    return {} as Response;
+  }) as typeof fetch;
+  const client = new EvidenceClient({ apiKey: "", url: "https://api.test" });
+  assert.equal(client.configured, false);
+  await assert.rejects(() => client.verify("x"), /SPONSIO_API_KEY/);
+  assert.equal(called, false, "a keyless client must not reach the network");
+});

--- a/ts/packages/sdk/src/__tests__/evidence.test.ts
+++ b/ts/packages/sdk/src/__tests__/evidence.test.ts
@@ -143,3 +143,16 @@ test("no key is an error before any request goes out", async () => {
   await assert.rejects(() => client.verify("x"), /SPONSIO_API_KEY/);
   assert.equal(called, false, "a keyless client must not reach the network");
 });
+
+test("a base url with many trailing slashes does not stall", () => {
+  // CodeQL caught `/\/+$/` here: polynomial backtracking on a string of
+  // slashes, and the url comes from an env var, so its shape is not ours
+  // to assume. Stripping is a linear scan now.
+  const started = Date.now();
+  const client = new EvidenceClient({
+    apiKey: "k",
+    url: "https://a.test" + "/".repeat(200_000),
+  });
+  assert.equal(client.url, "https://a.test");
+  assert.ok(Date.now() - started < 1000, "trailing-slash stripping must stay linear");
+});

--- a/ts/packages/sdk/src/cloud/evidence.ts
+++ b/ts/packages/sdk/src/cloud/evidence.ts
@@ -157,11 +157,14 @@ export class EvidenceClient {
 
   constructor(opts: EvidenceClientOptions = {}) {
     this.apiKey = opts.apiKey ?? process.env.SPONSIO_API_KEY ?? undefined;
-    this.url = (
-      opts.url ??
-      process.env.SPONSIO_API_URL ??
-      "https://app.sponsio.dev"
-    ).replace(/\/+$/, "");
+    // Trailing slashes stripped without a regex. `/\/+$/` backtracks
+    // polynomially on a string of many slashes, and the URL comes from
+    // an env var, so it is not ours to trust about its own shape.
+    let base =
+      opts.url ?? process.env.SPONSIO_API_URL ?? "https://app.sponsio.dev";
+    let end = base.length;
+    while (end > 0 && base.charCodeAt(end - 1) === 47) end -= 1;
+    this.url = base.slice(0, end);
     this.timeoutMs = opts.timeoutMs ?? 10_000;
   }
 

--- a/ts/packages/sdk/src/cloud/evidence.ts
+++ b/ts/packages/sdk/src/cloud/evidence.ts
@@ -1,0 +1,269 @@
+/**
+ * The evidence lane, from TypeScript.
+ *
+ * Rules check what an agent *does*; evidence checks what it *says*. A
+ * model that reports "the three line items total $100" is making a claim
+ * that is either true of the numbers it was given or is not, and no
+ * amount of prompting settles it. This sends the claim to
+ * `/v1/evidence/verify`, which resolves it against the declared inputs
+ * and answers PASS, MISMATCH, or a verdict meaning it could not tell.
+ *
+ * Parity with `sponsio/cloud/evidence.py`: same endpoint, same wire
+ * shape, same verdict vocabulary. One service, one meter — the server
+ * records usage per tenant and cannot see which SDK called it.
+ *
+ * The judgement is entirely server-side. This file normalises inputs,
+ * makes one request, and classifies the answer.
+ *
+ * @module @sponsio/sdk/cloud/evidence
+ */
+
+/** A verdict the server can return. Anything else is treated as unknown. */
+export type EvidenceVerdict =
+  | "PASS"
+  | "MISMATCH"
+  | "NO_EVIDENCE"
+  | "SOURCE_UNAVAILABLE"
+  | "UNDERDETERMINED";
+
+/** What the server says to do about a verdict. */
+export type EvidenceAction = "release" | "block" | "clarify";
+
+/**
+ * One input, tagged with where its value came from.
+ *
+ * The tag is not decoration. Each predicate declares which sources it
+ * will accept, and the server refuses a value that arrived from anywhere
+ * else: a total the model made up must not be checked against itself.
+ * `GET /v1/evidence/predicates` lists the allowlist per predicate.
+ */
+export interface TaggedInput {
+  value: unknown;
+  source: string;
+}
+
+/** Ergonomic forms accepted per input: a tagged object or a `[value, source]` pair. */
+export type InputSpec = TaggedInput | [unknown, string];
+
+export interface EvidenceResult {
+  predicate: string;
+  verdict: EvidenceVerdict | string;
+  action: EvidenceAction | string;
+  /** The resolved values the verdict was reached from. */
+  values: unknown[];
+  evidenceTs?: number;
+  source?: string;
+  tableVersion?: string;
+  /** The right value, when the server knows it. Never invented. */
+  correction?: unknown;
+  /** What to ask about, on a clarify action. */
+  clarifyOn: unknown[];
+  /** Server-side record of this check, for an audit trail. */
+  attestationId?: string;
+}
+
+/** The check did not reach a verdict. The caller decides open or closed. */
+export class EvidenceError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "EvidenceError";
+    this.status = status;
+  }
+}
+
+/** True when this verdict must stop the response. */
+export function isBlocking(result: EvidenceResult): boolean {
+  return result.action === "block";
+}
+
+/** True when this verdict asks the agent to clarify rather than stop. */
+export function needsClarification(result: EvidenceResult): boolean {
+  return result.action === "clarify";
+}
+
+/**
+ * Ergonomic input forms to the wire's tagged shape.
+ *
+ * An untagged input is rejected here rather than sent. The server would
+ * refuse it anyway under the taint rule, and failing locally names the
+ * input that is missing its tag.
+ *
+ * The pair form needs a string source. Without that check a two-element
+ * array of data read as a pair: `{ items: [40, 60] }` became
+ * `value: 40, source: "60"`, and the server then refused source `"60"`
+ * as untrusted, an error naming nothing the caller had written. A list
+ * value takes the explicit form, `[[40, 60], "submitted_output"]`.
+ */
+export function normalizeInputs(
+  inputs?: Record<string, InputSpec>,
+): Record<string, TaggedInput> {
+  const wire: Record<string, TaggedInput> = {};
+  for (const [name, spec] of Object.entries(inputs ?? {})) {
+    if (Array.isArray(spec) && spec.length === 2 && typeof spec[1] === "string") {
+      wire[name] = { value: spec[0], source: spec[1] };
+    } else if (spec && typeof spec === "object" && "source" in spec) {
+      wire[name] = {
+        value: (spec as TaggedInput).value,
+        source: String((spec as TaggedInput).source),
+      };
+    } else {
+      throw new Error(
+        `input '${name}' needs a source tag: pass [value, source] or ` +
+          `{ value, source } — the server rejects untagged inputs (taint rule)`,
+      );
+    }
+  }
+  return wire;
+}
+
+function parseResult(payload: Record<string, unknown>): EvidenceResult {
+  const evidence = (payload.evidence ?? {}) as Record<string, unknown>;
+  const rawValues = evidence.values;
+  const clarify = payload.clarify_on;
+  return {
+    predicate: String(payload.predicate ?? ""),
+    verdict: String(payload.verdict ?? ""),
+    action: String(payload.action ?? ""),
+    values: Array.isArray(rawValues) ? rawValues : [],
+    ...(typeof evidence.ts === "number" ? { evidenceTs: evidence.ts } : {}),
+    ...(typeof evidence.source === "string" ? { source: evidence.source } : {}),
+    ...(typeof evidence.table_version === "string"
+      ? { tableVersion: evidence.table_version }
+      : {}),
+    ...(payload.correction !== null && payload.correction !== undefined
+      ? { correction: payload.correction }
+      : {}),
+    clarifyOn: Array.isArray(clarify) ? clarify : [],
+    ...(typeof payload.attestation_id === "string"
+      ? { attestationId: payload.attestation_id }
+      : {}),
+  };
+}
+
+export interface EvidenceClientOptions {
+  /** Defaults to `SPONSIO_API_KEY`. */
+  apiKey?: string;
+  /** Defaults to `SPONSIO_API_URL`, then `https://app.sponsio.dev`. */
+  url?: string;
+  /** Per-request timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+export class EvidenceClient {
+  readonly url: string;
+  private readonly apiKey: string | undefined;
+  private readonly timeoutMs: number;
+
+  constructor(opts: EvidenceClientOptions = {}) {
+    this.apiKey = opts.apiKey ?? process.env.SPONSIO_API_KEY ?? undefined;
+    this.url = (
+      opts.url ??
+      process.env.SPONSIO_API_URL ??
+      "https://app.sponsio.dev"
+    ).replace(/\/+$/, "");
+    this.timeoutMs = opts.timeoutMs ?? 10_000;
+  }
+
+  get configured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  private async post(
+    path: string,
+    body: unknown,
+  ): Promise<Record<string, unknown>> {
+    if (!this.apiKey) {
+      throw new EvidenceError(
+        "no API key: set SPONSIO_API_KEY or pass apiKey to EvidenceClient",
+      );
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(`${this.url}${path}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+          "User-Agent": "sponsio-sdk-ts",
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      throw new EvidenceError(
+        `cannot reach ${this.url}: ${err instanceof Error ? err.message : err}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const text = await response.text();
+    let payload: unknown;
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      throw new EvidenceError(
+        `${this.url} answered ${response.status} with non-JSON`,
+        response.status,
+      );
+    }
+    if (!response.ok) {
+      const detail = (payload as Record<string, unknown>)?.detail;
+      throw new EvidenceError(
+        typeof detail === "string" ? detail : `verify failed (${response.status})`,
+        response.status,
+      );
+    }
+    return payload as Record<string, unknown>;
+  }
+
+  /**
+   * Verify one claim against fresh evidence, server-side.
+   *
+   * Throws `EvidenceError` when the check did not run to a verdict.
+   * Decide open or closed at the call site; closed means treating the
+   * throw as a block.
+   */
+  async verify(
+    predicate: string,
+    opts: {
+      value?: unknown;
+      text?: string;
+      inputs?: Record<string, InputSpec>;
+      sessionId?: string;
+    } = {},
+  ): Promise<EvidenceResult> {
+    const body: Record<string, unknown> = {
+      predicate,
+      claim: { value: opts.value ?? null, text: opts.text ?? null },
+      inputs: normalizeInputs(opts.inputs),
+    };
+    if (opts.sessionId) body.session_id = opts.sessionId;
+    return parseResult(await this.post("/v1/evidence/verify", body));
+  }
+
+  /** The predicate catalog this key can reach. */
+  async predicates(): Promise<Record<string, unknown>[]> {
+    if (!this.apiKey) {
+      throw new EvidenceError(
+        "no API key: set SPONSIO_API_KEY or pass apiKey to EvidenceClient",
+      );
+    }
+    const response = await fetch(`${this.url}/v1/evidence/predicates`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "User-Agent": "sponsio-sdk-ts",
+      },
+    });
+    if (!response.ok) {
+      throw new EvidenceError(
+        `predicates failed (${response.status})`,
+        response.status,
+      );
+    }
+    return (await response.json()) as Record<string, unknown>[];
+  }
+}

--- a/ts/packages/sdk/src/core/grounding.ts
+++ b/ts/packages/sdk/src/core/grounding.ts
@@ -41,6 +41,11 @@ export interface ToolEvent {
   content?: string;
   /** Optional event timestamp; if omitted, the grounding state's monotonic clock advances by 1. */
   ts?: number;
+  /**
+   * Subject of the event, for kinds whose subject is not a tool name.
+   * An ``evidence`` event puts the predicate name here.
+   */
+  key?: string;
 }
 
 export interface GroundingState {
@@ -440,6 +445,19 @@ export function groundEvent(
         state.currentCtx[String(k)] = val == null ? "" : String(val);
       }
     }
+  } else if (eventType === "evidence" && event.key) {
+    // A cloud claim-verification verdict fed back into the trace.
+    // `key` is the predicate name; `args` carries the server's verdict
+    // and policy action verbatim. No verdict computation happens here —
+    // the atoms only restate what the service answered, so contracts
+    // (`claim_requires_evidence`, `underdetermined_must_clarify`) can
+    // reference it. Verdict upper-cased, action lower-cased, matching
+    // the server's own vocabulary and Python's grounding.
+    v[predKey("claim_emitted", event.key)] = true;
+    const verdict = String(event.args?.verdict ?? "").toUpperCase();
+    if (verdict) v[predKey("evidence_verdict", event.key, verdict)] = true;
+    const action = String(event.args?.action ?? "").toLowerCase();
+    if (action) v[predKey("evidence_action", event.key, action)] = true;
   }
 
   // ── ctx(k, v) / ctx_value(k) — emit per current_ctx entry, every event ─

--- a/ts/packages/sdk/src/core/pattern-factory.ts
+++ b/ts/packages/sdk/src/core/pattern-factory.ts
@@ -46,7 +46,9 @@ import {
   destructiveActionGate,
   untrustedSourceGate,
   requiredStepsCompletion,
+  claimRequiresEvidence,
   redirectToSafe,
+  underdeterminedMustClarify,
   toolAllowlist,
   dangerousBashCommands,
   dangerousSqlVerbs,
@@ -282,6 +284,13 @@ export function buildPatternByName(
       );
     case "tool_allowlist":
       return toolAllowlist(asStrList(needArg(args, 0, "allowed_tools"), "allowed_tools"));
+    // Evidence obligations. The verdicts come from the cloud verify API
+    // (`evidence` events); these only reference the grounded atoms.
+    case "claim_requires_evidence":
+      return claimRequiresEvidence(asStr(needArg(args, 0, "pred"), "pred"));
+    case "underdetermined_must_clarify":
+      return underdeterminedMustClarify(asStr(needArg(args, 0, "pred"), "pred"));
+
     case "redirect_to_safe":
       // TS parity: formula side only. The Python runtime bundles a
       // ``RedirectToSafe`` strategy on the resulting DetFormula that

--- a/ts/packages/sdk/src/core/patterns.ts
+++ b/ts/packages/sdk/src/core/patterns.ts
@@ -672,6 +672,61 @@ export function toolAllowlist(allowedTools: string[]): DetFormula {
  * need transparent substitution should stay on the Python SDK
  * (LangGraph adapter) until the TS strategy port lands.
  */
+/**
+ * Every emitted claim of this predicate must verify as PASS.
+ *
+ * Compiles to `G(claim_emitted(pred) -> evidence_verdict(pred, PASS))`.
+ * Both atoms are grounded from the same `evidence` event, so the
+ * implication is decided at the timestep the verdict lands: a claim
+ * whose verdict is anything but PASS (MISMATCH, UNDERDETERMINED,
+ * NO_EVIDENCE, STALE, SOURCE_UNAVAILABLE, EXTRACTION_AMBIGUOUS)
+ * violates immediately.
+ *
+ * Parity with `sponsio.patterns.library.claim_requires_evidence`.
+ */
+export function claimRequiresEvidence(pred: string, desc?: string): DetFormula {
+  ensureNonEmpty(pred, "claimRequiresEvidence", "pred");
+  return {
+    formula: new G(
+      new Implies(
+        new Atom("claim_emitted", [pred]),
+        new Atom("evidence_verdict", [pred, "PASS"]),
+      ),
+    ),
+    desc: desc || `claims of ${pred} must verify against evidence (PASS)`,
+    patternName: "claim_requires_evidence",
+    liveness: false,
+  };
+}
+
+/**
+ * An UNDERDETERMINED verdict must resolve to a clarify action.
+ *
+ * Compiles to `G(evidence_verdict(pred, UNDERDETERMINED) ->
+ * evidence_action(pred, clarify))`.
+ *
+ * Guards the policy wiring rather than the claim itself: when the
+ * evidence was ambiguous, the recorded action on that same event must be
+ * `clarify`. A project override that quietly releases or hard-blocks an
+ * ambiguous claim trips this contract.
+ *
+ * Parity with `sponsio.patterns.library.underdetermined_must_clarify`.
+ */
+export function underdeterminedMustClarify(pred: string, desc?: string): DetFormula {
+  ensureNonEmpty(pred, "underdeterminedMustClarify", "pred");
+  return {
+    formula: new G(
+      new Implies(
+        new Atom("evidence_verdict", [pred, "UNDERDETERMINED"]),
+        new Atom("evidence_action", [pred, "clarify"]),
+      ),
+    ),
+    desc: desc || `ambiguous ${pred} claims must be clarified, not released or blocked`,
+    patternName: "underdetermined_must_clarify",
+    liveness: false,
+  };
+}
+
 export function redirectToSafe(unsafe: string, safe: string): DetFormula {
   ensureDistinct(unsafe, safe, "redirectToSafe", "unsafe", "safe");
   return {

--- a/ts/packages/sdk/src/index.ts
+++ b/ts/packages/sdk/src/index.ts
@@ -722,15 +722,52 @@ export class Sponsio {
    * violations the same way they branch on ``guardBefore``. In
    * enforce mode, ``blocked: true`` rolls back the synthetic event.
    */
+  /**
+   * Record a claim-verification verdict in the trace and check the
+   * contracts that reference it.
+   *
+   * Grounds `claim_emitted(pred)`, `evidence_verdict(pred, V)` and
+   * `evidence_action(pred, a)` at one timestep, so contracts built from
+   * `claimRequiresEvidence` / `underdeterminedMustClarify` can decide.
+   * No verdict is computed here: the atoms restate what
+   * `/v1/evidence/verify` answered.
+   *
+   * Parity with feeding `EvidenceResult.to_event()` through Python's
+   * trace path.
+   */
+  observeEvidence(
+    predicate: string,
+    verdict: string,
+    action: string,
+  ): CheckResult {
+    return this._checkSynthetic({
+      tool: "",
+      event_type: "evidence",
+      key: predicate,
+      args: { verdict, action },
+    }, `<evidence:${predicate}>`);
+  }
+
   observeResponse(content: string, opts: { segment?: string } = {}): CheckResult {
     const args: Record<string, unknown> = {};
     if (opts.segment) args.segment = opts.segment;
-    const event: ToolEvent = {
-      tool: "",
-      event_type: "llm_response",
-      content,
-      args,
-    };
+    return this._checkSynthetic(
+      { tool: "", event_type: "llm_response", content, args },
+      "<llm_response>",
+    );
+  }
+
+  /**
+   * Check one synthetic (non-tool-call) event against every contract.
+   *
+   * The output lane and the evidence lane both push an event that is not
+   * a tool call and then judge the trace. Sharing the body keeps their
+   * verdicts identical: a second copy is how one lane ends up with a
+   * rollback the other lacks.
+   *
+   * `label` names the subject in violation messages and session logs.
+   */
+  private _checkSynthetic(event: ToolEvent, label: string): CheckResult {
     const snapshot = this._snapshotState();
     const valuation = groundEvent(event, this._state, this._contentAtoms);
     this._trace.push(valuation);
@@ -754,7 +791,7 @@ export class Sponsio {
               : "blocked";
         if (isStoppingAction(action)) anyStopping = true;
         const verb = effMode === "observe" ? "WOULD-BLOCK" : "BLOCKED";
-        const msg = `${verb}: ${this.agentId}.<llm_response> — det constraint violated: ${contract.desc}`;
+        const msg = `${verb}: ${this.agentId}.${label} — det constraint violated: ${contract.desc}`;
         violations.push(msg);
         violatedDescs.push(contract.desc);
         detViolations.push({
@@ -776,7 +813,7 @@ export class Sponsio {
       this._trace.pop();
       this._state = snapshot;
       this._violations.push(...violations);
-      this._logViolations("<llm_response>", violations, violatedDescs, "blocked");
+      this._logViolations(label, violations, violatedDescs, "blocked");
       // `allowed` tracks `blocked` alone, not every stopping outcome:
       // Python computes `not any(action == "blocked")`, so a redirect
       // stays `allowed: true` because the agent flow continues down the
@@ -795,7 +832,7 @@ export class Sponsio {
 
     if (hasViolations) {
       this._violations.push(...violations);
-      this._logViolations("<llm_response>", violations, violatedDescs, "observed");
+      this._logViolations(label, violations, violatedDescs, "observed");
     }
     return {
       ...deriveVerdict(detViolations),


### PR DESCRIPTION
Rules check what an agent *does*; evidence checks what it *says*. Python had that lane and TS had nothing, so a TS user could enforce tool calls and had no way to verify a claim.

## Two things I got wrong first

I said this needed "a second cloud client" as though it were an architectural lift. **There is one service.** The judgement is entirely server-side; the client normalises inputs, makes one POST to `/v1/evidence/verify`, and classifies the answer. Python's is 404 lines and most of that is config parsing and message formatting.

I also said TS should wait on a billing decision. **There is none to make.** `record(db, tenant_id, kind, qty)` meters per tenant and action; the server sees a bearer token and cannot tell which SDK sent it. Evidence is not in `MODEL_KINDS`, so it does not touch the AI budget either.

## Parity, measured

`@sponsio/sdk/cloud/evidence` mirrors `sponsio/cloud/evidence.py`: same endpoint, same wire shape, same verdict vocabulary. Both were run against production on the same four claims, and their output is **byte-identical**:

```
items_sum_to_total 100        -> PASS         release
items_sum_to_total 999        -> MISMATCH     block
date_valid 2026-03-01         -> PASS         release
date_valid 2026-02-30         -> NO_EVIDENCE  block
```

## A bug in the Python client, found by writing the TS one

A two-element list of data was read as a `(value, source)` pair:

```python
_normalize_inputs({"items": [40, 60]})   # -> {'items': {'value': 40, 'source': '60'}}
```

The server then refused source `"60"` under the taint rule, an error naming nothing the caller had written. The pair form now requires a **string** source, in both runtimes; a list value takes the explicit form `([40, 60], "submitted_output")`.

TS inherited the bug by being written from Python, which is the argument for writing the second implementation at all.

## Tests

Six, with `fetch` replaced, so CI exercises the request we build and the answer we parse rather than the service's availability. The wire shapes in them were captured from production, including the 422 that established `claim` is a nested object and the taint refusal.

Python 2826 passed, 19 skipped. TS 53 passed, up from 47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)