### PR TITLE
chore(release): 0.2.0a15

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@ Sponsio はエージェントがツールを呼ぶ前に、その呼び出しを
 
 > **エージェント契約** とは、エージェントのすべてのアクションでチェックされるランタイムルールであり、[形式手法に裏打ちされています](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a14 alpha リリース。** `pip install --pre sponsio`、または `npm install -D @sponsio/sdk@alpha`。今回は TypeScript 向けです。インストール行に `alpha` タグが抜けていて、遥かに古い 0.1.0 を取得していました。QUICKSTART が教える API は例外を投げ、コマンドを打ち間違えても終了コードは 0 で、`redirect_to_safe` の判定は単なるブロックとして返るため、どのツールを代わりに呼ぶかをアダプタが知る術がありませんでした。エージェントの「言ったこと」を検証するエビデンス レーンも TypeScript から使えるようになりました。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a14)を参照。
+> **v0.2.0a15 alpha リリース。** `pip install --pre sponsio`。`SPONSIO_PRIVACY=tool_calls` はツール呼び出しだけを送ります。名前、順序、判定のみで、引数もモデル出力もクレーム内容も含みません。`full` との間にはさらに 4 段階あり、判定はどの段階でも同一です(実行はマシンから出ていないため)。violation は発火した pattern を持つようになり、すべての pattern がルールを書いていない人向けに平易な言葉で自身を説明できます。挙動が変わる修正が 1 件:`` never `A` after `B` ``(および `cannot` / `must not` の書き方)は鏡像にコンパイルされていましたが、書かれた通りの順序を禁止するようになりました。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a15)を参照。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sponsio checks an agent's tool calls before they run. A rule can look at what al
 
 > An **agent contract** is a runtime rule that is checked at every agent action, [backed by formal methods](docs/concepts/formal-methods.md).
 
-> **v0.2.0a14 alpha is out.** `pip install --pre sponsio`, or `npm install -D @sponsio/sdk@alpha`. This one is for TypeScript. the install line used to leave out the `alpha` tag, so it resolved to 0.1.0, a much older release; QUICKSTART taught an API that threw; a mistyped command exited 0; and a `redirect_to_safe` verdict came back as a plain block, so no adapter could learn which tool to call instead. The evidence lane, which checks what an agent says rather than what it does, now works from TypeScript too. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a14).
+> **v0.2.0a15 alpha is out.** `pip install --pre sponsio`. `SPONSIO_PRIVACY=tool_calls` sends only the tool calls: names, order and verdicts, with no arguments, no model output and no claim content; four gentler levels sit between it and `full`, and the verdict is identical at every one because enforcement never left the machine. Violations now carry the pattern that fired, and every pattern can explain itself in plain language for a reader who did not write the rule. One fix changes behaviour: `` never `A` after `B` `` (and its `cannot` / `must not` spellings) compiled to its own mirror image and now forbids what it says. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a15).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ Sponsio 在 Agent 调用工具之前先检查这次调用。一条规则可以�
 
 > **Agent 合约**是一条运行时规则，在每一次 Agent 操作时检查，[由形式化方法支撑](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a14 alpha 已发布。** `pip install --pre sponsio`,或 `npm install -D @sponsio/sdk@alpha`。这一版是给 TypeScript 的。安装命令以前漏了 `alpha` 标签,装到的是 0.1.0 这个老得多的版本;QUICKSTART 教的 API 会抛异常;打错命令会以 0 退出;`redirect_to_safe` 的判定回来是普通拦截,任何适配器都无从知道该改调哪个工具。证据链(核验 agent 说了什么,而不是做了什么)现在 TypeScript 也能用了。见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a14)。
+> **v0.2.0a15 alpha 已发布。** `pip install --pre sponsio`。`SPONSIO_PRIVACY=tool_calls` 只上传 tool call:名字、顺序和判定,不带参数、不带模型输出、不带 claim 内容;它和 `full` 之间还有四档,而且每一档的判定结果完全一样,因为执行本来就没离开过机器。violation 现在带着触发它的 pattern,每个 pattern 都能用一句人话解释自己,给没写过这条规则的人看。一处修复会改变行为:`` never `A` after `B` ``(以及 `cannot` / `must not` 写法)以前编译成了自己的镜像,现在禁止的是它字面说的那个顺序。见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a15)。
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sponsio"
-version = "0.2.0a14"
+version = "0.2.0a15"
 description = "Runtime contract enforcement for LLM agent systems"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump only. Notes go on the GitHub Release, which triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)