### PR TITLE
chore(ts): 0.2.0-alpha.6, and a workflow that can actually publish it

### DIFF
--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -1,0 +1,65 @@
+name: Publish @sponsio/sdk to npm
+
+# The Python SDK has published itself since 0.1.0 and the TypeScript one
+# never has: every release was a person remembering to run `npm publish`
+# from a laptop, and 0.2.0-alpha.5 shows what that costs — bumped in the
+# repo, named in the release notes, never actually published, so `npm
+# install @sponsio/sdk@alpha` kept serving alpha.4 for two releases.
+#
+# Trigger it by hand. The TypeScript SDK does not move in lockstep with
+# the Python one, so tying this to the Python release tag would publish
+# an unchanged package most of the time.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "npm dist-tag (alpha for a prerelease, latest for a stable)"
+        required: true
+        default: "alpha"
+        type: choice
+        options: ["alpha", "latest"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build, test and publish
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      # Provenance: npm records which workflow, commit and repository
+      # produced the tarball, so an install can be traced to a build.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install + build
+        working-directory: ts
+        run: npm install && npm run build
+
+      # Publishing an SDK whose own suite is red is how a broken parser
+      # reaches somebody's agent.
+      - name: Test
+        working-directory: ts/packages/sdk
+        run: npm test
+
+      - name: Check the NL parser against Python's
+        run: |
+          python -m pip install -e . --quiet
+          node scripts/check_nl_parity.mjs
+
+      - name: Publish
+        working-directory: ts/packages/sdk
+        run: npm publish --provenance --access public --tag "${{ inputs.tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1183,7 +1183,7 @@
     },
     "packages/sdk": {
       "name": "@sponsio/sdk",
-      "version": "0.2.0-alpha.5",
+      "version": "0.2.0-alpha.6",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "^3.3.0",

--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sponsio/sdk",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "description": "Runtime contract enforcement for LLM agents \u2014 native TypeScript",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
The Python SDK has published itself since 0.1.0. The TypeScript one never
has — every release was a person remembering to run `npm publish` from a
laptop, and `0.2.0-alpha.5` is what that costs: bumped in the repo, named
in the a14 release notes, and never published. `npm install
@sponsio/sdk@alpha` has been serving **alpha.4** through two releases.

That is why the parser rewrite, the cloud client and the CSPRNG fix all
landed on `main` this week and changed nothing for anyone installing the
package.

## What this does

Bumps to **0.2.0-alpha.6** — straight past the unpublished alpha.5,
because this package is a materially different thing from what alpha.5
was named for, and a version that means two things is worse than a
skipped number.

Adds `.github/workflows/publish-ts.yml`, run by hand (`workflow_dispatch`,
with a dist-tag input). Not tied to the Python release tag: the two SDKs
do not move in lockstep, so that would republish an unchanged package
most of the time.

Before publishing it builds, runs the SDK suite, and runs
`scripts/check_nl_parity.mjs` against Python — shipping an SDK whose own
tests are red is how a broken parser reaches somebody's agent. Published
with `--provenance`, so an install traces back to the commit that built
it.

## One thing to set up

An **`NPM_TOKEN`** secret in an environment named `npm`. Until that
exists the workflow will fail at the last step and nowhere earlier.

## Verified locally

TS suite 78 passed. `npm pack --dry-run` carries the new modules
(`dist/cloud/client.js`, `privacy.js`, `view-model.js`) — 256 files,
336 kB packed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)