### PR TITLE
DSL never-after fix, pattern identity on violations, privacy levels incl. tool_calls

### DIFF
--- a/sponsio/bridge/privacy.py
+++ b/sponsio/bridge/privacy.py
@@ -1,0 +1,153 @@
+"""What may leave the machine.
+
+Enforcement is local. A deterministic contract is evaluated in this
+process, against this trace, with no network call and no model, which
+means the content of a tool argument is needed *here* and is not needed
+anywhere else. What the cloud needs to render a dashboard, count a
+finding and bill a check is the shape of the run: which tool, in what
+order, with what verdict.
+
+That gap is the whole of this module. Four levels, decreasing in what
+crosses the boundary:
+
+``full``      arguments as the SDK already truncates them (the default,
+              and the right one for a team watching its own agents)
+``shape``     key names and value types, no values:
+              ``{"amount": <float>, "to": <str:9>}``
+``hashed``    a stable digest per argument set. Two calls with the same
+              arguments still look the same, which is what duplicate and
+              loop detection read, while the arguments themselves do not
+              leave
+``metadata``  no arguments at all, and no model output text
+
+A platform whose customers are in healthcare or finance can run
+``metadata`` and still get every finding the cloud derives, because a
+deterministic finding is a statement about which tools ran in which
+order, and none of the four levels changes that. The cost is evidence
+detail in the dashboard, and nothing else.
+
+Set it with ``SPONSIO_PRIVACY`` or ``bridge.attach(..., privacy="shape")``.
+The environment variable wins, so an operator can tighten a deployment
+without editing the code that ships in it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Any
+
+LEVELS = ("full", "shape", "hashed", "metadata")
+DEFAULT = "full"
+
+
+def resolve(explicit: str | None = None) -> str:
+    """The level in force. Environment beats argument, deliberately.
+
+    The person who decides what may leave a machine is the operator of
+    that machine, not the author of the agent running on it.
+    """
+    env = os.environ.get("SPONSIO_PRIVACY", "").strip().lower()
+    if env in LEVELS:
+        return env
+    if env:
+        # An unrecognised value is far more likely to be a typo in a
+        # deployment that meant to tighten than a request to loosen, so
+        # it fails closed rather than silently sending everything.
+        return "metadata"
+    if explicit in LEVELS:
+        return explicit
+    return DEFAULT
+
+
+def _type_of(value: Any) -> str:
+    if value is None:
+        return "<null>"
+    if isinstance(value, bool):
+        return "<bool>"
+    if isinstance(value, int):
+        return "<int>"
+    if isinstance(value, float):
+        return "<float>"
+    if isinstance(value, str):
+        return f"<str:{len(value)}>"
+    if isinstance(value, (list, tuple)):
+        return f"<list:{len(value)}>"
+    if isinstance(value, dict):
+        return "{" + ", ".join(f"{k!s}: {_type_of(v)}" for k, v in value.items()) + "}"
+    return f"<{type(value).__name__}>"
+
+
+def shape(args: Any) -> str:
+    """The structure of an argument set, with every value replaced.
+
+    Lengths survive for strings and lists because "the model passed a
+    40 000-character path" is a debugging fact and not content, and it is
+    the one an oversize-argument rule fires on.
+    """
+    if args is None:
+        return ""
+    if isinstance(args, dict):
+        return "{" + ", ".join(f'"{k}": {_type_of(v)}' for k, v in args.items()) + "}"
+    return _type_of(args)
+
+
+def digest(args: Any) -> str:
+    """A stable short hash of an argument set.
+
+    Sorted keys so two calls that differ only in dict ordering agree, and
+    truncated to 12 hex characters because this is an equality token, not
+    a signature.
+    """
+    if args is None:
+        return ""
+    try:
+        canonical = json.dumps(args, sort_keys=True, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        canonical = str(args)
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
+
+
+def preview(args: Any, level: str, *, full_preview: str) -> str:
+    """What the ``argsPreview`` field should carry at ``level``.
+
+    ``full_preview`` is what the existing truncating projection produced;
+    at ``full`` it is passed through unchanged so this module cannot
+    change today's behaviour for anyone who has not asked it to.
+    """
+    if level == "full":
+        return full_preview
+    if level == "shape":
+        return shape(args)
+    if level == "hashed":
+        return digest(args)
+    return ""
+
+
+def say(text: str, level: str) -> str:
+    """What a model turn may quote of itself.
+
+    At ``metadata`` the sentence goes entirely; at every other level it
+    is what it was. A response is the most content-bearing field in the
+    payload, so it moves one level earlier than arguments do.
+    """
+    if level == "metadata":
+        return ""
+    return text
+
+
+def describe(level: str) -> dict[str, Any]:
+    """A stamp for the run, so a reader knows what they are not seeing.
+
+    A dashboard showing empty arguments has to be able to say whether
+    the agent passed none or the deployment declined to send them. One
+    field answers that, and its absence would make every redacted trace
+    ambiguous.
+    """
+    return {
+        "level": level,
+        "sendsArguments": level == "full",
+        "sendsArgumentShapes": level in ("full", "shape"),
+        "sendsOutputText": level != "metadata",
+    }

--- a/sponsio/bridge/privacy.py
+++ b/sponsio/bridge/privacy.py
@@ -18,13 +18,25 @@ crosses the boundary:
               arguments still look the same, which is what duplicate and
               loop detection read, while the arguments themselves do not
               leave
-``metadata``  no arguments at all, and no model output text
+``metadata``  no arguments at all, and no model output text: the model
+              turn is still recorded, with its claim verdicts, but the
+              values those claims were checked against and any corrected
+              wording stay behind
+``tool_calls`` the action lane only. Tool name, order and verdict. No
+              model turns, no claim verdicts, no delegation notes. This is
+              the level a customer means by "only send us the tool calls"
 
 A platform whose customers are in healthcare or finance can run
-``metadata`` and still get every finding the cloud derives, because a
-deterministic finding is a statement about which tools ran in which
-order, and none of the four levels changes that. The cost is evidence
+``metadata`` or ``tool_calls`` and still get every deterministic finding
+the cloud derives, because such a finding is a statement about which
+tools ran in which order, and no level changes that. The cost is evidence
 detail in the dashboard, and nothing else.
+
+One thing no level can do is make cloud claim verification content-free:
+verifying a claim means sending the claim. ``tool_calls`` therefore
+refuses to coexist with an evidence configuration, at guard construction
+and again at attach, rather than quietly uploading through a side door
+the bridge does not own.
 
 Set it with ``SPONSIO_PRIVACY`` or ``bridge.attach(..., privacy="shape")``.
 The environment variable wins, so an operator can tighten a deployment
@@ -38,7 +50,8 @@ import json
 import os
 from typing import Any
 
-LEVELS = ("full", "shape", "hashed", "metadata")
+LEVELS = ("full", "shape", "hashed", "metadata", "tool_calls")
+STRICTEST = LEVELS[-1]
 DEFAULT = "full"
 
 
@@ -54,8 +67,8 @@ def resolve(explicit: str | None = None) -> str:
     if env:
         # An unrecognised value is far more likely to be a typo in a
         # deployment that meant to tighten than a request to loosen, so
-        # it fails closed rather than silently sending everything.
-        return "metadata"
+        # it fails closed, to the strictest level there is.
+        return STRICTEST
     if explicit in LEVELS:
         return explicit
     return DEFAULT
@@ -132,9 +145,40 @@ def say(text: str, level: str) -> str:
     is what it was. A response is the most content-bearing field in the
     payload, so it moves one level earlier than arguments do.
     """
-    if level == "metadata":
+    if level in ("metadata", "tool_calls"):
         return ""
     return text
+
+
+def keeps_step(step_type: str, level: str) -> bool:
+    """Whether a step of this type is recorded at all at ``level``.
+
+    Only ``tool_calls`` drops whole steps. Every other level keeps the
+    shape of the run and empties fields; this one keeps only the action
+    lane, because that is what the customer asked for by name.
+    """
+    if level == "tool_calls":
+        return step_type == "tool_call"
+    return True
+
+
+def claims(rows: list, level: str) -> list:
+    """Claim verdicts as ``level`` allows them to leave.
+
+    A verdict (MISMATCH, VERIFIED) is metadata. The authoritative value
+    the claim was checked against and the corrected sentence are content,
+    and at ``metadata`` they go the same way arguments do. ``tool_calls``
+    never reaches here: the whole output step is dropped first.
+    """
+    if level in ("full", "shape", "hashed"):
+        return rows
+    out = []
+    for row in rows:
+        kept = dict(row)
+        kept["evidence"] = ""
+        kept["fix"] = ""
+        out.append(kept)
+    return out
 
 
 def describe(level: str) -> dict[str, Any]:
@@ -149,5 +193,33 @@ def describe(level: str) -> dict[str, Any]:
         "level": level,
         "sendsArguments": level == "full",
         "sendsArgumentShapes": level in ("full", "shape"),
-        "sendsOutputText": level != "metadata",
+        "sendsOutputText": level in ("full", "shape", "hashed"),
+        "sendsClaimValues": level in ("full", "shape", "hashed"),
+        "sendsOutputLane": level != "tool_calls",
     }
+
+
+class PrivacyConflict(ValueError):
+    """A configuration that cannot keep the promise its privacy level makes."""
+
+
+def refuse_evidence_under_tool_calls(guard: Any, level: str) -> None:
+    """``tool_calls`` and cloud claim verification cannot both be true.
+
+    Verification sends the claim's value and text to the cloud; that is
+    what verifying means. A deployment that asked for tool calls only and
+    also configured evidence has asked for two incompatible things, and
+    the right answer is to say so before the first run, not to honour one
+    silently. Called at guard construction (environment level) and at
+    attach (resolved level), so neither path can slip past the other.
+    """
+    if level != "tool_calls":
+        return
+    if getattr(guard, "_evidence_config", None) is None:
+        return
+    raise PrivacyConflict(
+        "SPONSIO_PRIVACY=tool_calls sends only tool calls, but this guard has "
+        "an evidence configuration, and verifying a claim means sending its "
+        "value to the cloud. Remove the evidence section or choose "
+        "SPONSIO_PRIVACY=metadata."
+    )

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from sponsio.bridge import privacy as _privacy
 from sponsio.bridge.spans import (
     STOPPING_ACTIONS,
     args_preview,
@@ -150,9 +151,14 @@ class BridgeSession:
         contracts: list[dict] | None = None,
         agents: list[dict | str] | None = None,
         runs_dir: str | Path | None = None,
+        privacy: str | None = None,
     ) -> None:
         self.guard = guard
         self.project = project
+        # What may leave this machine. Enforcement already happened here,
+        # so this only ever narrows what the console can show, never what
+        # the runtime can check.
+        self.privacy = _privacy.resolve(privacy)
         # The server keys a run by this id and upserts, so two runs sharing
         # one id silently become one: the older is overwritten with no error.
         # The old id was 32 bits derived from id(guard) and the clock, which
@@ -271,7 +277,9 @@ class BridgeSession:
             "spanId": f"{idx:016x}",
             "type": type,
             "tool": tool,
-            "argsPreview": args_preview(args),
+            "argsPreview": _privacy.preview(
+                args, self.privacy, full_preview=args_preview(args)
+            ),
             "durationMs": round(float(turn.get("duration_ms", 0.0) or 0.0), 2),
             "status": status,
         }
@@ -305,7 +313,7 @@ class BridgeSession:
             "spanId": f"{idx:016x}",
             "type": type,
             "tool": text.split(":")[0].strip() or type,
-            "argsPreview": text,
+            "argsPreview": _privacy.say(text, self.privacy),
             "durationMs": 1.0,
             "status": "ok",
         }
@@ -381,7 +389,7 @@ class BridgeSession:
             "status": "mismatch"
             if any(c["verdict"] == "MISMATCH" for c in claims)
             else "ok",
-            "say": _say_of(response),
+            "say": _privacy.say(_say_of(response), self.privacy),
             "output": {"checked": len(claims), "claims": claims},
         }
         self.steps.append(step)
@@ -438,6 +446,9 @@ class BridgeSession:
             "steps": list(self.steps),
             "contracts": list(self.contracts.values()),
             "summary": self.summary(),
+            # So a reader can tell "the agent passed no arguments" from
+            # "this deployment does not send them".
+            "privacy": _privacy.describe(self.privacy),
         }
         # Which book this run enforced, when the config came from the cloud.
         # Absent for a local file, and absent is honest: a fabricated version
@@ -576,6 +587,7 @@ def attach(
     contracts: list[dict] | None = None,
     agents: list[dict | str] | None = None,
     runs_dir: str | Path | None = None,
+    privacy: str | None = None,
 ) -> BridgeSession:
     """Stream ``guard``'s run to a console.
 
@@ -591,6 +603,7 @@ def attach(
         contracts=contracts,
         agents=agents,
         runs_dir=runs_dir,
+        privacy=privacy,
     )
     if auto:
         original = guard.guard_before

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -304,6 +304,11 @@ class BridgeSession:
 
     def note(self, agent: str, text: str, type: str = "message") -> dict:
         idx = len(self.steps)
+        if not _privacy.keeps_step(type, self.privacy):
+            # The action lane only: the delegation edge itself is still
+            # drawn (see _edge), but its label is a sentence and stays.
+            self._ensure_agent(agent)
+            return {"type": type, "agentId": agent, "dropped": self.privacy}
         step = {
             "id": f"s{idx}",
             "ts": idx,
@@ -341,6 +346,8 @@ class BridgeSession:
         """
         claims_in = list(getattr(result, "evidence_claims", None) or [])
         if not claims_in:
