### PR TITLE
feat(bridge): which customer a run belongs to can come from the environment, and 0.2.0a16

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@ Sponsio はエージェントがツールを呼ぶ前に、その呼び出しを
 
 > **エージェント契約** とは、エージェントのすべてのアクションでチェックされるランタイムルールであり、[形式手法に裏打ちされています](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a15 alpha リリース。** `pip install --pre sponsio`。`SPONSIO_PRIVACY=tool_calls` はツール呼び出しだけを送ります。名前、順序、判定のみで、引数もモデル出力もクレーム内容も含みません。`full` との間にはさらに 4 段階あり、判定はどの段階でも同一です(実行はマシンから出ていないため)。violation は発火した pattern を持つようになり、すべての pattern がルールを書いていない人向けに平易な言葉で自身を説明できます。挙動が変わる修正が 1 件:`` never `A` after `B` ``(および `cannot` / `must not` の書き方)は鏡像にコンパイルされていましたが、書かれた通りの順序を禁止するようになりました。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a15)を参照。
+> **v0.2.0a16 alpha リリース。** `pip install --pre sponsio`。今回は自社の顧客向けにエージェントを運用するプラットフォーム向けです。`SPONSIO_PROJECT` が実行の帰属先の顧客を示すため、顧客ごとの鍵はコード変更なしで動き、顧客を取り違えることもありません。これまでは `attach()` が常に `default` を名乗り、単一顧客に限定した鍵は拒否されたため、正しく配線した環境からも実行が届きませんでした。OTLP エクスポータも `SPONSIO_PRIVACY` に従うようになり、どちらの経路でも設定した水準がそのまま機外に出る水準になります。[リリースノート](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a16)。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sponsio checks an agent's tool calls before they run. A rule can look at what al
 
 > An **agent contract** is a runtime rule that is checked at every agent action, [backed by formal methods](docs/concepts/formal-methods.md).
 
-> **v0.2.0a15 alpha is out.** `pip install --pre sponsio`. `SPONSIO_PRIVACY=tool_calls` sends only the tool calls: names, order and verdicts, with no arguments, no model output and no claim content; four gentler levels sit between it and `full`, and the verdict is identical at every one because enforcement never left the machine. Violations now carry the pattern that fired, and every pattern can explain itself in plain language for a reader who did not write the rule. One fix changes behaviour: `` never `A` after `B` `` (and its `cannot` / `must not` spellings) compiled to its own mirror image and now forbids what it says. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a15).
+> **v0.2.0a16 alpha is out.** `pip install --pre sponsio`. This one is for platforms running agents for their own customers. `SPONSIO_PROJECT` names the customer a run belongs to, so a per-customer key needs no code change and cannot get the customer wrong: before this, `attach()` always claimed `default`, and a key scoped to one customer was refused, which meant runs from a correctly wired deployment never arrived. The OTLP exporter now obeys `SPONSIO_PRIVACY` too, so the level you set is the level that leaves the machine on either path. See the [release notes](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a16).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ Sponsio 在 Agent 调用工具之前先检查这次调用。一条规则可以�
 
 > **Agent 合约**是一条运行时规则，在每一次 Agent 操作时检查，[由形式化方法支撑](docs/concepts/formal-methods.md)。
 
