### PR TITLE
chore(release): 0.2.0a14, @sponsio/sdk 0.2.0-alpha.5

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@ Sponsio はエージェントがツールを呼ぶ前に、その呼び出しを
 
 > **エージェント契約** とは、エージェントのすべてのアクションでチェックされるランタイムルールであり、[形式手法に裏打ちされています](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a13 alpha リリース。** `pip install --pre sponsio`。読み込めなかったバンドルが読み込めるようになりました。`include: sponsio:incident/openclaw` はエラーになり、37 本のルールが 1 本も有効になりませんでした。カタログに載っている 5 つのパターンが設定ローダーの参照するレジストリから漏れていて、`pattern: no_pii` は失敗する一方で同じルールを英文で書くとコンパイルできる状態でした。インストール バッジに `--pre` が抜けていて、最後の安定版 0.1.1 を指していました。ここより遥かに古いものです。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a13)を参照。
+> **v0.2.0a14 alpha リリース。** `pip install --pre sponsio`、または `npm install -D @sponsio/sdk@alpha`。今回は TypeScript 向けです。インストール行に `alpha` タグが抜けていて、遥かに古い 0.1.0 を取得していました。QUICKSTART が教える API は例外を投げ、コマンドを打ち間違えても終了コードは 0 で、`redirect_to_safe` の判定は単なるブロックとして返るため、どのツールを代わりに呼ぶかをアダプタが知る術がありませんでした。エージェントの「言ったこと」を検証するエビデンス レーンも TypeScript から使えるようになりました。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a14)を参照。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sponsio checks an agent's tool calls before they run. A rule can look at what al
 
 > An **agent contract** is a runtime rule that is checked at every agent action, [backed by formal methods](docs/concepts/formal-methods.md).
 
-> **v0.2.0a13 alpha is out.** `pip install --pre sponsio`. Bundles that could not load now load: `include: sponsio:incident/openclaw` raised instead of arming its 37 rules, and five patterns the catalog documents were missing from the registry the config loader reads, so `pattern: no_pii` failed while the same rule in English compiled. The install badge left out `--pre`, so it pointed at the last stable release, 0.1.1, which is much older. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a13).
+> **v0.2.0a14 alpha is out.** `pip install --pre sponsio`, or `npm install -D @sponsio/sdk@alpha`. This one is for TypeScript. the install line used to leave out the `alpha` tag, so it resolved to 0.1.0, a much older release; QUICKSTART taught an API that threw; a mistyped command exited 0; and a `redirect_to_safe` verdict came back as a plain block, so no adapter could learn which tool to call instead. The evidence lane, which checks what an agent says rather than what it does, now works from TypeScript too. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a14).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ Sponsio 在 Agent 调用工具之前先检查这次调用。一条规则可以�
 
 > **Agent 合约**是一条运行时规则，在每一次 Agent 操作时检查，[由形式化方法支撑](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a13 alpha 已发布。** `pip install --pre sponsio`。原本加载不了的合约包现在能加载了:`include: sponsio:incident/openclaw` 以前直接报错,那 37 条规则一条都上不了膛;另有五个目录里登记过的模式不在配置加载器读的注册表里,导致 `pattern: no_pii` 报错、而同一条规则写成英文句子却能编译。安装徽章漏了 `--pre`,指向的是最后一个稳定版 0.1.1,比这里老得多。见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a13)。
+> **v0.2.0a14 alpha 已发布。** `pip install --pre sponsio`,或 `npm install -D @sponsio/sdk@alpha`。这一版是给 TypeScript 的。安装命令以前漏了 `alpha` 标签,装到的是 0.1.0 这个老得多的版本;QUICKSTART 教的 API 会抛异常;打错命令会以 0 退出;`redirect_to_safe` 的判定回来是普通拦截,任何适配器都无从知道该改调哪个工具。证据链(核验 agent 说了什么,而不是做了什么)现在 TypeScript 也能用了。见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a14)。
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sponsio"
-version = "0.2.0a13"
+version = "0.2.0a14"
 description = "Runtime contract enforcement for LLM agent systems"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1167,7 +1167,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sponsio/sdk": "^0.2.0-alpha.4"
+        "@sponsio/sdk": "^0.2.0-alpha.5"
       },
       "devDependencies": {
         "@deepseek-ai/cordis": "^4",
@@ -1183,7 +1183,7 @@
     },
     "packages/sdk": {
       "name": "@sponsio/sdk",
-      "version": "0.2.0-alpha.4",
+      "version": "0.2.0-alpha.5",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "^3.3.0",

--- a/ts/packages/dsh-plugin/package.json
+++ b/ts/packages/dsh-plugin/package.json
@@ -29,7 +29,7 @@
     "@deepseek-ai/schemastery": ">=3"
   },
   "dependencies": {
-    "@sponsio/sdk": "^0.2.0-alpha.4"
+    "@sponsio/sdk": "^0.2.0-alpha.5"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4",

--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sponsio/sdk",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.0-alpha.5",
   "description": "Runtime contract enforcement for LLM agents \u2014 native TypeScript",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Version bump plus the three README banners.

**The TS package moves too.** Every change in this release is on that side, and npm's `alpha` tag still pointed at `0.2.0-alpha.4`, so `@sponsio/sdk@alpha` would have carried none of it.

## What a14 carries

| PR | |
|---|---|
| #158 | The evidence lane from TypeScript: claims verified against an authority, not just tool calls checked |
| #157 | A `redirect_to_safe` verdict came back as a plain block, so no adapter could learn which tool to call instead |
| #156 | QUICKSTART had the mode precedence backwards, in the direction that tells a reader their code outranks ops' env var |
| #155 | A DeepSeek Harness plugin |
| #154 | `npm install @sponsio/sdk` resolved to 0.1.0; a mistyped command exited 0 |

For Python users only #156 matters, and it matters: a team with `SPONSIO_MODE=enforce` in the container reads `mode="observe"` in the source and believes they are shadowing.

For TypeScript users this is the release that makes the documented path work at all.

`2826 passed, 19 skipped`. TS 59 passed. Links resolve across 46 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)