+            return None
+        if not _privacy.keeps_step("assistant_output", self.privacy):
             return None
 
         claims: list[dict] = []
@@ -390,7 +397,10 @@ class BridgeSession:
             if any(c["verdict"] == "MISMATCH" for c in claims)
             else "ok",
             "say": _privacy.say(_say_of(response), self.privacy),
-            "output": {"checked": len(claims), "claims": claims},
+            "output": {
+                "checked": len(claims),
+                "claims": _privacy.claims(claims, self.privacy),
+            },
         }
         self.steps.append(step)
         self._ensure_agent(agent_id)
@@ -605,6 +615,7 @@ def attach(
         runs_dir=runs_dir,
         privacy=privacy,
     )
+    _privacy.refuse_evidence_under_tool_calls(guard, session.privacy)
     if auto:
         original = guard.guard_before
 

--- a/sponsio/bridge/spans.py
+++ b/sponsio/bridge/spans.py
@@ -97,6 +97,11 @@ def violations_from_turn(
             "evidence": violation.get("evidence", ""),
             "reason": meta.get("reason", label),
         }
+        # Carried from the contract row so a violation is identified by the
+        # pattern that fired, not only by the sentence someone wrote.
+        if meta.get("pattern"):
+            entry["pattern"] = meta["pattern"]
+            entry["args"] = meta.get("args", [])
         # The safe tool that ran instead — only when there was one.
         if enforcement.get("redirect_to"):
             entry["enforcement"]["redirectTo"] = enforcement["redirect_to"]

--- a/sponsio/findings/explain.py
+++ b/sponsio/findings/explain.py
@@ -98,30 +98,40 @@ RULES: dict[str, Rule] = {
     "must_precede": Rule(
         category="sequence",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} runs before {phrase(_a(a,0))}",
+        title=lambda a: (
+            f"{phrase(_a(a, 1)).capitalize()} runs before {phrase(_a(a, 0))}"
+        ),
         business=lambda a: (
-            f"The agent tried to {phrase(_a(a,1))} without first doing "
-            f"{phrase(_a(a,0))}."
+            f"The agent tried to {phrase(_a(a, 1))} without first doing "
+            f"{phrase(_a(a, 0))}."
         ),
         why="A required step was skipped, so the action ran on unchecked ground.",
-        fix=lambda a: f"Call `{_a(a,0)}` before `{_a(a,1)}`, and refuse `{_a(a,1)}` until it has returned.",
+        fix=lambda a: (
+            f"Call `{_a(a, 0)}` before `{_a(a, 1)}`, and refuse `{_a(a, 1)}` until it has returned."
+        ),
     ),
     "always_followed_by": Rule(
         category="sequence",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} is never followed by {phrase(_a(a,1))}",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} is never followed by {phrase(_a(a, 1))}"
+        ),
         business=lambda a: (
-            f"The agent did {phrase(_a(a,0))} and then never did "
-            f"{phrase(_a(a,1))}, leaving the task half finished."
+            f"The agent did {phrase(_a(a, 0))} and then never did "
+            f"{phrase(_a(a, 1))}, leaving the task half finished."
         ),
         why="The follow-up that closes the loop never happened.",
-        fix=lambda a: f"After `{_a(a,0)}` succeeds, always call `{_a(a,1)}` before the run ends.",
+        fix=lambda a: (
+            f"After `{_a(a, 0)}` succeeds, always call `{_a(a, 1)}` before the run ends."
+        ),
     ),
     "workflow_step": Rule(
         category="sequence",
         severity="medium",
         title=lambda a: "A workflow step ran out of order",
-        business=lambda a: "The agent took a step in the workflow before the step it depends on.",
+        business=lambda a: (
+            "The agent took a step in the workflow before the step it depends on."
+        ),
         why="Workflow order encodes a real dependency; out of order means acting on stale state.",
         fix=lambda a: "Reorder the plan so each step waits for its prerequisite.",
     ),
@@ -129,81 +139,95 @@ RULES: dict[str, Rule] = {
         category="sequence",
         severity="medium",
         title=lambda a: "The agent finished with required steps undone",
-        business=lambda a: "The run ended before every step the workflow requires had happened.",
+        business=lambda a: (
+            "The run ended before every step the workflow requires had happened."
+        ),
         why="An incomplete run looks successful to the caller and is not.",
-        fix=lambda a: "Check the required steps before returning, and continue instead of ending early.",
+        fix=lambda a: (
+            "Check the required steps before returning, and continue instead of ending early."
+        ),
     ),
     "deadline": Rule(
         category="sequence",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} did not happen in time",
+        title=lambda a: f"{phrase(_a(a, 1)).capitalize()} did not happen in time",
         business=lambda a: (
-            f"After {phrase(_a(a,0))}, the agent had {_n(_a(a,2))} steps to "
-            f"{phrase(_a(a,1))} and did not."
+            f"After {phrase(_a(a, 0))}, the agent had {_n(_a(a, 2))} steps to "
+            f"{phrase(_a(a, 1))} and did not."
         ),
         why="A commitment was made and the follow-through never arrived.",
         fix=lambda a: (
-            f"Do `{_a(a,1)}` within {_n(_a(a,2))} steps of `{_a(a,0)}`, "
-            f"or do not call `{_a(a,0)}`."
+            f"Do `{_a(a, 1)}` within {_n(_a(a, 2))} steps of `{_a(a, 0)}`, "
+            f"or do not call `{_a(a, 0)}`."
         ),
     ),
     "audit_after": Rule(
         category="compliance",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was not audited",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} was not audited",
         business=lambda a: (
-            f"The agent did {phrase(_a(a,0))} and never wrote the audit record "
+            f"The agent did {phrase(_a(a, 0))} and never wrote the audit record "
             f"that is supposed to follow it."
         ),
         why="The action happened but the record that proves it did not.",
-        fix=lambda a: f"Call `{_a(a,1)}` immediately after every `{_a(a,0)}`.",
+        fix=lambda a: f"Call `{_a(a, 1)}` immediately after every `{_a(a, 0)}`.",
     ),
     "dry_run_before_commit": Rule(
         category="safety",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} ran without a dry run",
+        title=lambda a: f"{phrase(_a(a, 1)).capitalize()} ran without a dry run",
         business=lambda a: "The agent committed a change without previewing it first.",
         why="A preview is the last chance to catch a wrong change before it is real.",
-        fix=lambda a: f"Call `{_a(a,0)}` and inspect its output before `{_a(a,1)}`.",
+        fix=lambda a: f"Call `{_a(a, 0)}` and inspect its output before `{_a(a, 1)}`.",
     ),
     "backup_before_destructive": Rule(
         category="safety",
         severity="critical",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} ran with no backup",
+        title=lambda a: f"{phrase(_a(a, 1)).capitalize()} ran with no backup",
         business=lambda a: (
-            f"The agent did {phrase(_a(a,1))} without taking a backup first, "
+            f"The agent did {phrase(_a(a, 1))} without taking a backup first, "
             f"so the change cannot be undone."
         ),
         why="Destructive without a backup is unrecoverable.",
-        fix=lambda a: f"Call `{_a(a,0)}` and confirm it succeeded before `{_a(a,1)}`.",
+        fix=lambda a: (
+            f"Call `{_a(a, 0)}` and confirm it succeeded before `{_a(a, 1)}`."
+        ),
     ),
     "sanitized_before_sink": Rule(
         category="security",
         severity="high",
-        title=lambda a: f"Unsanitized data reached {phrase(_a(a,2))}",
+        title=lambda a: f"Unsanitized data reached {phrase(_a(a, 2))}",
         business=lambda a: (
-            f"Data from {phrase(_a(a,0))} reached {phrase(_a(a,2))} without "
-            f"going through {phrase(_a(a,1))} first."
+            f"Data from {phrase(_a(a, 0))} reached {phrase(_a(a, 2))} without "
+            f"going through {phrase(_a(a, 1))} first."
         ),
         why="Untrusted input reaching a sink is the shape of an injection.",
-        fix=lambda a: f"Route every value from `{_a(a,0)}` through `{_a(a,1)}` before `{_a(a,2)}`.",
+        fix=lambda a: (
+            f"Route every value from `{_a(a, 0)}` through `{_a(a, 1)}` before `{_a(a, 2)}`."
+        ),
     ),
     "confirm_after_source": Rule(
         category="security",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} ran unconfirmed after untrusted input",
+        title=lambda a: (
+            f"{phrase(_a(a, 1)).capitalize()} ran unconfirmed after untrusted input"
+        ),
         business=lambda a: (
-            f"The agent read from {phrase(_a(a,0))} and then did "
-            f"{phrase(_a(a,1))} without asking anyone."
+            f"The agent read from {phrase(_a(a, 0))} and then did "
+            f"{phrase(_a(a, 1))} without asking anyone."
         ),
         why="Content the agent read can steer what it does next; a human breaks that chain.",
-        fix=lambda a: f"Require a confirmation step between `{_a(a,0)}` and `{_a(a,1)}`.",
+        fix=lambda a: (
+            f"Require a confirmation step between `{_a(a, 0)}` and `{_a(a, 1)}`."
+        ),
     ),
     "confirm_after_source_assumption": Rule(
         category="security",
         severity="high",
         title=lambda a: "An untrusted read went unconfirmed",
-        business=lambda a: "The agent acted on content it had just read from an untrusted place.",
+        business=lambda a: (
+            "The agent acted on content it had just read from an untrusted place."
+        ),
         why="Content the agent read can steer what it does next.",
         fix=lambda a: "Insert a confirmation step after reading untrusted content.",
     ),
@@ -212,7 +236,7 @@ RULES: dict[str, Rule] = {
         severity="high",
         title=lambda a: "An action followed untrusted content with no gate",
         business=lambda a: (
-            f"The agent read from {_plain(_a(a,0))} and acted on it without a check."
+            f"The agent read from {_plain(_a(a, 0))} and acted on it without a check."
         ),
         why="This is the prompt-injection path: read something, then do what it says.",
         fix=lambda a: "Gate the actions that may follow an untrusted read.",
@@ -225,70 +249,79 @@ RULES: dict[str, Rule] = {
         why="Untrusted content is the entry point for injection.",
         fix=lambda a: "Treat the read as untrusted and gate what may follow it.",
     ),
-
     # -- limits and loops ---------------------------------------------------
     "rate_limit": Rule(
         category="limit",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} exceeded its limit of {_n(_a(a,1))}",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} exceeded its limit of {_n(_a(a, 1))}"
+        ),
         business=lambda a: (
-            f"The agent tried to {phrase(_a(a,0))} more than {_n(_a(a,1))} "
-            f"time{'' if _n(_a(a,1)) == 1 else 's'} in one run."
+            f"The agent tried to {phrase(_a(a, 0))} more than {_n(_a(a, 1))} "
+            f"time{'' if _n(_a(a, 1)) == 1 else 's'} in one run."
         ),
         why="Repeating a real-world action is how a small bug becomes an expensive one.",
-        fix=lambda a: f"Track how many times `{_a(a,0)}` has run and stop at {_n(_a(a,1))}.",
+        fix=lambda a: (
+            f"Track how many times `{_a(a, 0)}` has run and stop at {_n(_a(a, 1))}."
+        ),
     ),
     "duplicate_call_limit": Rule(
         category="limit",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} repeated with the same arguments",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} repeated with the same arguments"
+        ),
         business=lambda a: (
-            f"The agent called {phrase(_a(a,0))} with the same input more than "
-            f"{_n(_a(a,2))} times."
+            f"The agent called {phrase(_a(a, 0))} with the same input more than "
+            f"{_n(_a(a, 2))} times."
         ),
         why="Identical repeats are usually a retry loop, and each one can have a side effect.",
-        fix=lambda a: f"Cache or dedupe `{_a(a,0)}` results instead of calling again.",
+        fix=lambda a: f"Cache or dedupe `{_a(a, 0)}` results instead of calling again.",
     ),
     "bounded_retry": Rule(
         category="limit",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} retried past {_n(_a(a,1))}",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} retried past {_n(_a(a, 1))}",
         business=lambda a: (
-            f"The agent kept retrying {phrase(_a(a,0))} after "
-            f"{_n(_a(a,1))} failed attempt{'' if _n(_a(a,1)) == 1 else 's'}."
+            f"The agent kept retrying {phrase(_a(a, 0))} after "
+            f"{_n(_a(a, 1))} failed attempt{'' if _n(_a(a, 1)) == 1 else 's'}."
         ),
         why="Retrying a failing call rarely fixes it and always costs.",