-> **v0.2.0a15 alpha 已发布。** `pip install --pre sponsio`。`SPONSIO_PRIVACY=tool_calls` 只上传 tool call:名字、顺序和判定,不带参数、不带模型输出、不带 claim 内容;它和 `full` 之间还有四档,而且每一档的判定结果完全一样,因为执行本来就没离开过机器。violation 现在带着触发它的 pattern,每个 pattern 都能用一句人话解释自己,给没写过这条规则的人看。一处修复会改变行为:`` never `A` after `B` ``(以及 `cannot` / `must not` 写法)以前编译成了自己的镜像,现在禁止的是它字面说的那个顺序。见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a15)。
+> **v0.2.0a16 alpha 已发布。** `pip install --pre sponsio`。这一版是给「替自己的客户跑 agent」的平台用的。`SPONSIO_PROJECT` 指明一次 run 属于哪个客户,所以按客户发的 key 不需要改代码,也不会指错客户:在这之前 `attach()` 一律声称 `default`,而锁定单个客户的 key 会被拒,结果是接线完全正确的部署一条 run 都传不上来。OTLP 导出器现在也遵守 `SPONSIO_PRIVACY`,两条通路上你设的级别就是真正离开这台机器的级别。详见[发布说明](https://github.com/SponsioLabs/Sponsio/releases/tag/v0.2.0a16)。
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sponsio"
-version = "0.2.0a15"
+version = "0.2.0a16"
 description = "Runtime contract enforcement for LLM agent systems"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sponsio/bridge/session.py
+++ b/sponsio/bridge/session.py
@@ -590,7 +590,7 @@ class BridgeSession:
 def attach(
     guard: Any,
     *,
-    project: str = "default",
+    project: str | None = None,
     auto: bool = True,
     session_id: str | None = None,
     client: Any = None,
@@ -601,10 +601,22 @@ def attach(
 ) -> BridgeSession:
     """Stream ``guard``'s run to a console.
 
+    ``project`` is which space the run belongs to. Left out, it comes from
+    ``SPONSIO_PROJECT``, then falls back to ``default`` — so a platform
+    running the same agent for many customers ships one image and varies
+    only the environment.
+
     With ``auto=True`` every ``guard_before`` becomes a step. Turn it off for
     multi-agent runs where each step needs attributing to an agent and the
     delegation edges have to be drawn by hand.
     """
+    # An explicit argument wins; otherwise SPONSIO_PROJECT, so the same
+    # image can be deployed per customer with only the environment
+    # differing; otherwise the single-workspace default.
+    if project is None:
+        from sponsio.cloud.client import read_project
+
+        project = read_project() or "default"
     session = BridgeSession(
         guard,
         project=project,

--- a/sponsio/cloud/client.py
+++ b/sponsio/cloud/client.py
@@ -110,6 +110,19 @@ def read_api_key() -> str | None:
     return None
 
 
+def read_project() -> str | None:
+    """``SPONSIO_PROJECT``, or None.
+
+    Which space a run belongs to is deployment configuration, not code. A
+    platform that runs the same agent for forty customers ships one image
+    and varies the environment; without this, the customer's name had to
+    be passed in the call, so the image differed per customer or the
+    caller wrote the plumbing themselves.
+    """
+    value = os.environ.get("SPONSIO_PROJECT", "").strip()
+    return value or None
+
+
 def base_url() -> str:
     """Env var, then the endpoint login saved, then production."""
     explicit = os.environ.get("SPONSIO_API_URL", "").strip()

--- a/sponsio/tracer/otel_writer.py
+++ b/sponsio/tracer/otel_writer.py
@@ -97,9 +97,61 @@ def _span_time_ns(event: Event) -> int:
     return base + event.ts * step
 
 
+_DROP = object()
+
+
+def _privacy_shape(value: Any) -> str:
+    from sponsio.bridge.privacy import shape
+
+    return shape(value)
+
+
+def _privacy_digest(value: Any) -> str:
+    from sponsio.bridge.privacy import digest
+
+    return digest(value)
+
+
+def _privacy_keeps_step(step_type: str, level: str) -> bool:
+    from sponsio.bridge.privacy import keeps_step
+
+    # The writer's event types are the trace's, not the view-model's;
+    # only the tool lane is named the same in both, which is all this
+    # question needs.
+    return keeps_step("tool_call" if step_type == "tool_call" else step_type, level)
+
+
+def _at_level(value: Any, level: str) -> Any:
+    """One attribute value as ``level`` permits it, or :data:`_DROP`.
+
+    The exporter used to put every tool argument and the whole prompt and
+    completion into span attributes, and read no privacy setting at all.
+    An operator who set SPONSIO_PRIVACY=tool_calls and exported OTLP sent
+    everything anyway: the server's own floor caught it at the far end,
+    but the point of the setting is that it does not leave the machine.
+
+    ``full`` returns the value untouched, so nothing changes for anyone
+    who has not asked for it.
+    """
+    if level == "full":
+        return value
+    if level == "shape":
+        return _privacy_shape({"_": value})
+    if level == "hashed":
+        return _privacy_digest(value)
+    return _DROP
+
+
+def _add_content(attrs: list[dict], key: str, content: Any, level: str) -> None:
+    kept = _at_level(content, level)
+    if kept is not _DROP:
+        attrs.append(_attr(key, kept))
+
+
 def _build_llm_span(
     req: Event | None,
     resp: Event | None,
+    level: str = "full",
 ) -> dict:
     """Emit ONE OTLP span for an LLM call, optionally carrying both
     the prompt (from ``req``) and completion (from ``resp``).
@@ -133,9 +185,9 @@ def _build_llm_span(
     ]
 
     if req is not None and req.content:
-        attrs.append(_attr(_LLM_REQUEST_PROMPT_KEY, req.content))
+        _add_content(attrs, _LLM_REQUEST_PROMPT_KEY, req.content, level)
     if resp is not None and resp.content:
-        attrs.append(_attr(_LLM_RESPONSE_COMPLETION_KEY, resp.content))
+        _add_content(attrs, _LLM_RESPONSE_COMPLETION_KEY, resp.content, level)
 
     # Token counts — pull from whichever event provided them.
     # Consumer will sum input+output into total_tokens on replay.
@@ -161,7 +213,7 @@ def _build_llm_span(
     }
 
 
-def _build_tool_span(event: Event) -> dict:
+def _build_tool_span(event: Event, level: str = "full") -> dict:
     """One OTLP span per tool_call event.  Straightforward; no pairing."""
     start_ns = _span_time_ns(event)
     end_ns = start_ns + 500_000_000
@@ -169,10 +221,17 @@ def _build_tool_span(event: Event) -> dict:
     for k, v in (event.args or {}).items():
         # ``args.<k>`` is one of the three prefixes the consumer's
         # ``_parse_tool_args`` recognises — keep the key unchanged
-        # so round-trip preserves the arg name verbatim.
-        attrs.append(_attr(f"args.{k}", v))
+        # so round-trip preserves the arg name verbatim. The VALUE is
+        # what the privacy level speaks about, so the keys survive at
+        # every level that keeps arguments at all.
+        kept = _at_level(v, level)
+        if kept is _DROP:
+            continue
+        attrs.append(_attr(f"args.{k}", kept))
     if event.content is not None:
-        attrs.append(_attr("tool.output", event.content))
+        kept = _at_level(event.content, level)
+        if kept is not _DROP:
+            attrs.append(_attr("tool.output", kept))
 
     span: dict = {
         "traceId": "0" * 32,
@@ -226,7 +285,7 @@ def _build_fallback_span(event: Event) -> dict:
     return span
 
 
-def _events_to_spans(events: list[Event]) -> list[dict]:
+def _events_to_spans(events: list[Event], level: str = "full") -> list[dict]:
     """Walk events and emit one span per logical call.
 
     The non-trivial bit is LLM pairing: when we see an
@@ -240,6 +299,11 @@ def _events_to_spans(events: list[Event]) -> list[dict]:
     i = 0
     while i < len(events):
         ev = events[i]
+        # tool_calls means the action lane and nothing else, the same
+        # sentence the run upload obeys.
+        if not _privacy_keeps_step(ev.event_type or "tool_call", level):
+            i += 1
+            continue
         if ev.event_type == "llm_request":
             # Look ahead for a matching llm_response.  "Matching"
             # means same agent and no interleaving events between
@@ -251,18 +315,18 @@ def _events_to_spans(events: list[Event]) -> list[dict]:
                 and nxt.event_type == "llm_response"
                 and nxt.agent == ev.agent
             ):
-                spans.append(_build_llm_span(ev, nxt))
+                spans.append(_build_llm_span(ev, nxt, level))
                 i += 2
                 continue
-            spans.append(_build_llm_span(ev, None))
+            spans.append(_build_llm_span(ev, None, level))
             i += 1
             continue
         if ev.event_type == "llm_response":
-            spans.append(_build_llm_span(None, ev))
+            spans.append(_build_llm_span(None, ev, level))
             i += 1
             continue
         if ev.event_type == "tool_call":
-            spans.append(_build_tool_span(ev))
+            spans.append(_build_tool_span(ev, level))
             i += 1
             continue
         spans.append(_build_fallback_span(ev))
@@ -290,6 +354,7 @@ def trace_to_otlp(
     agent_id: str | None = None,
     service_name: str | None = None,
     rulebook: str | None = None,
+    privacy: str | None = None,
 ) -> dict:
     """Convert a Sponsio ``Trace`` to OTLP JSON that round-trips.
 
@@ -312,7 +377,12 @@ def trace_to_otlp(
         service_name or agent_id or (trace.events[0].agent if trace.events else "agent")
     )
 
-    spans = _events_to_spans(trace.events)
+    # The operator of the machine decides what leaves it, so the
+    # environment beats the argument, the same as everywhere else.
+    from sponsio.bridge.privacy import resolve as _resolve_privacy
+
+    level = _resolve_privacy(privacy)
+    spans = _events_to_spans(trace.events, level)
 
     resource_attrs = [_attr("service.name", resolved_agent)]
     # Which rulebook this run enforced, e.g. "quant@v7 sha:fee1dc1943d0".

--- a/tests/test_bridge_session.py
+++ b/tests/test_bridge_session.py
@@ -1,0 +1,54 @@
+
+
+# -- which customer a run belongs to ----------------------------------------
+
+
+def test_the_project_comes_from_the_environment_when_the_call_does_not_say(monkeypatch):
+    """A platform ships one image per agent and varies the environment.
+    Requiring the customer's name in the call meant the image differed per
+    customer, or the caller wrote the plumbing themselves."""
+    from sponsio.cloud.client import read_project
+
+    monkeypatch.setenv("SPONSIO_PROJECT", "fabrikam-health")
+    assert read_project() == "fabrikam-health"
+
+
+def test_an_unset_or_blank_project_is_none(monkeypatch):
+    from sponsio.cloud.client import read_project
+
+    monkeypatch.delenv("SPONSIO_PROJECT", raising=False)
+    assert read_project() is None
+    monkeypatch.setenv("SPONSIO_PROJECT", "   ")
+    assert read_project() is None
+
+
+def test_an_explicit_project_still_wins(monkeypatch):
+    """Code that names the customer is being deliberate; the environment
+    must not silently redirect its runs."""
+    import sponsio
+    from sponsio.bridge import session as bridge
+
+    monkeypatch.setenv("SPONSIO_PROJECT", "from-the-environment")
+    guard = sponsio.Sponsio(agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False)
+    run = bridge.attach(guard, project="from-the-call", auto=False)
+    assert run.project == "from-the-call"
+
+
+def test_the_environment_is_used_when_the_call_is_silent(monkeypatch):
+    import sponsio
+    from sponsio.bridge import session as bridge
+
+    monkeypatch.setenv("SPONSIO_PROJECT", "fabrikam-health")
+    guard = sponsio.Sponsio(agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False)
+    run = bridge.attach(guard, auto=False)
+    assert run.project == "fabrikam-health"
+
+
+def test_neither_falls_back_to_default(monkeypatch):
+    import sponsio
+    from sponsio.bridge import session as bridge
+
+    monkeypatch.delenv("SPONSIO_PROJECT", raising=False)
+    guard = sponsio.Sponsio(agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False)
+    run = bridge.attach(guard, auto=False)
+    assert run.project == "default"

--- a/tests/test_bridge_session.py
+++ b/tests/test_bridge_session.py
@@ -1,5 +1,3 @@
-
-
 # -- which customer a run belongs to ----------------------------------------
 
 
@@ -29,7 +27,9 @@ def test_an_explicit_project_still_wins(monkeypatch):
     from sponsio.bridge import session as bridge
 
     monkeypatch.setenv("SPONSIO_PROJECT", "from-the-environment")
-    guard = sponsio.Sponsio(agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False)
+    guard = sponsio.Sponsio(
+        agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False
+    )
     run = bridge.attach(guard, project="from-the-call", auto=False)
     assert run.project == "from-the-call"
 
@@ -39,7 +39,9 @@ def test_the_environment_is_used_when_the_call_is_silent(monkeypatch):
     from sponsio.bridge import session as bridge
 
     monkeypatch.setenv("SPONSIO_PROJECT", "fabrikam-health")
-    guard = sponsio.Sponsio(agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False)
+    guard = sponsio.Sponsio(
+        agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False
+    )
     run = bridge.attach(guard, auto=False)
     assert run.project == "fabrikam-health"
 
@@ -49,6 +51,8 @@ def test_neither_falls_back_to_default(monkeypatch):
     from sponsio.bridge import session as bridge
 
     monkeypatch.delenv("SPONSIO_PROJECT", raising=False)
-    guard = sponsio.Sponsio(agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False)
+    guard = sponsio.Sponsio(
+        agent_id="a", contracts=["tool `x` at most 1 times"], verbose=False
+    )
     run = bridge.attach(guard, auto=False)
     assert run.project == "default"

--- a/tests/test_config_sections.py
+++ b/tests/test_config_sections.py
@@ -215,11 +215,19 @@ class TestJudgeSection:
         with pytest.raises(ConfigError, match="fallback_mode"):
             load_config(path)
 
-    def test_build_sto_evaluator_requires_cloud(self):
-        """This build ships no StoEvaluator implementation;
-        ``build_sto_evaluator`` must surface a ConfigError instead of
-        silently returning some no-op stub."""
+    def test_build_sto_evaluator_requires_cloud(self, monkeypatch):
+        """With no StoEvaluator discovered, ``build_sto_evaluator`` must
+        surface a ConfigError instead of silently returning some no-op
+        stub.
+
+        Discovery is patched rather than assumed: the assertion is about
+        what this function does when it finds nothing, not about whether
+        anything happens to be installed beside it.
+        """
         from sponsio.config import ConfigError
+        from sponsio.integrations import base
+
+        monkeypatch.setattr(base, "_discover_sto_evaluator", lambda: None)
 
         section = JudgeSection(
             fallback_mode="deny",

--- a/tests/test_oss_sto_gate.py
+++ b/tests/test_oss_sto_gate.py
@@ -15,6 +15,21 @@ import sponsio
 from sponsio.formulas.formula import Atom, G
 
 
+@pytest.fixture(autouse=True)
+def no_evaluator_installed(monkeypatch):
+    """Assert the contract, not the contents of site-packages.
+
+    These tests say "this build ships no StoEvaluator", but what they
+    checked was that nothing in the environment registers one on the
+    ``sponsio.evaluators`` entry point. Anyone with sponsio-cloud
+    installed — which is everyone working on both halves — saw two red
+    tests that were telling them about their venv.
+    """
+    from sponsio.integrations import base
+
+    monkeypatch.setattr(base, "_discover_sto_evaluator", lambda: None)
+
+
 def test_sto_atom_in_python_api_raises_without_evaluator():
     """A contract built via the Python API with a sto Atom must fail
     loudly when no StoEvaluator is wired up, not silently no-op.

--- a/tests/test_otel_writer_privacy.py
+++ b/tests/test_otel_writer_privacy.py
@@ -1,0 +1,85 @@
+"""What the OTLP exporter is allowed to put in a span.
+
+It put every tool argument, the whole prompt and the whole completion
+into span attributes, and read no privacy setting at all. An operator who
+set SPONSIO_PRIVACY=tool_calls and exported OTLP sent all of it anyway.
+The point of that setting is that the data does not leave the machine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sponsio.models.trace import Event, Trace
+from sponsio.tracer.otel_writer import trace_to_otlp
+
+
+def trace_with_secrets() -> Trace:
+    t = Trace()
+    t.events.append(
+        Event(ts=0, event_type="tool_call", tool="lookup_case", agent="a",
+              args={"ssn": "999-88-7777", "case": 12}, content="found Jane Roe")
+    )
+    t.events.append(
+        Event(ts=1, event_type="llm_request", agent="a",
+              args={"model": "gpt-x"}, content="the patient's ssn is 999-88-7777")
+    )
+    t.events.append(
+        Event(ts=2, event_type="llm_response", agent="a",
+              args={"model": "gpt-x"}, content="I will not repeat it")
+    )
+    return t
+
+
+def rendered(level: str | None, monkeypatch) -> str:
+    import json
+
+    monkeypatch.delenv("SPONSIO_PRIVACY", raising=False)
+    return json.dumps(trace_to_otlp(trace_with_secrets(), privacy=level))
+
+
+def test_full_is_unchanged(monkeypatch):
+    """Nothing changes for anyone who has not asked for it."""
+    out = rendered("full", monkeypatch)
+    assert "999-88-7777" in out and "found Jane Roe" in out
+
+
+@pytest.mark.parametrize("level", ["metadata", "tool_calls"])
+def test_contents_never_leave_the_machine(level, monkeypatch):
+    out = rendered(level, monkeypatch)
+    assert "999-88-7777" not in out
+    assert "found Jane Roe" not in out
+    assert "the patient's ssn" not in out
+    # the call itself still does
+    assert "lookup_case" in out
+
+
+def test_the_argument_names_survive_below_full(monkeypatch):
+    """"args.ssn was set" is a debugging fact; its value is not."""
+    out = rendered("shape", monkeypatch)
+    assert "args.ssn" in out and "999-88-7777" not in out
+
+
+def test_hashed_keeps_repeats_comparable(monkeypatch):
+    import json
+
+    monkeypatch.delenv("SPONSIO_PRIVACY", raising=False)
+    one = json.dumps(trace_to_otlp(trace_with_secrets(), privacy="hashed"))
+    two = json.dumps(trace_to_otlp(trace_with_secrets(), privacy="hashed"))
+    assert one == two and "999-88-7777" not in one
+
+
+def test_tool_calls_drops_the_model_turn_whole(monkeypatch):
+    out = rendered("tool_calls", monkeypatch)
+    assert "llm_call" not in out
+    assert "lookup_case" in out
+
+
+def test_the_environment_beats_the_argument(monkeypatch):
+    """The person who decides what may leave a machine is its operator,
+    not the author of the agent running on it."""
+    import json
+
+    monkeypatch.setenv("SPONSIO_PRIVACY", "tool_calls")
+    out = json.dumps(trace_to_otlp(trace_with_secrets(), privacy="full"))
+    assert "999-88-7777" not in out

--- a/tests/test_otel_writer_privacy.py
+++ b/tests/test_otel_writer_privacy.py
@@ -17,16 +17,32 @@ from sponsio.tracer.otel_writer import trace_to_otlp
 def trace_with_secrets() -> Trace:
     t = Trace()
     t.events.append(
-        Event(ts=0, event_type="tool_call", tool="lookup_case", agent="a",
-              args={"ssn": "999-88-7777", "case": 12}, content="found Jane Roe")
+        Event(
+            ts=0,
+            event_type="tool_call",
+            tool="lookup_case",
+            agent="a",
+            args={"ssn": "999-88-7777", "case": 12},
+            content="found Jane Roe",
+        )
     )
     t.events.append(
-        Event(ts=1, event_type="llm_request", agent="a",
-              args={"model": "gpt-x"}, content="the patient's ssn is 999-88-7777")
+        Event(
+            ts=1,
+            event_type="llm_request",
+            agent="a",
+            args={"model": "gpt-x"},
+            content="the patient's ssn is 999-88-7777",
+        )
     )
     t.events.append(
-        Event(ts=2, event_type="llm_response", agent="a",
-              args={"model": "gpt-x"}, content="I will not repeat it")
+        Event(
+            ts=2,
+            event_type="llm_response",
+            agent="a",
+            args={"model": "gpt-x"},
+            content="I will not repeat it",
+        )
     )
     return t
 
@@ -55,7 +71,7 @@ def test_contents_never_leave_the_machine(level, monkeypatch):
 
 
 def test_the_argument_names_survive_below_full(monkeypatch):
-    """"args.ssn was set" is a debugging fact; its value is not."""
+    """ "args.ssn was set" is a debugging fact; its value is not."""
     out = rendered("shape", monkeypatch)
     assert "args.ssn" in out and "999-88-7777" not in out
 


### PR DESCRIPTION
Two things a platform running one agent for many customers needs, both
found by being that platform for an evening.

## The customer a run belongs to can come from the environment

A platform ships one image per agent and varies the environment.
`attach()` took the customer's name as an argument and defaulted to
`default`, so either the image differed per customer or the caller wrote
the plumbing themselves — and the wiring instructions the console hands
out set `SPONSIO_PROJECT`, which nothing read.

`attach(project=...)` still wins when the code names it. Silent, it reads
`SPONSIO_PROJECT`, then `default`. Verified by running three customers'
agents from one script that knows no customer names: each pulled its own
derived rulebook with its own key, and every run landed in the right
customer with only the environment differing.

## The OTLP exporter obeys the privacy level

It put every tool argument into `args.<k>`, the tool output into
`tool.output`, and the whole prompt and completion into the LLM span, and
read no privacy setting at all. An operator who set
`SPONSIO_PRIVACY=tool_calls` and exported OTLP sent all of it:

    full        1029 bytes   ssn on the wire: yes   llm span: yes
    shape       1047 bytes   ssn on the wire: no    llm span: yes
    metadata     743 bytes   ssn on the wire: no    llm span: yes
    tool_calls   388 bytes   ssn on the wire: no    llm span: no

The server's project floor now catches this at the far end
(SponsioLabs/Sponsio-cloud#11), but the point of the setting is that the
data does not leave the machine, and the console's TypeScript wiring
instructions route a customer's deployment through exactly this exporter.

`full` is untouched. Below it the argument names survive, because
"args.ssn was set" is a debugging fact and its value is not. The
environment beats the argument, because the person who decides what may
leave a machine is its operator and not the author of the agent.

## Also

Two STO-gate tests and one config test said "this build ships no
StoEvaluator" and actually checked that nothing in the environment
registers one on the `sponsio.evaluators` entry point. Anyone with
sponsio-cloud installed — everyone working on both halves — saw three red
tests that were telling them about their venv.

2834 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