-        fix=lambda a: f"Give up on `{_a(a,0)}` after {_n(_a(a,1))} attempts and surface the failure.",
+        fix=lambda a: (
+            f"Give up on `{_a(a, 0)}` after {_n(_a(a, 1))} attempts and surface the failure."
+        ),
     ),
     "loop_detection": Rule(
         category="limit",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran in a loop",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} ran in a loop",
         business=lambda a: (
-            f"The agent called {phrase(_a(a,0))} {_n(_a(a,1))} times in a row "
+            f"The agent called {phrase(_a(a, 0))} {_n(_a(a, 1))} times in a row "
             f"with no progress in between."
         ),
         why="A stuck agent burns budget and never finishes the task.",
-        fix=lambda a: f"Break out of the loop after {_n(_a(a,1))} consecutive `{_a(a,0)}` calls.",
+        fix=lambda a: (
+            f"Break out of the loop after {_n(_a(a, 1))} consecutive `{_a(a, 0)}` calls."
+        ),
     ),
     "cooldown": Rule(
         category="limit",
         severity="low",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} repeated too soon",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} repeated too soon",
         business=lambda a: (
-            f"The agent did {phrase(_a(a,0))} again before the required "
-            f"{_n(_a(a,1))}-step gap had passed."
+            f"The agent did {phrase(_a(a, 0))} again before the required "
+            f"{_n(_a(a, 1))}-step gap had passed."
         ),
         why="The gap exists so a downstream system can settle before the next call.",
-        fix=lambda a: f"Wait {_n(_a(a,1))} steps between `{_a(a,0)}` calls.",
+        fix=lambda a: f"Wait {_n(_a(a, 1))} steps between `{_a(a, 0)}` calls.",
     ),
     "token_budget": Rule(
         category="cost",
         severity="medium",
         title=lambda a: "The run went over its token budget",
         business=lambda a: (
-            f"The agent used more than {_n(_a(a,0)):,} tokens "
-            f"({phrase(_a(a,1)) or 'total'})."
+            f"The agent used more than {_n(_a(a, 0)):,} tokens "
+            f"({phrase(_a(a, 1)) or 'total'})."
         ),
         why="Unbounded token use is unbounded cost.",
         fix=lambda a: "Shorten the context or cap the number of turns.",
@@ -296,166 +329,182 @@ RULES: dict[str, Rule] = {
     "delegation_depth_limit": Rule(
         category="limit",
         severity="medium",
-        title=lambda a: f"Delegation went deeper than {_n(_a(a,0))}",
+        title=lambda a: f"Delegation went deeper than {_n(_a(a, 0))}",
         business=lambda a: (
-            f"An agent handed work to another agent more than {_n(_a(a,0))} "
-            f"level{'' if _n(_a(a,0)) == 1 else 's'} deep."
+            f"An agent handed work to another agent more than {_n(_a(a, 0))} "
+            f"level{'' if _n(_a(a, 0)) == 1 else 's'} deep."
         ),
         why="Deep delegation chains lose the original intent and are hard to audit.",
-        fix=lambda a: f"Cap sub-agent delegation at {_n(_a(a,0))} levels.",
+        fix=lambda a: f"Cap sub-agent delegation at {_n(_a(a, 0))} levels.",
     ),
     "idempotent": Rule(
         category="limit",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran more than once",
-        business=lambda a: f"The agent did {phrase(_a(a,0))} twice, and it is meant to happen once.",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} ran more than once",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a, 0))} twice, and it is meant to happen once."
+        ),
         why="Doing a once-only action twice usually means a duplicate charge, message or record.",
-        fix=lambda a: f"Guard `{_a(a,0)}` with an idempotency key.",
+        fix=lambda a: f"Guard `{_a(a, 0)}` with an idempotency key.",
     ),
     "irreversible_once": Rule(
         category="safety",
         severity="critical",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was attempted twice",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} was attempted twice",
         business=lambda a: (
-            f"The agent tried to {phrase(_a(a,0))} a second time. This action "
+            f"The agent tried to {phrase(_a(a, 0))} a second time. This action "
             f"cannot be undone."
         ),
         why="An irreversible action repeated cannot be walked back.",
-        fix=lambda a: f"Record that `{_a(a,0)}` ran and refuse the second call.",
+        fix=lambda a: f"Record that `{_a(a, 0)}` ran and refuse the second call.",
     ),
-
     # -- authorisation and gates -------------------------------------------
     "must_confirm": Rule(
         category="approval",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without confirmation",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} ran without confirmation",
         business=lambda a: (
-            f"The agent did {phrase(_a(a,0))} without anyone confirming it."
+            f"The agent did {phrase(_a(a, 0))} without anyone confirming it."
         ),
         why="The confirmation is the human in the loop; without it the agent acted alone.",
-        fix=lambda a: f"Call `confirm_{_a(a,0)}` and require its approval before `{_a(a,0)}`.",
+        fix=lambda a: (
+            f"Call `confirm_{_a(a, 0)}` and require its approval before `{_a(a, 0)}`."
+        ),
     ),
     "requires_permission": Rule(
         category="approval",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without the {phrase(_a(a,1))} permission",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} ran without the {phrase(_a(a, 1))} permission"
+        ),
         business=lambda a: (
-            f"The agent did {phrase(_a(a,0))} but does not hold the "
-            f"{phrase(_a(a,1))} permission."
+            f"The agent did {phrase(_a(a, 0))} but does not hold the "
+            f"{phrase(_a(a, 1))} permission."
         ),
         why="The agent acted outside what it is authorised to do.",
         fix=lambda a: (
-            f"Either grant this agent the `{_a(a,1)}` permission in its agent "
-            f"definition, or stop it from reaching `{_a(a,0)}`."
+            f"Either grant this agent the `{_a(a, 1)}` permission in its agent "
+            f"definition, or stop it from reaching `{_a(a, 0)}`."
         ),
     ),
     "destructive_action_gate": Rule(
         category="approval",
         severity="critical",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without {phrase(_a(a,1))} approval",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} ran without {phrase(_a(a, 1))} approval"
+        ),
         business=lambda a: (
-            f"The agent did {phrase(_a(a,0))}, which requires sign-off from "
-            f"{phrase(_a(a,1))}, and no sign-off was present."
+            f"The agent did {phrase(_a(a, 0))}, which requires sign-off from "
+            f"{phrase(_a(a, 1))}, and no sign-off was present."
         ),
         why="A destructive action went ahead without the person accountable for it.",
-        fix=lambda a: f"Require an approval from `{_a(a,1)}` before `{_a(a,0)}`.",
+        fix=lambda a: f"Require an approval from `{_a(a, 1)}` before `{_a(a, 0)}`.",
     ),
     "approval_freshness": Rule(
         category="approval",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} used a stale approval",
+        title=lambda a: f"{phrase(_a(a, 1)).capitalize()} used a stale approval",
         business=lambda a: (
-            f"The approval for {phrase(_a(a,1))} was more than {_n(_a(a,2))} "
+            f"The approval for {phrase(_a(a, 1))} was more than {_n(_a(a, 2))} "
             f"steps old when it was used."
         ),
         why="An old approval was given for an older situation.",
-        fix=lambda a: f"Re-request `{_a(a,0)}` if more than {_n(_a(a,2))} steps have passed.",
+        fix=lambda a: (
+            f"Re-request `{_a(a, 0)}` if more than {_n(_a(a, 2))} steps have passed."
+        ),
     ),
     "approval_active": Rule(
         category="approval",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran on an expired approval",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} ran on an expired approval",
         business=lambda a: (
-            f"The {phrase(_a(a,1))} approval for {phrase(_a(a,0))} had expired "
-            f"(valid for {_n(_a(a,2))}s)."
+            f"The {phrase(_a(a, 1))} approval for {phrase(_a(a, 0))} had expired "
+            f"(valid for {_n(_a(a, 2))}s)."
         ),
         why="An expired approval is not an approval.",
-        fix=lambda a: f"Refresh the `{_a(a,1)}` approval before `{_a(a,0)}`.",
+        fix=lambda a: f"Refresh the `{_a(a, 1)}` approval before `{_a(a, 0)}`.",
     ),
     "segregation_of_duty": Rule(
         category="compliance",
         severity="high",
-        title=lambda a: f"One agent did both {phrase(_a(a,0))} and {phrase(_a(a,1))}",
+        title=lambda a: f"One agent did both {phrase(_a(a, 0))} and {phrase(_a(a, 1))}",
         business=lambda a: (
-            f"The same agent both did {phrase(_a(a,0))} and {phrase(_a(a,1))}. "
+            f"The same agent both did {phrase(_a(a, 0))} and {phrase(_a(a, 1))}. "
             f"These are meant to be done by different parties."
         ),
         why="Separation of duties is what stops one actor completing a whole fraud alone.",
-        fix=lambda a: f"Route `{_a(a,1)}` to a different agent or a human.",
+        fix=lambda a: f"Route `{_a(a, 1)}` to a different agent or a human.",
     ),
     "mutual_exclusion": Rule(
         category="safety",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} and {phrase(_a(a,1))} both ran",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} and {phrase(_a(a, 1))} both ran"
+        ),
         business=lambda a: (
-            f"The agent did both {phrase(_a(a,0))} and {phrase(_a(a,1))} in one "
+            f"The agent did both {phrase(_a(a, 0))} and {phrase(_a(a, 1))} in one "
             f"run; only one of them is allowed."
         ),
         why="The two actions contradict each other and the end state is undefined.",
-        fix=lambda a: f"Pick one of `{_a(a,0)}` / `{_a(a,1)}` per run.",
+        fix=lambda a: f"Pick one of `{_a(a, 0)}` / `{_a(a, 1)}` per run.",
     ),
     "no_reversal": Rule(
         category="safety",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} reversed an earlier {phrase(_a(a,0))}",
+        title=lambda a: (
+            f"{phrase(_a(a, 1)).capitalize()} reversed an earlier {phrase(_a(a, 0))}"
+        ),
         business=lambda a: (
-            f"The agent committed to {phrase(_a(a,0))} and then did "
-            f"{phrase(_a(a,1))}, which undoes it."
+            f"The agent committed to {phrase(_a(a, 0))} and then did "
+            f"{phrase(_a(a, 1))}, which undoes it."
         ),
         why="A commitment the agent takes back leaves whoever relied on it wrong.",
-        fix=lambda a: f"Once `{_a(a,0)}` has run, refuse `{_a(a,1)}`.",
+        fix=lambda a: f"Once `{_a(a, 0)}` has run, refuse `{_a(a, 1)}`.",
     ),
-
     # -- data boundaries ----------------------------------------------------
     "no_data_leak": Rule(
         category="security",
         severity="critical",
-        title=lambda a: f"Data from {phrase(_a(a,0))} reached {phrase(_a(a,1))}",
+        title=lambda a: f"Data from {phrase(_a(a, 0))} reached {phrase(_a(a, 1))}",
         business=lambda a: (
-            f"The agent moved data out of {phrase(_a(a,0))} and into "
-            f"{phrase(_a(a,1))}, which is outside the allowed boundary."
+            f"The agent moved data out of {phrase(_a(a, 0))} and into "
+            f"{phrase(_a(a, 1))}, which is outside the allowed boundary."
         ),
         why="Data crossed a boundary it was not meant to cross.",
-        fix=lambda a: f"Stop `{_a(a,1)}` from receiving anything sourced from `{_a(a,0)}`.",
+        fix=lambda a: (
+            f"Stop `{_a(a, 1)}` from receiving anything sourced from `{_a(a, 0)}`."
+        ),
     ),
     "data_intact": Rule(
         category="compliance",
         severity="high",
         title=lambda a: "Protected data was modified",
         business=lambda a: (
-            f"The agent changed data under {_plain(_a(a,1))}, which is meant to "
+            f"The agent changed data under {_plain(_a(a, 1))}, which is meant to "
             f"stay as it is."
         ),
         why="The record is supposed to be immutable after this point.",
-        fix=lambda a: f"Make `{_a(a,0)}` read-only for these paths.",
+        fix=lambda a: f"Make `{_a(a, 0)}` read-only for these paths.",
     ),
     "scope_limit": Rule(
         category="security",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} reached outside its allowed paths",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} reached outside its allowed paths"
+        ),
         business=lambda a: (
-            f"The agent used {phrase(_a(a,0))} on something outside "
-            f"{_plain(_a(a,1))}."
+            f"The agent used {phrase(_a(a, 0))} on something outside "
+            f"{_plain(_a(a, 1))}."
         ),
         why="The tool was pointed at data it has no business touching.",
-        fix=lambda a: f"Restrict `{_a(a,0)}` to {_list(_a(a,1))}.",
+        fix=lambda a: f"Restrict `{_a(a, 0)}` to {_list(_a(a, 1))}.",
     ),
     "no_pii": Rule(
         category="privacy",
         severity="critical",
         title=lambda a: "Personal data appeared in the agent's output",
         business=lambda a: (
-            f"The agent's reply contained {_plain(_a(a,0)) or 'personal data'}."
+            f"The agent's reply contained {_plain(_a(a, 0)) or 'personal data'}."
         ),
         why="Personal data in an output leaves the boundary the moment it is shown.",
         fix=lambda a: "Redact these fields before returning the response.",
@@ -466,7 +515,7 @@ RULES: dict[str, Rule] = {
         title=lambda a: "The agent used forbidden wording",
         business=lambda a: "The agent's reply used wording that is not allowed.",
         why="Certain phrasing carries legal or brand risk regardless of intent.",
-        fix=lambda a: f"Remove {_list(_a(a,0))} from the response.",
+        fix=lambda a: f"Remove {_list(_a(a, 0))} from the response.",
     ),
     "max_length": Rule(
         category="policy",
@@ -474,152 +523,172 @@ RULES: dict[str, Rule] = {
         title=lambda a: "The agent's reply was too long",
         business=lambda a: (
             f"The reply exceeded the allowed length "
-            f"({_n(_a(a,0))} words / {_n(_a(a,1))} characters)."
+            f"({_n(_a(a, 0))} words / {_n(_a(a, 1))} characters)."
         ),
         why="Long replies cost more and get read less.",
         fix=lambda a: "Constrain the response length in the prompt or post-process it.",
     ),
-
     # -- arguments ----------------------------------------------------------
     "arg_blacklist": Rule(
         category="security",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was called with a forbidden {phrase(_a(a,1))}",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} was called with a forbidden {phrase(_a(a, 1))}"
+        ),
         business=lambda a: (
-            f"The agent called {phrase(_a(a,0))} with a {phrase(_a(a,1))} value "
+            f"The agent called {phrase(_a(a, 0))} with a {phrase(_a(a, 1))} value "
             f"that is not allowed."
         ),
         why="The argument matched a pattern that is known to be dangerous.",
-        fix=lambda a: f"Validate `{_a(a,1)}` before calling `{_a(a,0)}` and reject {_list(_a(a,2))}.",
+        fix=lambda a: (
+            f"Validate `{_a(a, 1)}` before calling `{_a(a, 0)}` and reject {_list(_a(a, 2))}."
+        ),
     ),
     "arg_allowlist": Rule(
         category="security",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was called with an unlisted {phrase(_a(a,1))}",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} was called with an unlisted {phrase(_a(a, 1))}"
+        ),
         business=lambda a: (
-            f"The agent called {phrase(_a(a,0))} with a {phrase(_a(a,1))} value "
+            f"The agent called {phrase(_a(a, 0))} with a {phrase(_a(a, 1))} value "
             f"outside the approved set."
         ),
         why="Only known-good values are meant to reach this tool.",
-        fix=lambda a: f"Restrict `{_a(a,1)}` to {_list(_a(a,2))}.",
+        fix=lambda a: f"Restrict `{_a(a, 1)}` to {_list(_a(a, 2))}.",
     ),
     "arg_value_range": Rule(
         category="safety",
         severity="high",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} was out of range",
+        title=lambda a: f"{phrase(_a(a, 1)).capitalize()} was out of range",
         business=lambda a: (
-            f"The agent called {phrase(_a(a,0))} with a {phrase(_a(a,1))} outside "
-            f"the allowed range ({_a(a,2)} to {_a(a,3)})."
+            f"The agent called {phrase(_a(a, 0))} with a {phrase(_a(a, 1))} outside "
+            f"the allowed range ({_a(a, 2)} to {_a(a, 3)})."
         ),
         why="Out-of-range values are where the expensive mistakes live.",
-        fix=lambda a: f"Clamp or validate `{_a(a,1)}` to [{_a(a,2)}, {_a(a,3)}] before `{_a(a,0)}`.",
+        fix=lambda a: (
+            f"Clamp or validate `{_a(a, 1)}` to [{_a(a, 2)}, {_a(a, 3)}] before `{_a(a, 0)}`."
+        ),
     ),
     "arg_length_limit": Rule(
         category="safety",
         severity="low",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} was too long",
+        title=lambda a: f"{phrase(_a(a, 1)).capitalize()} was too long",
         business=lambda a: (
-            f"The agent passed a {phrase(_a(a,1))} longer than {_n(_a(a,2))} "
-            f"characters to {phrase(_a(a,0))}."
+            f"The agent passed a {phrase(_a(a, 1))} longer than {_n(_a(a, 2))} "
+            f"characters to {phrase(_a(a, 0))}."
         ),
         why="Oversized arguments are usually a sign of a runaway prompt or an injection.",
-        fix=lambda a: f"Truncate or reject `{_a(a,1)}` over {_n(_a(a,2))} characters.",
+        fix=lambda a: (
+            f"Truncate or reject `{_a(a, 1)}` over {_n(_a(a, 2))} characters."
+        ),
     ),
     "ctx_required": Rule(
         category="safety",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without required context",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} ran without required context",
         business=lambda a: (
-            f"The agent called {phrase(_a(a,0))} without {phrase(_a(a,1))} set to "
-            f"{_plain(_a(a,2))}."
+            f"The agent called {phrase(_a(a, 0))} without {phrase(_a(a, 1))} set to "
+            f"{_plain(_a(a, 2))}."
         ),
         why="The tool needs this context to behave correctly.",
-        fix=lambda a: f"Set `{_a(a,1)}` before calling `{_a(a,0)}`.",
+        fix=lambda a: f"Set `{_a(a, 1)}` before calling `{_a(a, 0)}`.",
     ),
     "ctx_matches_required": Rule(
         category="safety",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,1)).capitalize()} did not match what {phrase(_a(a,0))} requires",
+        title=lambda a: (
+            f"{phrase(_a(a, 1)).capitalize()} did not match what {phrase(_a(a, 0))} requires"
+        ),
         business=lambda a: (
-            f"The {phrase(_a(a,1))} in context did not match the expected form "
-            f"when {phrase(_a(a,0))} ran."
+            f"The {phrase(_a(a, 1))} in context did not match the expected form "
+            f"when {phrase(_a(a, 0))} ran."
         ),
         why="Acting on context in the wrong shape means acting on the wrong thing.",
-        fix=lambda a: f"Validate `{_a(a,1)}` against `{_a(a,2)}` before `{_a(a,0)}`.",
+        fix=lambda a: (
+            f"Validate `{_a(a, 1)}` against `{_a(a, 2)}` before `{_a(a, 0)}`."
+        ),
     ),
     "time_since": Rule(
         category="safety",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was too old",
+        title=lambda a: f"{phrase(_a(a, 0)).capitalize()} was too old",
         business=lambda a: (
-            f"The agent relied on {phrase(_a(a,0))} that was more than "
-            f"{_n(_a(a,1))} seconds old."
+            f"The agent relied on {phrase(_a(a, 0))} that was more than "
+            f"{_n(_a(a, 1))} seconds old."
         ),
         why="Stale state leads to decisions about a world that has moved on.",
-        fix=lambda a: f"Refresh `{_a(a,0)}` when it is older than {_n(_a(a,1))}s.",
+        fix=lambda a: f"Refresh `{_a(a, 0)}` when it is older than {_n(_a(a, 1))}s.",
     ),
-
     # -- tools --------------------------------------------------------------
     "tool_allowlist": Rule(
         category="policy",
         severity="high",
         title=lambda a: "The agent used a tool it is not allowed to use",
         business=lambda a: (
-            f"The agent called a tool outside its approved set "
-            f"({_plain(_a(a,0))})."
+            f"The agent called a tool outside its approved set ({_plain(_a(a, 0))})."
         ),
         why="The agent reached for a capability nobody granted it.",
-        fix=lambda a: "Either add the tool to the allowlist deliberately, or remove it from the agent's tool set.",
+        fix=lambda a: (
+            "Either add the tool to the allowlist deliberately, or remove it from the agent's tool set."
+        ),
     ),
     "redirect_to_safe": Rule(
         category="safety",
         severity="medium",
-        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was replaced with {phrase(_a(a,1))}",
+        title=lambda a: (
+            f"{phrase(_a(a, 0)).capitalize()} was replaced with {phrase(_a(a, 1))}"
+        ),
         business=lambda a: (
-            f"The agent reached for {phrase(_a(a,0))}; Sponsio ran "
-            f"{phrase(_a(a,1))} instead."
+            f"The agent reached for {phrase(_a(a, 0))}; Sponsio ran "
+            f"{phrase(_a(a, 1))} instead."
         ),
         why="The agent keeps choosing the unsafe tool, which is a prompt problem, not a runtime one.",
-        fix=lambda a: f"Remove `{_a(a,0)}` from the tool set and describe `{_a(a,1)}` in its place.",
+        fix=lambda a: (
+            f"Remove `{_a(a, 0)}` from the tool set and describe `{_a(a, 1)}` in its place."
+        ),
     ),
     "dangerous_bash_commands": Rule(
         category="security",
         severity="critical",
         title=lambda a: "The agent tried to run a dangerous shell command",
-        business=lambda a: "The agent tried to run a shell command that can destroy data or the machine.",
+        business=lambda a: (
+            "The agent tried to run a shell command that can destroy data or the machine."
+        ),
         why="One of these commands succeeding is an outage, not a bug.",
-        fix=lambda a: f"Block {_list(_a(a,0))} at the tool layer, not only in the prompt.",
+        fix=lambda a: (
+            f"Block {_list(_a(a, 0))} at the tool layer, not only in the prompt."
+        ),
     ),
     "dangerous_sql_verbs": Rule(
         category="security",
         severity="critical",
         title=lambda a: "The agent tried to run a destructive SQL statement",
         business=lambda a: (
-            f"The agent tried to run a statement using {_plain(_a(a,1))} against "
+            f"The agent tried to run a statement using {_plain(_a(a, 1))} against "
             f"the database."
         ),
         why="A destructive statement from an agent is not recoverable from the agent's side.",
-        fix=lambda a: f"Give `{_a(a,0)}` a read-only connection.",
+        fix=lambda a: f"Give `{_a(a, 0)}` a read-only connection.",
     ),
-
     # -- claims and evidence ------------------------------------------------
     "claim_requires_evidence": Rule(
         category="grounding",
         severity="high",
-        title=lambda a: f"An unsupported claim about {phrase(_a(a,0))}",
+        title=lambda a: f"An unsupported claim about {phrase(_a(a, 0))}",
         business=lambda a: (
-            f"The agent stated something about {phrase(_a(a,0))} that nothing in "
+            f"The agent stated something about {phrase(_a(a, 0))} that nothing in "
             f"the run supports."
         ),
         why="A confident answer with no source behind it is the failure users notice last.",
-        fix=lambda a: f"Require a `{_a(a,0)}` lookup before the agent asserts it.",
+        fix=lambda a: f"Require a `{_a(a, 0)}` lookup before the agent asserts it.",
     ),
     "underdetermined_must_clarify": Rule(
         category="grounding",
         severity="medium",
         title=lambda a: "The agent guessed instead of asking",
         business=lambda a: (
-            f"The request did not determine {phrase(_a(a,0))} and the agent "
+            f"The request did not determine {phrase(_a(a, 0))} and the agent "
             f"proceeded anyway."
         ),
         why="Guessing on an ambiguous request produces confident wrong work.",
@@ -628,9 +697,9 @@ RULES: dict[str, Rule] = {
     "claim_requires_smt_valid": Rule(
         category="grounding",
         severity="high",
-        title=lambda a: f"A claim about {phrase(_a(a,0))} does not hold",
+        title=lambda a: f"A claim about {phrase(_a(a, 0))} does not hold",
         business=lambda a: (
-            f"The agent asserted something about {phrase(_a(a,0))} that is not "
+            f"The agent asserted something about {phrase(_a(a, 0))} that is not "
             f"true under the stated constraints."
         ),
         why="The statement contradicts the constraints it was derived from.",
@@ -639,7 +708,9 @@ RULES: dict[str, Rule] = {
     "smt_premises_must_be_consistent": Rule(
         category="grounding",
         severity="high",
-        title=lambda a: f"The constraints around {phrase(_a(a,0))} contradict each other",
+        title=lambda a: (
+            f"The constraints around {phrase(_a(a, 0))} contradict each other"
+        ),
         business=lambda a: (
             "The conditions the agent was working from cannot all be true at "
             "once, so any answer it gives is meaningless."

--- a/sponsio/findings/explain.py
+++ b/sponsio/findings/explain.py
@@ -1,0 +1,772 @@
+"""One violation, said two ways.
+
+A deterministic contract already knows exactly what it checked, so the
+sentence a business reader needs does not have to be guessed by a model.
+It can be looked up. This module is that lookup: pattern name plus the
+arguments the pattern was built with, in; a title, a plain-language
+account, why it matters, and what to change, out.
+
+Two audiences, on purpose. A platform embedding Sponsio shows the
+developer line to whoever maintains the agent and the business line to
+whoever bought it, and neither should have to read the other's:
+
+    developer   must_precede(check_policy, issue_refund) failed at step 1
+    business    The agent issued a refund before checking the refund
+                policy. Sponsio stopped the call.
+
+No model runs here. The same violation produces the same sentence on
+every machine, forever, which is what makes it safe to put in a
+customer-facing dashboard, an audit export, or a diff.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Sequence
+
+
+def phrase(name: Any) -> str:
+    """A tool name as prose: ``issue_refund`` -> ``issue refund``.
+
+    Deliberately literal. Inflecting to "issues a refund" would need a
+    verb lexicon, and a wrong guess in a customer-facing sentence is
+    worse than a plain one.
+    """
+    return str(name).replace("_", " ").replace(".", " ").strip()
+
+
+def _list(values: Any, quote: str = "`") -> str:
+    if isinstance(values, (list, tuple, set)):
+        items = [f"{quote}{v}{quote}" for v in values]
+    else:
+        items = [f"{quote}{values}{quote}"]
+    if not items:
+        return "(none)"
+    if len(items) == 1:
+        return items[0]
+    return ", ".join(items[:-1]) + " or " + items[-1]
+
+
+def _plain(values: Any) -> str:
+    if isinstance(values, (list, tuple, set)):
+        items = [phrase(v) for v in values]
+    else:
+        items = [phrase(values)]
+    if len(items) == 1:
+        return items[0]
+    return ", ".join(items[:-1]) + " or " + items[-1]
+
+
+def _n(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class Rule:
+    """How one pattern explains itself.
+
+    ``severity`` is the pattern's inherent weight, before enforcement is
+    considered. :func:`explain` lowers it when the rule only watched,
+    because a rule that fires in observe mode is a finding about the agent
+    and a rule that blocked is a finding about a call that did not happen.
+    """
+
+    category: str
+    severity: str
+    title: Callable[[Sequence], str]
+    business: Callable[[Sequence], str]
+    why: str
+    fix: Callable[[Sequence], str]
+
+
+def _a(args: Sequence, i: int, default: Any = "") -> Any:
+    try:
+        return args[i]
+    except (IndexError, TypeError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# The table. One entry per pattern in sponsio/patterns/library.py.
+# ---------------------------------------------------------------------------
+
+RULES: dict[str, Rule] = {
+    # -- ordering and workflow ---------------------------------------------
+    "must_precede": Rule(
+        category="sequence",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} runs before {phrase(_a(a,0))}",
+        business=lambda a: (
+            f"The agent tried to {phrase(_a(a,1))} without first doing "
+            f"{phrase(_a(a,0))}."
+        ),
+        why="A required step was skipped, so the action ran on unchecked ground.",
+        fix=lambda a: f"Call `{_a(a,0)}` before `{_a(a,1)}`, and refuse `{_a(a,1)}` until it has returned.",
+    ),
+    "always_followed_by": Rule(
+        category="sequence",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} is never followed by {phrase(_a(a,1))}",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a,0))} and then never did "
+            f"{phrase(_a(a,1))}, leaving the task half finished."
+        ),
+        why="The follow-up that closes the loop never happened.",
+        fix=lambda a: f"After `{_a(a,0)}` succeeds, always call `{_a(a,1)}` before the run ends.",
+    ),
+    "workflow_step": Rule(
+        category="sequence",
+        severity="medium",
+        title=lambda a: "A workflow step ran out of order",
+        business=lambda a: "The agent took a step in the workflow before the step it depends on.",
+        why="Workflow order encodes a real dependency; out of order means acting on stale state.",
+        fix=lambda a: "Reorder the plan so each step waits for its prerequisite.",
+    ),
+    "required_steps_completion": Rule(
+        category="sequence",
+        severity="medium",
+        title=lambda a: "The agent finished with required steps undone",
+        business=lambda a: "The run ended before every step the workflow requires had happened.",
+        why="An incomplete run looks successful to the caller and is not.",
+        fix=lambda a: "Check the required steps before returning, and continue instead of ending early.",
+    ),
+    "deadline": Rule(
+        category="sequence",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} did not happen in time",
+        business=lambda a: (
+            f"After {phrase(_a(a,0))}, the agent had {_n(_a(a,2))} steps to "
+            f"{phrase(_a(a,1))} and did not."
+        ),
+        why="A commitment was made and the follow-through never arrived.",
+        fix=lambda a: (
+            f"Do `{_a(a,1)}` within {_n(_a(a,2))} steps of `{_a(a,0)}`, "
+            f"or do not call `{_a(a,0)}`."
+        ),
+    ),
+    "audit_after": Rule(
+        category="compliance",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was not audited",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a,0))} and never wrote the audit record "
+            f"that is supposed to follow it."
+        ),
+        why="The action happened but the record that proves it did not.",
+        fix=lambda a: f"Call `{_a(a,1)}` immediately after every `{_a(a,0)}`.",
+    ),
+    "dry_run_before_commit": Rule(
+        category="safety",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} ran without a dry run",
+        business=lambda a: "The agent committed a change without previewing it first.",
+        why="A preview is the last chance to catch a wrong change before it is real.",
+        fix=lambda a: f"Call `{_a(a,0)}` and inspect its output before `{_a(a,1)}`.",
+    ),
+    "backup_before_destructive": Rule(
+        category="safety",
+        severity="critical",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} ran with no backup",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a,1))} without taking a backup first, "
+            f"so the change cannot be undone."
+        ),
+        why="Destructive without a backup is unrecoverable.",
+        fix=lambda a: f"Call `{_a(a,0)}` and confirm it succeeded before `{_a(a,1)}`.",
+    ),
+    "sanitized_before_sink": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: f"Unsanitized data reached {phrase(_a(a,2))}",
+        business=lambda a: (
+            f"Data from {phrase(_a(a,0))} reached {phrase(_a(a,2))} without "
+            f"going through {phrase(_a(a,1))} first."
+        ),
+        why="Untrusted input reaching a sink is the shape of an injection.",
+        fix=lambda a: f"Route every value from `{_a(a,0)}` through `{_a(a,1)}` before `{_a(a,2)}`.",
+    ),
+    "confirm_after_source": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} ran unconfirmed after untrusted input",
+        business=lambda a: (
+            f"The agent read from {phrase(_a(a,0))} and then did "
+            f"{phrase(_a(a,1))} without asking anyone."
+        ),
+        why="Content the agent read can steer what it does next; a human breaks that chain.",
+        fix=lambda a: f"Require a confirmation step between `{_a(a,0)}` and `{_a(a,1)}`.",
+    ),
+    "confirm_after_source_assumption": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: "An untrusted read went unconfirmed",
+        business=lambda a: "The agent acted on content it had just read from an untrusted place.",
+        why="Content the agent read can steer what it does next.",
+        fix=lambda a: "Insert a confirmation step after reading untrusted content.",
+    ),
+    "untrusted_source_gate": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: "An action followed untrusted content with no gate",
+        business=lambda a: (
+            f"The agent read from {_plain(_a(a,0))} and acted on it without a check."
+        ),
+        why="This is the prompt-injection path: read something, then do what it says.",
+        fix=lambda a: "Gate the actions that may follow an untrusted read.",
+    ),
+    "untrusted_source_gate_assumption": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: "An untrusted source was read",
+        business=lambda a: "The agent read content from a source it does not control.",
+        why="Untrusted content is the entry point for injection.",
+        fix=lambda a: "Treat the read as untrusted and gate what may follow it.",
+    ),
+
+    # -- limits and loops ---------------------------------------------------
+    "rate_limit": Rule(
+        category="limit",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} exceeded its limit of {_n(_a(a,1))}",
+        business=lambda a: (
+            f"The agent tried to {phrase(_a(a,0))} more than {_n(_a(a,1))} "
+            f"time{'' if _n(_a(a,1)) == 1 else 's'} in one run."
+        ),
+        why="Repeating a real-world action is how a small bug becomes an expensive one.",
+        fix=lambda a: f"Track how many times `{_a(a,0)}` has run and stop at {_n(_a(a,1))}.",
+    ),
+    "duplicate_call_limit": Rule(
+        category="limit",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} repeated with the same arguments",
+        business=lambda a: (
+            f"The agent called {phrase(_a(a,0))} with the same input more than "
+            f"{_n(_a(a,2))} times."
+        ),
+        why="Identical repeats are usually a retry loop, and each one can have a side effect.",
+        fix=lambda a: f"Cache or dedupe `{_a(a,0)}` results instead of calling again.",
+    ),
+    "bounded_retry": Rule(
+        category="limit",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} retried past {_n(_a(a,1))}",
+        business=lambda a: (
+            f"The agent kept retrying {phrase(_a(a,0))} after "
+            f"{_n(_a(a,1))} failed attempt{'' if _n(_a(a,1)) == 1 else 's'}."
+        ),
+        why="Retrying a failing call rarely fixes it and always costs.",
+        fix=lambda a: f"Give up on `{_a(a,0)}` after {_n(_a(a,1))} attempts and surface the failure.",
+    ),
+    "loop_detection": Rule(
+        category="limit",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran in a loop",
+        business=lambda a: (
+            f"The agent called {phrase(_a(a,0))} {_n(_a(a,1))} times in a row "
+            f"with no progress in between."
+        ),
+        why="A stuck agent burns budget and never finishes the task.",
+        fix=lambda a: f"Break out of the loop after {_n(_a(a,1))} consecutive `{_a(a,0)}` calls.",
+    ),
+    "cooldown": Rule(
+        category="limit",
+        severity="low",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} repeated too soon",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a,0))} again before the required "
+            f"{_n(_a(a,1))}-step gap had passed."
+        ),
+        why="The gap exists so a downstream system can settle before the next call.",
+        fix=lambda a: f"Wait {_n(_a(a,1))} steps between `{_a(a,0)}` calls.",
+    ),
+    "token_budget": Rule(
+        category="cost",
+        severity="medium",
+        title=lambda a: "The run went over its token budget",
+        business=lambda a: (
+            f"The agent used more than {_n(_a(a,0)):,} tokens "
+            f"({phrase(_a(a,1)) or 'total'})."
+        ),
+        why="Unbounded token use is unbounded cost.",
+        fix=lambda a: "Shorten the context or cap the number of turns.",
+    ),
+    "delegation_depth_limit": Rule(
+        category="limit",
+        severity="medium",
+        title=lambda a: f"Delegation went deeper than {_n(_a(a,0))}",
+        business=lambda a: (
+            f"An agent handed work to another agent more than {_n(_a(a,0))} "
+            f"level{'' if _n(_a(a,0)) == 1 else 's'} deep."
+        ),
+        why="Deep delegation chains lose the original intent and are hard to audit.",
+        fix=lambda a: f"Cap sub-agent delegation at {_n(_a(a,0))} levels.",
+    ),
+    "idempotent": Rule(
+        category="limit",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran more than once",
+        business=lambda a: f"The agent did {phrase(_a(a,0))} twice, and it is meant to happen once.",
+        why="Doing a once-only action twice usually means a duplicate charge, message or record.",
+        fix=lambda a: f"Guard `{_a(a,0)}` with an idempotency key.",
+    ),
+    "irreversible_once": Rule(
+        category="safety",
+        severity="critical",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was attempted twice",
+        business=lambda a: (
+            f"The agent tried to {phrase(_a(a,0))} a second time. This action "
+            f"cannot be undone."
+        ),
+        why="An irreversible action repeated cannot be walked back.",
+        fix=lambda a: f"Record that `{_a(a,0)}` ran and refuse the second call.",
+    ),
+
+    # -- authorisation and gates -------------------------------------------
+    "must_confirm": Rule(
+        category="approval",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without confirmation",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a,0))} without anyone confirming it."
+        ),
+        why="The confirmation is the human in the loop; without it the agent acted alone.",
+        fix=lambda a: f"Call `confirm_{_a(a,0)}` and require its approval before `{_a(a,0)}`.",
+    ),
+    "requires_permission": Rule(
+        category="approval",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without the {phrase(_a(a,1))} permission",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a,0))} but does not hold the "
+            f"{phrase(_a(a,1))} permission."
+        ),
+        why="The agent acted outside what it is authorised to do.",
+        fix=lambda a: (
+            f"Either grant this agent the `{_a(a,1)}` permission in its agent "
+            f"definition, or stop it from reaching `{_a(a,0)}`."
+        ),
+    ),
+    "destructive_action_gate": Rule(
+        category="approval",
+        severity="critical",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without {phrase(_a(a,1))} approval",
+        business=lambda a: (
+            f"The agent did {phrase(_a(a,0))}, which requires sign-off from "
+            f"{phrase(_a(a,1))}, and no sign-off was present."
+        ),
+        why="A destructive action went ahead without the person accountable for it.",
+        fix=lambda a: f"Require an approval from `{_a(a,1)}` before `{_a(a,0)}`.",
+    ),
+    "approval_freshness": Rule(
+        category="approval",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} used a stale approval",
+        business=lambda a: (
+            f"The approval for {phrase(_a(a,1))} was more than {_n(_a(a,2))} "
+            f"steps old when it was used."
+        ),
+        why="An old approval was given for an older situation.",
+        fix=lambda a: f"Re-request `{_a(a,0)}` if more than {_n(_a(a,2))} steps have passed.",
+    ),
+    "approval_active": Rule(
+        category="approval",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran on an expired approval",
+        business=lambda a: (
+            f"The {phrase(_a(a,1))} approval for {phrase(_a(a,0))} had expired "
+            f"(valid for {_n(_a(a,2))}s)."
+        ),
+        why="An expired approval is not an approval.",
+        fix=lambda a: f"Refresh the `{_a(a,1)}` approval before `{_a(a,0)}`.",
+    ),
+    "segregation_of_duty": Rule(
+        category="compliance",
+        severity="high",
+        title=lambda a: f"One agent did both {phrase(_a(a,0))} and {phrase(_a(a,1))}",
+        business=lambda a: (
+            f"The same agent both did {phrase(_a(a,0))} and {phrase(_a(a,1))}. "
+            f"These are meant to be done by different parties."
+        ),
+        why="Separation of duties is what stops one actor completing a whole fraud alone.",
+        fix=lambda a: f"Route `{_a(a,1)}` to a different agent or a human.",
+    ),
+    "mutual_exclusion": Rule(
+        category="safety",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} and {phrase(_a(a,1))} both ran",
+        business=lambda a: (
+            f"The agent did both {phrase(_a(a,0))} and {phrase(_a(a,1))} in one "
+            f"run; only one of them is allowed."
+        ),
+        why="The two actions contradict each other and the end state is undefined.",
+        fix=lambda a: f"Pick one of `{_a(a,0)}` / `{_a(a,1)}` per run.",
+    ),
+    "no_reversal": Rule(
+        category="safety",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} reversed an earlier {phrase(_a(a,0))}",
+        business=lambda a: (
+            f"The agent committed to {phrase(_a(a,0))} and then did "
+            f"{phrase(_a(a,1))}, which undoes it."
+        ),
+        why="A commitment the agent takes back leaves whoever relied on it wrong.",
+        fix=lambda a: f"Once `{_a(a,0)}` has run, refuse `{_a(a,1)}`.",
+    ),
+
+    # -- data boundaries ----------------------------------------------------
+    "no_data_leak": Rule(
+        category="security",
+        severity="critical",
+        title=lambda a: f"Data from {phrase(_a(a,0))} reached {phrase(_a(a,1))}",
+        business=lambda a: (
+            f"The agent moved data out of {phrase(_a(a,0))} and into "
+            f"{phrase(_a(a,1))}, which is outside the allowed boundary."
+        ),
+        why="Data crossed a boundary it was not meant to cross.",
+        fix=lambda a: f"Stop `{_a(a,1)}` from receiving anything sourced from `{_a(a,0)}`.",
+    ),
+    "data_intact": Rule(
+        category="compliance",
+        severity="high",
+        title=lambda a: "Protected data was modified",
+        business=lambda a: (
+            f"The agent changed data under {_plain(_a(a,1))}, which is meant to "
+            f"stay as it is."
+        ),
+        why="The record is supposed to be immutable after this point.",
+        fix=lambda a: f"Make `{_a(a,0)}` read-only for these paths.",
+    ),
+    "scope_limit": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} reached outside its allowed paths",
+        business=lambda a: (
+            f"The agent used {phrase(_a(a,0))} on something outside "
+            f"{_plain(_a(a,1))}."
+        ),
+        why="The tool was pointed at data it has no business touching.",
+        fix=lambda a: f"Restrict `{_a(a,0)}` to {_list(_a(a,1))}.",
+    ),
+    "no_pii": Rule(
+        category="privacy",
+        severity="critical",
+        title=lambda a: "Personal data appeared in the agent's output",
+        business=lambda a: (
+            f"The agent's reply contained {_plain(_a(a,0)) or 'personal data'}."
+        ),
+        why="Personal data in an output leaves the boundary the moment it is shown.",
+        fix=lambda a: "Redact these fields before returning the response.",
+    ),
+    "no_keywords": Rule(
+        category="policy",
+        severity="medium",
+        title=lambda a: "The agent used forbidden wording",
+        business=lambda a: "The agent's reply used wording that is not allowed.",
+        why="Certain phrasing carries legal or brand risk regardless of intent.",
+        fix=lambda a: f"Remove {_list(_a(a,0))} from the response.",
+    ),
+    "max_length": Rule(
+        category="policy",
+        severity="low",
+        title=lambda a: "The agent's reply was too long",
+        business=lambda a: (
+            f"The reply exceeded the allowed length "
+            f"({_n(_a(a,0))} words / {_n(_a(a,1))} characters)."
+        ),
+        why="Long replies cost more and get read less.",
+        fix=lambda a: "Constrain the response length in the prompt or post-process it.",
+    ),
+
+    # -- arguments ----------------------------------------------------------
+    "arg_blacklist": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was called with a forbidden {phrase(_a(a,1))}",
+        business=lambda a: (
+            f"The agent called {phrase(_a(a,0))} with a {phrase(_a(a,1))} value "
+            f"that is not allowed."
+        ),
+        why="The argument matched a pattern that is known to be dangerous.",
+        fix=lambda a: f"Validate `{_a(a,1)}` before calling `{_a(a,0)}` and reject {_list(_a(a,2))}.",
+    ),
+    "arg_allowlist": Rule(
+        category="security",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was called with an unlisted {phrase(_a(a,1))}",
+        business=lambda a: (
+            f"The agent called {phrase(_a(a,0))} with a {phrase(_a(a,1))} value "
+            f"outside the approved set."
+        ),
+        why="Only known-good values are meant to reach this tool.",
+        fix=lambda a: f"Restrict `{_a(a,1)}` to {_list(_a(a,2))}.",
+    ),
+    "arg_value_range": Rule(
+        category="safety",
+        severity="high",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} was out of range",
+        business=lambda a: (
+            f"The agent called {phrase(_a(a,0))} with a {phrase(_a(a,1))} outside "
+            f"the allowed range ({_a(a,2)} to {_a(a,3)})."
+        ),
+        why="Out-of-range values are where the expensive mistakes live.",
+        fix=lambda a: f"Clamp or validate `{_a(a,1)}` to [{_a(a,2)}, {_a(a,3)}] before `{_a(a,0)}`.",
+    ),
+    "arg_length_limit": Rule(
+        category="safety",
+        severity="low",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} was too long",
+        business=lambda a: (
+            f"The agent passed a {phrase(_a(a,1))} longer than {_n(_a(a,2))} "
+            f"characters to {phrase(_a(a,0))}."
+        ),
+        why="Oversized arguments are usually a sign of a runaway prompt or an injection.",
+        fix=lambda a: f"Truncate or reject `{_a(a,1)}` over {_n(_a(a,2))} characters.",
+    ),
+    "ctx_required": Rule(
+        category="safety",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} ran without required context",
+        business=lambda a: (
+            f"The agent called {phrase(_a(a,0))} without {phrase(_a(a,1))} set to "
+            f"{_plain(_a(a,2))}."
+        ),
+        why="The tool needs this context to behave correctly.",
+        fix=lambda a: f"Set `{_a(a,1)}` before calling `{_a(a,0)}`.",
+    ),
+    "ctx_matches_required": Rule(
+        category="safety",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,1)).capitalize()} did not match what {phrase(_a(a,0))} requires",
+        business=lambda a: (
+            f"The {phrase(_a(a,1))} in context did not match the expected form "
+            f"when {phrase(_a(a,0))} ran."
+        ),
+        why="Acting on context in the wrong shape means acting on the wrong thing.",
+        fix=lambda a: f"Validate `{_a(a,1)}` against `{_a(a,2)}` before `{_a(a,0)}`.",
+    ),
+    "time_since": Rule(
+        category="safety",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was too old",
+        business=lambda a: (
+            f"The agent relied on {phrase(_a(a,0))} that was more than "
+            f"{_n(_a(a,1))} seconds old."
+        ),
+        why="Stale state leads to decisions about a world that has moved on.",
+        fix=lambda a: f"Refresh `{_a(a,0)}` when it is older than {_n(_a(a,1))}s.",
+    ),
+
+    # -- tools --------------------------------------------------------------
+    "tool_allowlist": Rule(
+        category="policy",
+        severity="high",
+        title=lambda a: "The agent used a tool it is not allowed to use",
+        business=lambda a: (
+            f"The agent called a tool outside its approved set "
+            f"({_plain(_a(a,0))})."
+        ),
+        why="The agent reached for a capability nobody granted it.",
+        fix=lambda a: "Either add the tool to the allowlist deliberately, or remove it from the agent's tool set.",
+    ),
+    "redirect_to_safe": Rule(
+        category="safety",
+        severity="medium",
+        title=lambda a: f"{phrase(_a(a,0)).capitalize()} was replaced with {phrase(_a(a,1))}",
+        business=lambda a: (
+            f"The agent reached for {phrase(_a(a,0))}; Sponsio ran "
+            f"{phrase(_a(a,1))} instead."
+        ),
+        why="The agent keeps choosing the unsafe tool, which is a prompt problem, not a runtime one.",
+        fix=lambda a: f"Remove `{_a(a,0)}` from the tool set and describe `{_a(a,1)}` in its place.",
+    ),
+    "dangerous_bash_commands": Rule(
+        category="security",
+        severity="critical",
+        title=lambda a: "The agent tried to run a dangerous shell command",
+        business=lambda a: "The agent tried to run a shell command that can destroy data or the machine.",
+        why="One of these commands succeeding is an outage, not a bug.",
+        fix=lambda a: f"Block {_list(_a(a,0))} at the tool layer, not only in the prompt.",
+    ),
+    "dangerous_sql_verbs": Rule(
+        category="security",
+        severity="critical",
+        title=lambda a: "The agent tried to run a destructive SQL statement",
+        business=lambda a: (
+            f"The agent tried to run a statement using {_plain(_a(a,1))} against "
+            f"the database."
+        ),
+        why="A destructive statement from an agent is not recoverable from the agent's side.",
+        fix=lambda a: f"Give `{_a(a,0)}` a read-only connection.",
+    ),
+
+    # -- claims and evidence ------------------------------------------------
+    "claim_requires_evidence": Rule(
+        category="grounding",
+        severity="high",
+        title=lambda a: f"An unsupported claim about {phrase(_a(a,0))}",
+        business=lambda a: (
+            f"The agent stated something about {phrase(_a(a,0))} that nothing in "
+            f"the run supports."
+        ),
+        why="A confident answer with no source behind it is the failure users notice last.",
+        fix=lambda a: f"Require a `{_a(a,0)}` lookup before the agent asserts it.",
+    ),
+    "underdetermined_must_clarify": Rule(
+        category="grounding",
+        severity="medium",
+        title=lambda a: "The agent guessed instead of asking",
+        business=lambda a: (
+            f"The request did not determine {phrase(_a(a,0))} and the agent "
+            f"proceeded anyway."
+        ),
+        why="Guessing on an ambiguous request produces confident wrong work.",
+        fix=lambda a: "Ask a clarifying question when the input is ambiguous.",
+    ),
+    "claim_requires_smt_valid": Rule(
+        category="grounding",
+        severity="high",
+        title=lambda a: f"A claim about {phrase(_a(a,0))} does not hold",
+        business=lambda a: (
+            f"The agent asserted something about {phrase(_a(a,0))} that is not "
+            f"true under the stated constraints."
+        ),
+        why="The statement contradicts the constraints it was derived from.",
+        fix=lambda a: "Have the agent verify the claim before stating it.",
+    ),
+    "smt_premises_must_be_consistent": Rule(
+        category="grounding",
+        severity="high",
+        title=lambda a: f"The constraints around {phrase(_a(a,0))} contradict each other",
+        business=lambda a: (
+            "The conditions the agent was working from cannot all be true at "
+            "once, so any answer it gives is meaningless."
+        ),
+        why="An inconsistent premise set makes every conclusion derivable.",
+        fix=lambda a: "Surface the contradiction to the user instead of answering.",
+    ),
+}
+
+
+_SEVERITY_ORDER = ["low", "medium", "high", "critical"]
+
+
+def _lower_severity(base: str, steps: int = 1) -> str:
+    try:
+        i = _SEVERITY_ORDER.index(base)
+    except ValueError:
+        return base
+    return _SEVERITY_ORDER[max(i - steps, 0)]
+
+
+@dataclass(frozen=True)
+class Explanation:
+    """One violation, explained for both audiences."""
+
+    pattern: str
+    category: str
+    severity: str
+    title: str
+    developer: str
+    business: str
+    why: str
+    fix: str
+    known: bool = True
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "pattern": self.pattern,
+            "category": self.category,
+            "severity": self.severity,
+            "title": self.title,
+            "explanation": {"developer": self.developer, "business": self.business},
+            "why": self.why,
+            "fix": self.fix,
+            "known": self.known,
+            **self.extra,
+        }
+
+
+def explain(
+    pattern: str,
+    args: Sequence = (),
+    *,
+    rule_text: str = "",
+    tool: str = "",
+    action: str = "",
+    step: int | None = None,
+    run: str = "",
+) -> Explanation:
+    """Explain one violation of ``pattern``.
+
+    ``action`` is what the runtime did: ``blocked`` means the call never
+    happened, ``observed`` means it did and only the log knows. Severity
+    moves with it: a rule that stopped a wire transfer is a bigger event
+    than the same rule watching one go through in shadow mode, and a
+    dashboard that ranks them the same ranks nothing.
+
+    An unknown pattern still gets an answer. The alternative, dropping
+    it, would make a new pattern invisible in every embedded dashboard
+    until this table caught up, which is exactly the kind of silent gap
+    that gets noticed by a customer rather than by us.
+    """
+    rule = RULES.get(pattern)
+    where = ""
+    if step is not None:
+        where = f" at step {step}" + (f" of run {run}" if run else "")
+    elif run:
+        where = f" in run {run}"
+
+    if rule is None:
+        text = rule_text or pattern.replace("_", " ")
+        return Explanation(
+            pattern=pattern or "unknown",
+            category="other",
+            severity="medium",
+            title=text[:1].upper() + text[1:] if text else "Contract violated",
+            developer=f"{pattern}({', '.join(str(x) for x in args)}) failed{where}.",
+            business=f"The agent broke the rule: {text}.",
+            why="A contract the operator wrote was not satisfied.",
+            fix="Review the rule and the step that violated it.",
+            known=False,
+        )
+
+    severity = rule.severity
+    if action in ("observed", "warned", "redirected"):
+        # It happened. The rule saw it and let it through (or substituted),
+        # which is a weaker signal about the deployment even when the rule
+        # is grave.
+        severity = _lower_severity(severity)
+
+    business = rule.business(args)
+    if action == "blocked":
+        business += " Sponsio stopped the call."
+    elif action == "escalated":
+        business += " Sponsio stopped the call and raised it to a human."
+    elif action in ("observed", "warned"):
+        business += " Sponsio recorded it; the call still ran."
+    elif action == "redirected":
+        business += " Sponsio substituted a safe alternative."
+
+    developer = f"{pattern}({', '.join(repr(x) for x in args)}) failed{where}."
+    if tool:
+        developer += f" Offending call: {tool}."
+
+    return Explanation(
+        pattern=pattern,
+        category=rule.category,
+        severity=severity,
+        title=rule.title(args),
+        developer=developer,
+        business=business,
+        why=rule.why,
+        fix=rule.fix(args),
+    )
+
+
+def coverage() -> dict[str, Any]:
+    """Which library patterns this table explains. Used by the test."""
+    return {"explained": sorted(RULES), "count": len(RULES)}

--- a/sponsio/generation/dsl_to_contract.py
+++ b/sponsio/generation/dsl_to_contract.py
@@ -1884,7 +1884,16 @@ def parse_dsl(expr: str) -> ParsedConstraint:
     if pattern_name == "no_reversal" and len(actions) >= 2:
         _lower = text.lower()
         if re.search(
-            r"must not follow|should not follow|not allowed after|forbidden after|prohibited after|never after",
+            r"must not follow|should not follow|not allowed after|forbidden after"
+            r"|prohibited after|never after"
+            # "never `A` after `B`" and its two siblings put the
+            # contradiction first as well, and matched none of the
+            # spellings above because the negation word is separated from
+            # "after" by the action itself. Without them the rule compiled
+            # to its own mirror image: "never `export_phi` after
+            # `share_record`" permitted exactly the order it names and
+            # blocked the harmless one, while the console reported ARMED.
+            r"|^(?:never|cannot|can\s*not|must\s+not)\b(?=.*\bafter\b)",
             _lower,
         ) or _forbidden_action_comes_first(_lower, actions[0], actions[1]):
             actions = [actions[1], actions[0]] + actions[2:]

--- a/sponsio/integrations/base.py
+++ b/sponsio/integrations/base.py
@@ -891,6 +891,13 @@ class BaseGuard:
             from sponsio.integrations.evidence_middleware import EvidenceConfig
 
             self._evidence_config = EvidenceConfig.from_value(evidence)
+            # A deployment that asked for tool calls only cannot also
+            # verify claims in the cloud: the check happens here, once,
+            # against the operator's environment, so the contradiction
+            # surfaces at construction and not on the first model turn.
+            from sponsio.bridge import privacy as _privacy
+
+            _privacy.refuse_evidence_under_tool_calls(self, _privacy.resolve(None))
 
         # --- Shadow-mode session logger ---
         # Always attach the JSONL logger in observe mode so users have a

--- a/tests/test_bridge_pattern_identity.py
+++ b/tests/test_bridge_pattern_identity.py
@@ -1,0 +1,79 @@
+"""A violation leaves the machine as a pattern, not only as a sentence.
+
+Contract rows already carry ``pattern`` and ``args`` (added for the
+copilot's mining dedupe). Violations did not: everything downstream that
+wants to group runs by rule, rank by severity or say what to change had
+to parse English to recover what the SDK already knew.
+"""
+
+from __future__ import annotations
+
+import sponsio
+from sponsio.bridge.session import _contracts_from_guard
+from sponsio.bridge.spans import violations_from_turn
+
+
+def test_contract_rows_carry_the_pattern_and_its_arguments(capsys):
+    guard = sponsio.Sponsio(
+        agent_id="a",
+        contracts=[
+            "tool `check_policy` must precede `issue_refund`",
+            "tool `run_bash` at most 5 times",
+        ],
+        verbose=False,
+    )
+    capsys.readouterr()
+    rows = {r["pattern"]: r for r in _contracts_from_guard(guard)}
+    assert rows["must_precede"]["args"] == ["check_policy", "issue_refund"]
+    assert rows["rate_limit"]["args"] == ["run_bash", 5]
+
+
+def test_tuple_arguments_become_lists_so_they_survive_json():
+    """scope_limit and friends carry a tuple of paths; a tuple is not JSON.
+
+    Built from the pattern library directly rather than through the DSL,
+    because the property is about the projection, not about parsing."""
+    from types import SimpleNamespace
+
+    from sponsio.patterns.library import scope_limit
+
+    formula = scope_limit("read_file", ["/srv/app", "/srv/data"])
+    guard = SimpleNamespace(
+        mode="enforce",
+        _system=SimpleNamespace(
+            _contracts=[SimpleNamespace(desc=None, mode=None, guarantees=[formula])]
+        ),
+    )
+    (row,) = _contracts_from_guard(guard)
+    assert row["pattern"] == "scope_limit"
+    assert row["args"] == ["read_file", ["/srv/app", "/srv/data"]]
+    for arg in row["args"]:
+        assert not isinstance(arg, tuple)
+
+
+def test_a_violation_carries_the_pattern_of_the_rule_it_broke():
+    label = "tool `check_policy` must precede `issue_refund`"
+    by_label = {
+        label: {
+            "id": "c1",
+            "label": label,
+            "pattern": "must_precede",
+            "args": ["check_policy", "issue_refund"],
+        }
+    }
+    turn = {
+        "children": [
+            {
+                "span_type": "sponsio.contract_check",
+                "contract_name": label,
+                "children": [
+                    {"span_type": "sponsio.guarantee", "formula_desc": label},
+                    {"span_type": "sponsio.violation", "kind": "guarantee"},
+                    {"span_type": "sponsio.enforcement", "result_action": "blocked"},
+                ],
+            }
+        ]
+    }
+    (entry,) = violations_from_turn(turn, by_label)
+    assert entry["pattern"] == "must_precede"
+    assert entry["args"] == ["check_policy", "issue_refund"]

--- a/tests/test_bridge_privacy.py
+++ b/tests/test_bridge_privacy.py
@@ -1,0 +1,116 @@
+"""What a deployment declines to send, and what that costs it.
+
+The claim these tests defend is the one a regulated customer will ask
+about directly: turning redaction on changes what the console can show
+and changes nothing about what the runtime enforces. Enforcement is
+local and deterministic, so the two are genuinely independent, but
+"genuinely independent" is a property, and properties get tests.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sponsio.bridge import privacy
+
+ARGS = {"amount": 250.0, "to": "ACC-9911", "memo": "patient MRN-88213", "urgent": True}
+
+
+def test_full_is_the_default_and_passes_the_existing_preview_through():
+    """Nobody's payload changes until they ask for it to."""
+    assert privacy.resolve(None) == "full"
+    assert privacy.preview(ARGS, "full", full_preview="already truncated") == "already truncated"
+
+
+def test_shape_keeps_the_keys_and_drops_every_value():
+    out = privacy.shape(ARGS)
+    assert "amount" in out and "memo" in out
+    assert "250" not in out and "MRN-88213" not in out and "ACC-9911" not in out
+
+
+def test_shape_keeps_string_length_because_length_is_a_debugging_fact():
+    """An oversize-argument rule fires on length, and "the model passed
+    40 000 characters" is the finding, not the 40 000 characters."""
+    assert "<str:8>" in privacy.shape({"to": "ACC-9911"})
+
+
+def test_hashed_is_stable_across_key_order():
+    """Duplicate and loop detection read "same arguments"; they must not
+    read "same arguments" differently because a dict was built in another
+    order."""
+    a = privacy.digest({"x": 1, "y": 2})
+    b = privacy.digest({"y": 2, "x": 1})
+    assert a == b and a.startswith("sha256:")
+
+
+def test_hashed_still_hides_the_content():
+    assert "MRN-88213" not in privacy.digest(ARGS)
+
+
+def test_metadata_sends_no_arguments_and_no_model_text():
+    assert privacy.preview(ARGS, "metadata", full_preview="anything") == ""
+    assert privacy.say("the patient's balance is $412", "metadata") == ""
+
+
+def test_an_unrecognised_level_fails_closed(monkeypatch):
+    """A typo in a deployment that meant to tighten must not silently
+    send everything."""
+    monkeypatch.setenv("SPONSIO_PRIVACY", "redacted-ish")
+    assert privacy.resolve("full") == "metadata"
+
+
+def test_the_environment_beats_the_argument(monkeypatch):
+    """The person who decides what leaves a machine operates it; they do
+    not necessarily control the code running on it."""
+    monkeypatch.setenv("SPONSIO_PRIVACY", "hashed")
+    assert privacy.resolve("full") == "hashed"
+
+
+def test_the_run_says_what_it_is_not_sending():
+    """Otherwise an empty argument field is ambiguous: no arguments, or
+    arguments withheld?"""
+    stamp = privacy.describe("shape")
+    assert stamp["sendsArguments"] is False
+    assert stamp["sendsArgumentShapes"] is True
+    assert stamp["level"] == "shape"
+
+
+@pytest.mark.parametrize("level", privacy.LEVELS)
+def test_enforcement_is_identical_at_every_level(level, monkeypatch, capsys, tmp_path):
+    """The point of the whole module. The check runs before anything is
+    sent, so what is sent cannot change the verdict."""
+    import sponsio
+    from sponsio.bridge import session as bridge
+
+    monkeypatch.setenv("SPONSIO_PRIVACY", level)
+
+    class Capture:
+        configured = True
+
+        def __init__(self):
+            self.frames = []
+
+        def ingest_session(self, project, payload):
+            self.frames.append(payload)
+
+    cap = Capture()
+    guard = sponsio.Sponsio(
+        agent_id="a",
+        contracts=["tool `check_policy` must precede `issue_refund`"],
+        mode="enforce",
+        verbose=False,
+    )
+    session = bridge.attach(guard, client=cap, session_id=f"p-{level}", runs_dir=tmp_path)
+    verdicts = [
+        guard.guard_before("lookup", {"id": "A-1"}).allowed,
+        guard.guard_before("issue_refund", {"amount": 250.0, "memo": "MRN-88213"}).allowed,
+    ]
+    session.finish()
+    capsys.readouterr()
+
+    assert verdicts == [True, False], "the contract decided differently under redaction"
+    payload = json.dumps(cap.frames[-1])
+    if level != "full":
+        assert "MRN-88213" not in payload

--- a/tests/test_bridge_privacy.py
+++ b/tests/test_bridge_privacy.py
@@ -21,7 +21,10 @@ ARGS = {"amount": 250.0, "to": "ACC-9911", "memo": "patient MRN-88213", "urgent"
 def test_full_is_the_default_and_passes_the_existing_preview_through():
     """Nobody's payload changes until they ask for it to."""
     assert privacy.resolve(None) == "full"
-    assert privacy.preview(ARGS, "full", full_preview="already truncated") == "already truncated"
+    assert (
+        privacy.preview(ARGS, "full", full_preview="already truncated")
+        == "already truncated"
+    )
 
 
 def test_shape_keeps_the_keys_and_drops_every_value():
@@ -54,11 +57,12 @@ def test_metadata_sends_no_arguments_and_no_model_text():
     assert privacy.say("the patient's balance is $412", "metadata") == ""
 
 
-def test_an_unrecognised_level_fails_closed(monkeypatch):
+def test_an_unrecognised_level_fails_closed_to_the_strictest(monkeypatch):
     """A typo in a deployment that meant to tighten must not silently
-    send everything."""
+    send everything. It gets the strictest level there is, not merely a
+    strict one."""
     monkeypatch.setenv("SPONSIO_PRIVACY", "redacted-ish")
-    assert privacy.resolve("full") == "metadata"
+    assert privacy.resolve("full") == privacy.STRICTEST == "tool_calls"
 
 
 def test_the_environment_beats_the_argument(monkeypatch):
@@ -66,6 +70,30 @@ def test_the_environment_beats_the_argument(monkeypatch):
     not necessarily control the code running on it."""
     monkeypatch.setenv("SPONSIO_PRIVACY", "hashed")
     assert privacy.resolve("full") == "hashed"
+
+
+def test_metadata_keeps_the_verdict_and_drops_the_claim_content():
+    """A MISMATCH is metadata. The value it was checked against and the
+    corrected sentence are the model's output and the customer's data."""
+    rows = [
+        {
+            "predicate": "balance",
+            "verdict": "MISMATCH",
+            "evidence": "authoritative: 412.00",
+            "fix": "Your balance is $412.00, Dana.",
+        }
+    ]
+    (kept,) = privacy.claims(rows, "metadata")
+    assert kept["verdict"] == "MISMATCH" and kept["predicate"] == "balance"
+    assert kept["evidence"] == "" and kept["fix"] == ""
+    assert privacy.claims(rows, "hashed") == rows
+
+
+def test_tool_calls_keeps_only_the_action_lane():
+    assert privacy.keeps_step("tool_call", "tool_calls") is True
+    assert privacy.keeps_step("assistant_output", "tool_calls") is False
+    assert privacy.keeps_step("delegation", "tool_calls") is False
+    assert privacy.keeps_step("assistant_output", "metadata") is True
 
 
 def test_the_run_says_what_it_is_not_sending():
@@ -102,10 +130,14 @@ def test_enforcement_is_identical_at_every_level(level, monkeypatch, capsys, tmp
         mode="enforce",
         verbose=False,
     )
-    session = bridge.attach(guard, client=cap, session_id=f"p-{level}", runs_dir=tmp_path)
+    session = bridge.attach(
+        guard, client=cap, session_id=f"p-{level}", runs_dir=tmp_path
+    )
     verdicts = [
         guard.guard_before("lookup", {"id": "A-1"}).allowed,
-        guard.guard_before("issue_refund", {"amount": 250.0, "memo": "MRN-88213"}).allowed,
+        guard.guard_before(
+            "issue_refund", {"amount": 250.0, "memo": "MRN-88213"}
+        ).allowed,
     ]
     session.finish()
     capsys.readouterr()
@@ -114,3 +146,118 @@ def test_enforcement_is_identical_at_every_level(level, monkeypatch, capsys, tmp
     payload = json.dumps(cap.frames[-1])
     if level != "full":
         assert "MRN-88213" not in payload
+
+
+# ---------------------------------------------------------------------------
+# The output lane, end to end, and the one contradiction that is refused
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+SECRET_VALUE = "412.00"
+SECRET_FIX = "Your balance is $412.00, Dana."
+
+
+def _verified_claim():
+    res = SimpleNamespace(
+        verdict="MISMATCH",
+        correction=SECRET_FIX,
+        values=[SECRET_VALUE],
+        action="rewrite",
+        source="table:balances",
+    )
+    vc = SimpleNamespace(
+        result=res, spec=SimpleNamespace(predicate="balance"), span=(0, 10)
+    )
+    return SimpleNamespace(evidence_claims=[vc])
+
+
+def _run(level, monkeypatch, tmp_path):
+    import sponsio
+    from sponsio.bridge import session as bridge
+
+    monkeypatch.setenv("SPONSIO_PRIVACY", level)
+
+    class Capture:
+        configured = True
+
+        def __init__(self):
+            self.frames = []
+
+        def ingest_session(self, project, payload):
+            self.frames.append(payload)
+
+    cap = Capture()
+    guard = sponsio.Sponsio(
+        agent_id="a", contracts=["tool `x` at most 9 times"], verbose=False
+    )
+    s = bridge.attach(guard, client=cap, session_id=f"lane-{level}", runs_dir=tmp_path)
+    guard.guard_before("lookup", {"mrn": "MRN-88213"})
+    s.note("a", "delegating patient MRN-88213", type="delegation")
+    s.record_output("The balance is " + SECRET_VALUE, _verified_claim())
+    s.finish()
+    return cap.frames[-1]["vm"], json.dumps(cap.frames[-1])
+
+
+def test_metadata_still_records_the_model_turn_without_its_content(
+    monkeypatch, tmp_path, capsys
+):
+    vm, raw = _run("metadata", monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert "assistant_output" in [st["type"] for st in vm["steps"]]
+    assert SECRET_VALUE not in raw and SECRET_FIX not in raw
+
+
+def test_tool_calls_sends_the_action_lane_and_nothing_else(
+    monkeypatch, tmp_path, capsys
+):
+    """The level a customer means by "only send us the tool calls"."""
+    vm, raw = _run("tool_calls", monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert [st["type"] for st in vm["steps"]] == ["tool_call"]
+    assert vm["steps"][0]["tool"] == "lookup"
+    assert "MRN-88213" not in raw and SECRET_VALUE not in raw and SECRET_FIX not in raw
+    assert vm["privacy"]["sendsOutputLane"] is False
+
+
+def test_tool_calls_refuses_an_evidence_configuration(monkeypatch, capsys):
+    """Verifying a claim means sending it. A deployment cannot have both,
+    and it should hear so at construction rather than on the first turn."""
+    import sponsio
+    from sponsio.bridge.privacy import PrivacyConflict
+
+    monkeypatch.setenv("SPONSIO_PRIVACY", "tool_calls")
+    with pytest.raises(PrivacyConflict):
+        sponsio.Sponsio(
+            agent_id="a",
+            contracts=["tool `x` at most 9 times"],
+            verbose=False,
+            evidence={"claims": [{"predicate": "balance", "claim_field": "balance"}]},
+        )
+    capsys.readouterr()
+
+
+def test_the_same_refusal_at_attach_when_the_level_comes_by_argument(
+    monkeypatch, tmp_path, capsys
+):
+    """The environment gate cannot see attach(privacy=...); attach checks
+    again so the argument path cannot slip past."""
+    import sponsio
+    from sponsio.bridge import session as bridge
+    from sponsio.bridge.privacy import PrivacyConflict
+
+    monkeypatch.delenv("SPONSIO_PRIVACY", raising=False)
+    guard = sponsio.Sponsio(
+        agent_id="a",
+        contracts=["tool `x` at most 9 times"],
+        verbose=False,
+        evidence={"claims": [{"predicate": "balance", "claim_field": "balance"}]},
+    )
+    capsys.readouterr()
+    with pytest.raises(PrivacyConflict):
+        bridge.attach(
+            guard,
+            client=SimpleNamespace(configured=False),
+            privacy="tool_calls",
+            runs_dir=tmp_path,
+        )

--- a/tests/test_dsl_no_reversal_order.py
+++ b/tests/test_dsl_no_reversal_order.py
@@ -1,0 +1,50 @@
+"""Every spelling of "A is forbidden after B" forbids A after B.
+
+The DSL swaps ``no_reversal``'s arguments for phrasings that name the
+contradiction first. Three common spellings never matched the swap
+trigger, so the rule compiled to its mirror image: it permitted exactly
+the order it names and blocked the harmless one, while the console
+reported the rule ARMED. No test covered those spellings, which is how
+the bug survived.
+
+Each case is checked against the runtime, not against the formula
+string: what matters is which order a guard actually stops.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import sponsio
+
+A, B = "export_phi", "share_record"
+
+# Every spelling means: once B has happened, A is forbidden.
+SPELLINGS = [
+    f"never `{A}` after `{B}`",
+    f"cannot `{A}` after `{B}`",
+    f"must not `{A}` after `{B}`",
+    f"`{A}` is forbidden after `{B}`",
+    f"`{A}` is not allowed after `{B}`",
+    f"tool `{A}` must not follow `{B}`",
+    f"no {A} after {B}",
+    f"cannot {A} after {B}",
+    f"once `{B}` is called, `{A}` must not be called",
+]
+
+
+def _stops(rule: str, script: list[str]) -> list[bool]:
+    guard = sponsio.Sponsio(agent_id="t", contracts=[rule], mode="enforce", verbose=False)
+    return [not guard.guard_before(tool, {}).allowed for tool in script]
+
+
+@pytest.mark.parametrize("rule", SPELLINGS)
+def test_the_forbidden_order_is_stopped(rule, capsys):
+    assert _stops(rule, [B, A])[-1] is True, f"{rule!r} let {A} run after {B}"
+    capsys.readouterr()
+
+
+@pytest.mark.parametrize("rule", SPELLINGS)
+def test_the_harmless_order_is_allowed(rule, capsys):
+    assert _stops(rule, [A, B])[-1] is False, f"{rule!r} blocked {B} after {A}"
+    capsys.readouterr()

--- a/tests/test_dsl_no_reversal_order.py
+++ b/tests/test_dsl_no_reversal_order.py
@@ -34,7 +34,9 @@ SPELLINGS = [
 
 
 def _stops(rule: str, script: list[str]) -> list[bool]:
-    guard = sponsio.Sponsio(agent_id="t", contracts=[rule], mode="enforce", verbose=False)
+    guard = sponsio.Sponsio(
+        agent_id="t", contracts=[rule], mode="enforce", verbose=False
+    )
     return [not guard.guard_before(tool, {}).allowed for tool in script]
 
 

--- a/tests/test_findings_explain.py
+++ b/tests/test_findings_explain.py
@@ -46,7 +46,9 @@ def test_the_table_invents_no_patterns():
 def test_forthcoming_entries_are_still_forthcoming():
     """Once the library has the pattern, the allowance above is stale."""
     landed = sorted(FORTHCOMING & library_patterns())
-    assert not landed, f"drop these from FORTHCOMING, the library has them now: {landed}"
+    assert not landed, (
+        f"drop these from FORTHCOMING, the library has them now: {landed}"
+    )
 
 
 def test_an_unknown_pattern_still_explains_itself():

--- a/tests/test_findings_explain.py
+++ b/tests/test_findings_explain.py
@@ -1,0 +1,84 @@
+"""Every deterministic pattern can say what it means in plain language.
+
+A platform embedding Sponsio shows these sentences to people who did not
+write the rule and will never read a formula. The table is the product
+surface for that audience, so the test that matters is coverage: a new
+pattern landing in the library without an entry here would appear in a
+customer's dashboard as raw pattern-name soup.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sponsio.findings.explain import RULES, explain
+
+LIBRARY = Path(__file__).resolve().parent.parent / "sponsio" / "patterns" / "library.py"
+
+
+def library_patterns() -> set[str]:
+    return set(re.findall(r'pattern_name="([a-z_0-9]+)"', LIBRARY.read_text()))
+
+
+def test_every_library_pattern_has_an_explanation():
+    missing = sorted(library_patterns() - set(RULES))
+    assert not missing, f"patterns with no plain-language entry: {missing}"
+
+
+# Patterns explained ahead of the library commit that adds them. Each entry
+# here names work that is on its way; empty this set when it lands. An
+# entry that stays here past its branch is a sentence nobody will see.
+FORTHCOMING = {
+    # fix/enforcement-and-evidence-mw: SMT claim checking
+    "claim_requires_smt_valid",
+    "smt_premises_must_be_consistent",
+}
+
+
+def test_the_table_invents_no_patterns():
+    """An entry for a pattern that no longer exists is a sentence nobody
+    will ever see, and it will quietly rot."""
+    extra = sorted(set(RULES) - library_patterns() - FORTHCOMING)
+    assert not extra, f"explanations for patterns that no longer exist: {extra}"
+
+
+def test_forthcoming_entries_are_still_forthcoming():
+    """Once the library has the pattern, the allowance above is stale."""
+    landed = sorted(FORTHCOMING & library_patterns())
+    assert not landed, f"drop these from FORTHCOMING, the library has them now: {landed}"
+
+
+def test_an_unknown_pattern_still_explains_itself():
+    """A pattern from outside the library, a customer's own, must not
+    vanish from the dashboard just because this table has not caught up."""
+    e = explain("some_future_pattern", ("a", "b"), rule_text="a must not follow b")
+    assert e.known is False
+    assert e.business
+    assert e.title
+
+
+def test_enforcement_changes_what_the_sentence_claims():
+    """The same rule blocking a call and watching one go through are
+    different events, and a business reader must be able to tell."""
+    blocked = explain("rate_limit", ("issue_refund", 2), action="blocked")
+    observed = explain("rate_limit", ("issue_refund", 2), action="observed")
+    assert "stopped the call" in blocked.business
+    assert "still ran" in observed.business
+    assert blocked.severity != observed.severity
+
+
+def test_every_entry_renders_without_arguments():
+    """Args arrive from a trace and a trace can be short of them. A
+    KeyError here would take down whatever endpoint was rendering the
+    finding, for every finding, not just the malformed one."""
+    for name in RULES:
+        e = explain(name, ())
+        assert e.title and e.business and e.fix
+
+
+def test_every_entry_renders_with_plausible_arguments():
+    for name in RULES:
+        e = explain(name, ("alpha_tool", "beta_tool", 3, 9), action="blocked")
+        assert "{" not in e.business and "{" not in e.fix
+        assert e.severity in ("low", "medium", "high", "critical")


### PR DESCRIPTION
Three changes that came out of the Primitive POC exploration, each a self-contained commit that passes the suite on its own.

**fix(dsl): "never `A` after `B`" forbade B after A.** The no_reversal argument-order fixer matched "must not follow", "forbidden after" and "never after", but not the three spellings that put the negation word first with the action in between (`never`/`cannot`/`must not` `` `A` `` after `` `B` ``). Those compiled to their own mirror image while the console reported the rule ARMED. One regex on the trigger list; a parametrised test now runs all nine spellings against the guard in both orders.

**feat(bridge): violations carry their pattern; content need not leave.** Violation entries in the view-model now carry `pattern` and `args`, the same fields contract rows already had. New `sponsio/findings/explain.py` renders any pattern + args as a developer line and a business line with no model in the loop; all 51 library patterns are covered and a test keeps it that way (two entries are ahead of the SMT branch and a second test retires the allowance when it lands). New `sponsio/bridge/privacy.py`: `SPONSIO_PRIVACY=full|shape|hashed|metadata` decides what leaves the machine; enforcement is local so the verdict is identical at every level, and a test asserts that.

**feat(bridge): a `tool_calls` level that sends the action lane and nothing else.** "Only send us the tool calls" was the partner's phrasing, and `metadata` did not deliver it: the model turn still went up with the claim's authoritative value and corrected wording. `metadata` now empties those and keeps the verdict; `tool_calls` records tool_call steps only. Cloud claim verification cannot be made content-free, so a guard with an evidence configuration under `tool_calls` raises `PrivacyConflict` at construction and at attach.

Local: 2819 passed with the CI-pinned ruff clean. The 3 failures in this venv (`test_oss_sto_gate`, `test_build_sto_evaluator_requires_cloud`) fail identically on pristine `main` here because `sponsio_cloud` is importable in the same venv; they pass in CI's clean environment.

Merge order: this before SponsioLabs/Sponsio-cloud's `poc/primitive-embed`, whose image installs this repo's `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
